### PR TITLE
Fix global topology for routes

### DIFF
--- a/cmd/ccm/main.go
+++ b/cmd/ccm/main.go
@@ -274,7 +274,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("starting kubelb")
+	setupLog.Info("starting kubelb CCM")
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running kubelb")
 		os.Exit(1)

--- a/cmd/kubelb/main.go
+++ b/cmd/kubelb/main.go
@@ -179,6 +179,7 @@ func main() {
 		Recorder:           mgr.GetEventRecorderFor(kubelb.RouteControllerName),
 		EnvoyProxyTopology: kubelb.EnvoyProxyTopology(config.GetEnvoyProxyTopology()),
 		PortAllocator:      portAllocator,
+		Namespace:          opt.namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", kubelb.RouteControllerName)
 		os.Exit(1)

--- a/internal/controllers/kubelb/loadbalancer_controller.go
+++ b/internal/controllers/kubelb/loadbalancer_controller.go
@@ -64,6 +64,10 @@ const (
 	EnvoyProxyTopologyGlobal    EnvoyProxyTopology = "global"
 )
 
+func (e EnvoyProxyTopology) IsGlobalTopology() bool {
+	return e == EnvoyProxyTopologyGlobal
+}
+
 // LoadBalancerReconciler reconciles a LoadBalancer object
 type LoadBalancerReconciler struct {
 	ctrlruntimeclient.Client

--- a/internal/controllers/kubelb/route_controller.go
+++ b/internal/controllers/kubelb/route_controller.go
@@ -199,7 +199,7 @@ func (r *RouteReconciler) manageServices(ctx context.Context, log logr.Logger, r
 	services := []corev1.Service{}
 	for _, service := range route.Spec.Source.Kubernetes.Services {
 		// Transform the service into desired state.
-		svc := serviceHelpers.GenerateServiceForLBCluster(service.Service, appName, route.Namespace, resourceNamespace, r.PortAllocator)
+		svc := serviceHelpers.GenerateServiceForLBCluster(service.Service, appName, route.Namespace, resourceNamespace, r.PortAllocator, r.EnvoyProxyTopology.IsGlobalTopology())
 		services = append(services, svc)
 	}
 
@@ -446,7 +446,7 @@ func (r *RouteReconciler) createOrUpdateHTTPRoute(ctx context.Context, log logr.
 						ns := ref.Namespace
 						// Corresponding service found, update the name.
 						if ns != nil && ns == (*gwapiv1.Namespace)(&service.Namespace) {
-							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateName(false, string(service.UID), service.Name, service.Namespace))
+							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(service.UID), service.Name, service.Namespace))
 							// Set the namespace to nil since all the services are created in the same namespace as the Route.
 							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Namespace = nil
 						}
@@ -462,7 +462,7 @@ func (r *RouteReconciler) createOrUpdateHTTPRoute(ctx context.Context, log logr.
 						ns := ref.Namespace
 						// Corresponding service found, update the name.
 						if ns != nil && ns == (*gwapiv1.Namespace)(&service.Namespace) {
-							object.Spec.Rules[i].BackendRefs[j].Name = gwapiv1.ObjectName(kubelb.GenerateName(false, string(service.UID), service.Name, service.Namespace))
+							object.Spec.Rules[i].BackendRefs[j].Name = gwapiv1.ObjectName(kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(service.UID), service.Name, service.Namespace))
 							// Set the namespace to nil since all the services are created in the same namespace as the Route.
 							object.Spec.Rules[i].BackendRefs[j].Namespace = nil
 						}
@@ -479,7 +479,7 @@ func (r *RouteReconciler) createOrUpdateHTTPRoute(ctx context.Context, log logr.
 								ns := ref.Namespace
 								// Corresponding service found, update the name.
 								if ns != nil && ns == (*gwapiv1.Namespace)(&service.Namespace) {
-									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateName(false, string(service.UID), service.Name, service.Namespace))
+									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(service.UID), service.Name, service.Namespace))
 									// Set the namespace to nil since all the services are created in the same namespace as the Route.
 									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Namespace = nil
 								}
@@ -535,7 +535,7 @@ func (r *RouteReconciler) createOrUpdateGRPCRoute(ctx context.Context, log logr.
 						ns := ref.Namespace
 						// Corresponding service found, update the name.
 						if ns != nil && ns == (*gwapiv1.Namespace)(&service.Namespace) {
-							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateName(false, string(service.UID), service.Name, service.Namespace))
+							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(service.UID), service.Name, service.Namespace))
 							// Set the namespace to nil since all the services are created in the same namespace as the Route.
 							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Namespace = nil
 						}
@@ -551,7 +551,7 @@ func (r *RouteReconciler) createOrUpdateGRPCRoute(ctx context.Context, log logr.
 						ns := ref.Namespace
 						// Corresponding service found, update the name.
 						if ns != nil && ns == (*gwapiv1.Namespace)(&service.Namespace) {
-							object.Spec.Rules[i].BackendRefs[j].Name = gwapiv1.ObjectName(kubelb.GenerateName(false, string(service.UID), service.Name, service.Namespace))
+							object.Spec.Rules[i].BackendRefs[j].Name = gwapiv1.ObjectName(kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(service.UID), service.Name, service.Namespace))
 							// Set the namespace to nil since all the services are created in the same namespace as the Route.
 							object.Spec.Rules[i].BackendRefs[j].Namespace = nil
 						}
