### PR TITLE
use upstream kube-rbac-proxy from quay.io

### DIFF
--- a/charts/kubelb-ccm/templates/deployment.yaml
+++ b/charts/kubelb-ccm/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           - --secure-listen-address=0.0.0.0:8443
           - --upstream=http://127.0.0.1:8080/
           - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.16.0
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: kube-rbac-proxy
           ports:

--- a/charts/kubelb-manager/templates/deployment.yaml
+++ b/charts/kubelb-manager/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
           - --secure-listen-address=0.0.0.0:8443
           - --upstream=http://127.0.0.1:8080/
           - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.16.0
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: kube-rbac-proxy
           ports:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.16.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
**What this PR does / why we need it**:
As per https://github.com/kubernetes-sigs/kubebuilder/discussions/3907

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Use `quay.io/brancz/kube-rbac-proxy` to fetch kube-rbac-proxy.
```

**Documentation**:
```documentation
NONE
```
