### PR TITLE
Fix status propagation and global topology

### DIFF
--- a/api/kubelb.k8c.io/v1alpha1/sync_secret_types.go
+++ b/api/kubelb.k8c.io/v1alpha1/sync_secret_types.go
@@ -32,6 +32,8 @@ type SyncSecret struct {
 	// Source: https://pkg.go.dev/k8s.io/api/core/v1#Secret
 
 	// +optional
+	Immutable *bool `json:"immutable,omitempty" protobuf:"varint,5,opt,name=immutable"`
+	// +optional
 	Data map[string][]byte `json:"data,omitempty" protobuf:"bytes,2,rep,name=data"`
 
 	// +k8s:conversion-gen=false

--- a/api/kubelb.k8c.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/kubelb.k8c.io/v1alpha1/zz_generated.deepcopy.go
@@ -759,6 +759,11 @@ func (in *SyncSecret) DeepCopyInto(out *SyncSecret) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Immutable != nil {
+		in, out := &in.Immutable, &out.Immutable
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Data != nil {
 		in, out := &in.Data, &out.Data
 		*out = make(map[string][]byte, len(*in))

--- a/charts/kubelb-ccm/crds/kubelb.k8c.io_syncsecrets.yaml
+++ b/charts/kubelb-ccm/crds/kubelb.k8c.io_syncsecrets.yaml
@@ -33,6 +33,8 @@ spec:
               format: byte
               type: string
             type: object
+          immutable:
+            type: boolean
           kind:
             description: |-
               Kind is a string value representing the REST resource this object represents.

--- a/charts/kubelb-ccm/templates/clusterrole.yaml
+++ b/charts/kubelb-ccm/templates/clusterrole.yaml
@@ -25,6 +25,7 @@ rules:
   - patch
   - update
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/charts/kubelb-manager/crds/kubelb.k8c.io_syncsecrets.yaml
+++ b/charts/kubelb-manager/crds/kubelb.k8c.io_syncsecrets.yaml
@@ -33,6 +33,8 @@ spec:
               format: byte
               type: string
             type: object
+          immutable:
+            type: boolean
           kind:
             description: |-
               Kind is a string value representing the REST resource this object represents.

--- a/charts/kubelb-manager/templates/clusterrole.yaml
+++ b/charts/kubelb-manager/templates/clusterrole.yaml
@@ -54,6 +54,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gateways

--- a/cmd/ccm/main.go
+++ b/cmd/ccm/main.go
@@ -232,7 +232,7 @@ func main() {
 	if !disableIngressController {
 		if err = (&ccm.IngressReconciler{
 			Client:          mgr.GetClient(),
-			LBClient:        kubeLBMgr.GetClient(),
+			LBManager:       kubeLBMgr,
 			ClusterName:     clusterName,
 			Log:             ctrl.Log.WithName("controllers").WithName(ccm.IngressControllerName),
 			Scheme:          mgr.GetScheme(),
@@ -247,7 +247,7 @@ func main() {
 	if !disableGatewayController && !disableGatewayAPI {
 		if err = (&ccm.GatewayReconciler{
 			Client:          mgr.GetClient(),
-			LBClient:        kubeLBMgr.GetClient(),
+			LBManager:       kubeLBMgr,
 			ClusterName:     clusterName,
 			Log:             ctrl.Log.WithName("controllers").WithName(ccm.GatewayControllerName),
 			Scheme:          mgr.GetScheme(),
@@ -262,7 +262,7 @@ func main() {
 	if !disableHTTPRouteController && !disableGatewayAPI {
 		if err = (&ccm.HTTPRouteReconciler{
 			Client:      mgr.GetClient(),
-			LBClient:    kubeLBMgr.GetClient(),
+			LBManager:   kubeLBMgr,
 			ClusterName: clusterName,
 			Log:         ctrl.Log.WithName("controllers").WithName(ccm.GatewayHTTPRouteControllerName),
 			Scheme:      mgr.GetScheme(),
@@ -276,7 +276,7 @@ func main() {
 	if !disableGRPCRouteController && !disableGatewayAPI {
 		if err = (&ccm.GRPCRouteReconciler{
 			Client:      mgr.GetClient(),
-			LBClient:    kubeLBMgr.GetClient(),
+			LBManager:   kubeLBMgr,
 			ClusterName: clusterName,
 			Log:         ctrl.Log.WithName("controllers").WithName(ccm.GatewayGRPCRouteControllerName),
 			Scheme:      mgr.GetScheme(),

--- a/cmd/kubelb/main.go
+++ b/cmd/kubelb/main.go
@@ -240,6 +240,19 @@ func main() {
 		}
 	}
 
+	// This is only required when using global topology.
+	if conf.IsGlobalTopology() {
+		if err = (&kubelb.BridgeServiceReconciler{
+			Client:   mgr.GetClient(),
+			Scheme:   mgr.GetScheme(),
+			Log:      ctrl.Log.WithName("controllers").WithName(kubelb.BridgeServiceControllerName),
+			Recorder: mgr.GetEventRecorderFor(kubelb.BridgeServiceControllerName),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", kubelb.BridgeServiceControllerName)
+			os.Exit(1)
+		}
+	}
+
 	go func() {
 		setupLog.Info("starting kubelb envoy manager")
 

--- a/config/crd/bases/kubelb.k8c.io_syncsecrets.yaml
+++ b/config/crd/bases/kubelb.k8c.io_syncsecrets.yaml
@@ -33,6 +33,8 @@ spec:
               format: byte
               type: string
             type: object
+          immutable:
+            type: boolean
           kind:
             description: |-
               Kind is a string value representing the REST resource this object represents.

--- a/config/kubelb/rbac/role.yaml
+++ b/config/kubelb/rbac/role.yaml
@@ -85,6 +85,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gateways

--- a/internal/controllers/ccm/gateway_grpcroute_controller.go
+++ b/internal/controllers/ccm/gateway_grpcroute_controller.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -55,7 +56,7 @@ const (
 type GRPCRouteReconciler struct {
 	ctrlclient.Client
 
-	LBClient    ctrlclient.Client
+	LBManager   ctrl.Manager
 	ClusterName string
 
 	Log      logr.Logger
@@ -115,14 +116,14 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *GRPCRouteReconciler) reconcile(ctx context.Context, log logr.Logger, grpcRoute *gwapiv1.GRPCRoute) error {
 	// We need to traverse the GRPCRoute, find all the services associated with it, create/update the corresponding Route in LB cluster.
 	originalServices := grpcrouteHelpers.GetServicesFromGRPCRoute(grpcRoute)
-	err := reconcileSourceForRoute(ctx, log, r.Client, r.LBClient, grpcRoute, originalServices, nil, r.ClusterName)
+	err := reconcileSourceForRoute(ctx, log, r.Client, r.LBManager.GetClient(), grpcRoute, originalServices, nil, r.ClusterName)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile source for route: %w", err)
 	}
 
 	// Route was reconciled successfully, now we need to update the status of the Resource.
 	route := kubelbv1alpha1.Route{}
-	err = r.LBClient.Get(ctx, types.NamespacedName{Name: string(grpcRoute.UID), Namespace: r.ClusterName}, &route)
+	err = r.LBManager.GetClient().Get(ctx, types.NamespacedName{Name: string(grpcRoute.UID), Namespace: r.ClusterName}, &route)
 	if err != nil {
 		return fmt.Errorf("failed to get Route from LB cluster: %w", err)
 	}
@@ -186,7 +187,7 @@ func (r *GRPCRouteReconciler) cleanup(ctx context.Context, grpcRoute *gwapiv1.GR
 	}
 
 	// Find the Route in LB cluster and delete it
-	err = cleanupRoute(ctx, r.LBClient, string(grpcRoute.UID), r.ClusterName)
+	err = cleanupRoute(ctx, r.LBManager.GetClient(), string(grpcRoute.UID), r.ClusterName)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to cleanup route: %w", err)
 	}
@@ -277,6 +278,10 @@ func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.Service{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueResources()),
+		).
+		WatchesRawSource(
+			source.Kind(r.LBManager.GetCache(), &kubelbv1alpha1.Route{},
+				handler.TypedEnqueueRequestsFromMapFunc[*kubelbv1alpha1.Route](enqueueRoutes("GRPCRoute.gateway.networking.k8s.io", r.ClusterName))),
 		).
 		Complete(r)
 }

--- a/internal/controllers/ccm/secret_conversion_controller.go
+++ b/internal/controllers/ccm/secret_conversion_controller.go
@@ -108,6 +108,7 @@ func (r *SecretConversionReconciler) reconcile(ctx context.Context, _ logr.Logge
 	syncSecret.Labels[kubelb.LabelOriginName] = secret.Name
 	syncSecret.Data = secret.Data
 	syncSecret.StringData = secret.StringData
+	syncSecret.Immutable = secret.Immutable
 	syncSecret.Type = secret.Type
 	return CreateOrUpdateSyncSecret(ctx, r.Client, syncSecret)
 }

--- a/internal/controllers/kubelb/bridgeservice_controller.go
+++ b/internal/controllers/kubelb/bridgeservice_controller.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2024 The KubeLB Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"k8c.io/kubelb/internal/kubelb"
+	"k8c.io/kubelb/internal/util/predicate"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	BridgeServiceControllerName = "bridge-service-controller"
+)
+
+// BridgeServiceReconciler reconciles the "bridge" service. This service is used to forward traffic from tenant namespace to the controller namespace when global
+// topology is used.
+type BridgeServiceReconciler struct {
+	ctrlclient.Client
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=get;list;watch;create;update;patch;delete
+
+func (r *BridgeServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("name", req.NamespacedName)
+
+	log.Info("Reconciling Service")
+
+	resource := &corev1.Service{}
+	if err := r.Get(ctx, req.NamespacedName, resource); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// Resource is marked for deletion
+	if resource.DeletionTimestamp != nil {
+		// Ignore since no cleanup is required. Clean up is done automatically using owner references.
+		return reconcile.Result{}, nil
+	}
+
+	err := r.reconcile(ctx, log, resource)
+	if err != nil {
+		log.Error(err, "reconciling failed")
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *BridgeServiceReconciler) reconcile(ctx context.Context, _ logr.Logger, object *corev1.Service) error {
+	// Find original service against the bridge service
+	name := object.Labels[kubelb.LabelOriginName]
+	namespace := object.Labels[kubelb.LabelOriginNamespace]
+
+	originalService := &corev1.Service{}
+	err := r.Get(ctx, ctrlclient.ObjectKey{Name: name, Namespace: namespace}, originalService)
+	if err != nil {
+		return fmt.Errorf("failed to get original service: %w", err)
+	}
+
+	endpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	endpointSlice.Labels = make(map[string]string)
+	endpointSlice.Labels = kubelb.AddKubeLBLabels(endpointSlice.Labels, name, namespace, "Service")
+	endpointSlice.Labels[discoveryv1.LabelServiceName] = name
+	endpointSlice.AddressType = discoveryv1.AddressTypeIPv4
+	for _, port := range originalService.Spec.Ports {
+		endpointSlice.Ports = append(endpointSlice.Ports, discoveryv1.EndpointPort{
+			Name:     ptr.To(port.Name),
+			Port:     ptr.To(port.TargetPort.IntVal),
+			Protocol: ptr.To(port.Protocol),
+		})
+	}
+	endpointSlice.Endpoints = []discoveryv1.Endpoint{
+		{
+			Addresses: object.Spec.ClusterIPs,
+			Conditions: discoveryv1.EndpointConditions{
+				Ready: ptr.To(true),
+			},
+		},
+	}
+
+	ownerReference := metav1.OwnerReference{
+		APIVersion: originalService.APIVersion,
+		Kind:       originalService.Kind,
+		Name:       originalService.Name,
+		UID:        originalService.UID,
+		Controller: ptr.To(true),
+	}
+
+	// Set owner reference for the resource.
+	endpointSlice.SetOwnerReferences([]metav1.OwnerReference{ownerReference})
+
+	return CreateOrUpdateEndpointSlice(ctx, r.Client, endpointSlice)
+}
+
+func CreateOrUpdateEndpointSlice(ctx context.Context, client ctrlclient.Client, obj *discoveryv1.EndpointSlice) error {
+	key := ctrlclient.ObjectKey{Namespace: obj.Namespace, Name: obj.Name}
+	existing := &discoveryv1.EndpointSlice{}
+	if err := client.Get(ctx, key, existing); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get EndpointSlice: %w", err)
+		}
+		err := client.Create(ctx, obj)
+		if err != nil {
+			return fmt.Errorf("failed to create EndpointSlice: %w", err)
+		}
+		return nil
+	}
+
+	// Update the object if it is different from the existing one.
+	if equality.Semantic.DeepEqual(existing.Ports, obj.Ports) &&
+		equality.Semantic.DeepEqual(existing.Endpoints, obj.Endpoints) &&
+		equality.Semantic.DeepEqual(existing.Labels, obj.Labels) {
+		return nil
+	}
+
+	// Required to update the object.
+	obj.ResourceVersion = existing.ResourceVersion
+	obj.UID = existing.UID
+
+	if err := client.Update(ctx, obj); err != nil {
+		return fmt.Errorf("failed to update EndpointSlice: %w", err)
+	}
+	return nil
+}
+
+func (r *BridgeServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// Watch services with label app.kubernetes.io/type=bridge-service
+		For(&corev1.Service{}, builder.WithPredicates(predicate.ByLabel(kubelb.LabelAppKubernetesType, kubelb.LabelBridgeService))).
+		Complete(r)
+}

--- a/internal/controllers/kubelb/sync_secret_controller.go
+++ b/internal/controllers/kubelb/sync_secret_controller.go
@@ -104,9 +104,6 @@ func (r *SyncSecretReconciler) reconcile(ctx context.Context, _ logr.Logger, obj
 	secret.Labels = object.Labels
 	secret.Annotations = object.Annotations
 	secret.Namespace = object.Namespace
-	if r.EnvoyProxyTopology.IsGlobalTopology() {
-		secret.Namespace = r.Namespace
-	}
 
 	// Name needs to be randomized so using the UID of the SyncSecret.
 	secret.Name = string(object.UID)
@@ -160,10 +157,6 @@ func CreateOrUpdateSecret(ctx context.Context, client ctrlclient.Client, obj *co
 func (r *SyncSecretReconciler) cleanup(ctx context.Context, object *kubelbv1alpha1.SyncSecret) (ctrl.Result, error) {
 	resource := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: string(object.UID), Namespace: object.Namespace},
-	}
-
-	if r.EnvoyProxyTopology.IsGlobalTopology() {
-		resource.Namespace = r.Namespace
 	}
 
 	err := r.Delete(ctx, resource)

--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -33,8 +33,10 @@ const LabelLoadBalancerName = "kubelb.k8c.io/lb-name"
 const LabelTenantName = "kubelb.k8c.io/tenant"
 const LabelManagedBy = "kubelb.k8c.io/managed-by"
 const LabelControllerName = "kubelb"
+const LabelBridgeService = "bridge-service"
 
 const LabelAppKubernetesName = "app.kubernetes.io/name"            // mysql
+const LabelAppKubernetesType = "app.kubernetes.io/type"            // mysql
 const LabelAppKubernetesInstance = "app.kubernetes.io/instance"    // mysql-abcxzy"
 const LabelAppKubernetesVersion = "app.kubernetes.io/version"      // 5.7.21
 const LabelAppKubernetesComponent = "app.kubernetes.io/component"  // database

--- a/internal/resources/ingress/ingress.go
+++ b/internal/resources/ingress/ingress.go
@@ -75,7 +75,7 @@ func CreateOrUpdateIngress(ctx context.Context, log logr.Logger, client ctrlclie
 	// Process secrets.
 	if object.Spec.TLS != nil {
 		for i := range object.Spec.TLS {
-			secretName := util.GetSecretNameIfExists(ctx, client, object.Spec.TLS[i].SecretName, object.Namespace)
+			secretName := util.GetSecretNameIfExists(ctx, client, object.Spec.TLS[i].SecretName, object.Namespace, namespace)
 			if secretName != "" {
 				object.Spec.TLS[i].SecretName = secretName
 			}

--- a/internal/util/kubernetes/secret.go
+++ b/internal/util/kubernetes/secret.go
@@ -25,9 +25,9 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetSecretNameIfExists(ctx context.Context, client ctrlclient.Client, name, namespace string) string {
+func GetSecretNameIfExists(ctx context.Context, client ctrlclient.Client, name, namespace string, tenantNamespace string) string {
 	secrets := corev1.SecretList{}
-	err := client.List(ctx, &secrets, ctrlclient.MatchingLabels{kubelb.LabelOriginName: name, kubelb.LabelOriginNamespace: namespace})
+	err := client.List(ctx, &secrets, ctrlclient.InNamespace(tenantNamespace), ctrlclient.MatchingLabels{kubelb.LabelOriginName: name, kubelb.LabelOriginNamespace: namespace})
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

For global topology, we had an issue with how traffic would be forwarded and regulated throughout; for ingress to service, gateway to service to envoy, etc. Previously, for `LoadBalancer` the service that was getting created corresponding to an LB CR was being created in the controller namespace. This has serious security implications as it exposes services, ingress, gateway API resources for ALL tenants in a single namespace. Giving the tenants un-monitored access to resoures for other tenants. Although the resources are managed by KubeLB still and we take good care of naming to keep this isolated -- it's not an assurity and still risky architecture.

What options were assessed for this:
1. ExternalName service that forwards traffic to `service-name.controller-namespace.svc.cluster.local`. Dropped this idea since ExternalName services are not supported in Gateway API
2. EndpointSlice with FQDN `service-name.controller-namespace.svc.cluster.local` as endpoint. FQDN is deprecated https://github.com/kubernetes/kubernetes/pull/114677
3. Place all resources in controller namespace - this is possible but is poor from a security and isolation standpoint since we lose the ability of 1-1 mapping of resources to namespaces. Resources are not unique anymore and someone might end up attaching their services/httproutes to Ingresses/Gateways for another tenant. Complete NO GO for Layer 7.

**Decision:** Use a bridge service in controller namespace that simply forwards traffic to envoy on the correct target port. Use Service without Selector in tenant namespace and EndpointSlices to forward traffic from tenant namespace to the envoy proxy in controller namespace.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1728
```