@@ -568,7 +568,7 @@ func (r *RouteReconciler) createOrUpdateGRPCRoute(ctx context.Context, log logr.
 								ns := ref.Namespace
 								// Corresponding service found, update the name.
 								if ns != nil && ns == (*gwapiv1.Namespace)(&service.Namespace) {
-									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateName(false, string(service.UID), service.Name, service.Namespace))
+									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(service.UID), service.Name, service.Namespace))
 									// Set the namespace to nil since all the services are created in the same namespace as the Route.
 									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Namespace = nil
 								}
@@ -619,7 +619,7 @@ func (r *RouteReconciler) createOrUpdateIngress(ctx context.Context, log logr.Lo
 		for j, path := range rule.HTTP.Paths {
 			for _, service := range referencedServices {
 				if path.Backend.Service.Name == service.Name {
-					object.Spec.Rules[i].HTTP.Paths[j].Backend.Service.Name = kubelb.GenerateName(false, string(service.UID), service.Name, service.Namespace)
+					object.Spec.Rules[i].HTTP.Paths[j].Backend.Service.Name = kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(service.UID), service.Name, service.Namespace)
 				}
 			}
 		}
@@ -628,13 +628,13 @@ func (r *RouteReconciler) createOrUpdateIngress(ctx context.Context, log logr.Lo
 	if object.Spec.DefaultBackend != nil && object.Spec.DefaultBackend.Service != nil {
 		for _, service := range referencedServices {
 			if object.Spec.DefaultBackend.Service.Name == service.Name {
-				object.Spec.DefaultBackend.Service.Name = kubelb.GenerateName(false, string(service.UID), service.Name, service.Namespace)
+				object.Spec.DefaultBackend.Service.Name = kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(service.UID), service.Name, service.Namespace)
 			}
 		}
 	}
 
 	object.Spec.IngressClassName = config.GetConfig().Spec.IngressClassName
-	object.Name = kubelb.GenerateName(false, string(object.UID), object.Name, object.Namespace)
+	object.Name = kubelb.GenerateName(r.EnvoyProxyTopology.IsGlobalTopology(), string(object.UID), object.Name, object.Namespace)
 	object.Namespace = namespace
 	object.SetUID("") // Reset UID to generate a new UID for the object
 

--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -52,16 +52,16 @@ const ServiceKind = "Service"
 
 const NameSuffixLength = 4
 
-func GenerateName(useUID bool, uid, name, namespace string) string {
-	if useUID {
-		return uid
-	}
-
+func GenerateName(appendUID bool, uid, name, namespace string) string {
 	output := fmt.Sprintf("%s-%s", namespace, name)
+	uidSuffix := uid[len(uid)-NameSuffixLength:]
+
 	// If the output is longer than 63 characters, truncate the name and append a suffix
-	if len(output) > 63 {
+	if len(output) > 63 || (appendUID && len(output)+len(uidSuffix) > 63) {
 		output = output[:63-NameSuffixLength+1]
-		output = fmt.Sprintf("%s-%s", output, uid[len(uid)-NameSuffixLength:])
+		output = fmt.Sprintf("%s-%s", output, uidSuffix)
+	} else if appendUID {
+		output = fmt.Sprintf("%s-%s", output, uidSuffix)
 	}
 
 	return output

--- a/internal/resources/service/service.go
+++ b/internal/resources/service/service.go
@@ -107,11 +107,11 @@ func NormalizeAndReplicateServices(ctx context.Context, log logr.Logger, client 
 	return services, nil
 }
 
-func GenerateServiceForLBCluster(service corev1.Service, appName, namespace string, portAllocator *portlookup.PortAllocator) corev1.Service {
+func GenerateServiceForLBCluster(service corev1.Service, appName, namespace, resourceNamespace string, portAllocator *portlookup.PortAllocator) corev1.Service {
 	endpointKey := fmt.Sprintf(kubelb.EnvoyEndpointRoutePattern, namespace, service.Namespace, service.Name)
 
 	service.Name = kubelb.GenerateName(false, string(service.UID), GetServiceName(service), service.Namespace)
-	service.Namespace = namespace
+	service.Namespace = resourceNamespace
 	service.UID = ""
 	if service.Spec.Type == corev1.ServiceTypeNodePort {
 		service.Spec.Type = corev1.ServiceTypeClusterIP

--- a/internal/resources/service/service.go
+++ b/internal/resources/service/service.go
@@ -107,10 +107,10 @@ func NormalizeAndReplicateServices(ctx context.Context, log logr.Logger, client 
 	return services, nil
 }
 
-func GenerateServiceForLBCluster(service corev1.Service, appName, namespace, resourceNamespace string, portAllocator *portlookup.PortAllocator) corev1.Service {
+func GenerateServiceForLBCluster(service corev1.Service, appName, namespace, resourceNamespace string, portAllocator *portlookup.PortAllocator, globalTopology bool) corev1.Service {
 	endpointKey := fmt.Sprintf(kubelb.EnvoyEndpointRoutePattern, namespace, service.Namespace, service.Name)
 
-	service.Name = kubelb.GenerateName(false, string(service.UID), GetServiceName(service), service.Namespace)
+	service.Name = kubelb.GenerateName(globalTopology, string(service.UID), GetServiceName(service), service.Namespace)
 	service.Namespace = resourceNamespace
 	service.UID = ""
 	if service.Spec.Type == corev1.ServiceTypeNodePort {


### PR DESCRIPTION
**What this PR does / why we need it**:
For global topology, all the services and route resources like ingress, httproute etc. need to exist in the `kubelb` namespace instead of dedicated tenant namespaces. This is required since they need to route traffic to the single dedicated Envoy Proxy running in the `kubelb` namespace.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
