### PR TITLE
Remove enovy-proxy finalizer from load balancers

### DIFF
--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -173,7 +173,7 @@ func (r *EnvoyCPReconciler) ListLoadBalancersAndRoutes(ctx context.Context, req 
 
 	lbs := make([]kubelbv1alpha1.LoadBalancer, 0, len(loadBalancers.Items))
 	for _, lb := range loadBalancers.Items {
-		if lb.DeletionTimestamp.IsZero() && controllerutil.ContainsFinalizer(&lb, envoyProxyCleanupFinalizer) {
+		if lb.DeletionTimestamp.IsZero() && controllerutil.ContainsFinalizer(&lb, CleanupFinalizer) {
 			lbs = append(lbs, lb)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Simply replacing `kubelb.k8c.io/cleanup-envoy-proxy` with a more generic cleanup finalizer since LoadBalancer is no longer responsible/associated with the deployment on Envoy Proxy.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
