### PR TITLE
Add 'tenant-' prefix to tenant name in CCM, if not provided

### DIFF
--- a/cmd/ccm/main.go
+++ b/cmd/ccm/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"go.uber.org/zap/zapcore"
@@ -112,6 +113,11 @@ func main() {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	// If clusterName is not prefixed with "tenant-" then prefix it
+	if !strings.HasPrefix(clusterName, "tenant-") {
+		clusterName = "tenant-" + clusterName
+	}
 
 	if enableGatewayAPI {
 		utilruntime.Must(gwapiv1.Install(scheme))

--- a/hack/ci/e2e/config/ccm/tenant-1/kustomization.yaml
+++ b/hack/ci/e2e/config/ccm/tenant-1/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
 - ../base
-namespace: cluster-tenant1
+namespace: tenant-primary
 patches:
 - patch: |-
     - op: add
       path: "/spec/template/spec/containers/0/args/-"
-      value: "--cluster-name=cluster-tenant1"
+      value: "--cluster-name=tenant-primary"
   target:
     kind: Deployment

--- a/hack/ci/e2e/config/ccm/tenant-2/kustomization.yaml
+++ b/hack/ci/e2e/config/ccm/tenant-2/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
 - ../base
-namespace: cluster-tenant2
+namespace: tenant-secondary
 patches:
 - patch: |-
     - op: add
       path: "/spec/template/spec/containers/0/args/-"
-      value: "--cluster-name=cluster-tenant2"
+      value: "--cluster-name=tenant-secondary"
   target:
     kind: Deployment

--- a/hack/ci/e2e/deploy-kubelb.sh
+++ b/hack/ci/e2e/deploy-kubelb.sh
@@ -56,11 +56,15 @@ kind load docker-image --name=kubelb kubermatic.io/ccm:e2e
 echodate "Install kubelb"
 make install
 make e2e-deploy-kubelb
-for i in 1 2; do
-  echodate "Install ccm for cluster-tenant${i}"
-  kubectl create ns "cluster-tenant${i}"
-  kubectl label ns "cluster-tenant${i}" kubelb.k8c.io/managed-by=kubelb
-  kubectl config set-context $(kubectl config current-context) --namespace="cluster-tenant${i}"
+
+tenants=("tenant-primary" "tenant-secondary")
+i=1
+for tenant in "${tenants[@]}"; do
+  echodate "Install ccm for $tenant"
+  kubectl create ns "$tenant"
+  kubectl label ns "$tenant" kubelb.k8c.io/managed-by=kubelb
+  kubectl config set-context $(kubectl config current-context) --namespace="$tenant"
   kubectl create secret generic kubelb-cluster --from-file=kubelb="${TMPDIR}"/kubelb.kubeconfig --from-file=tenant="${TMPDIR}/tenant${i}.kubeconfig"
   make "e2e-deploy-ccm-tenant-${i}"
+  i=$((i + 1))
 done

--- a/hack/ci/e2e/tests/basic_test.go
+++ b/hack/ci/e2e/tests/basic_test.go
@@ -68,14 +68,14 @@ func TestSimpleService(t *testing.T) {
 	expectHTTPGet(testServiceURL, "nginx/1.24.0")
 
 	lb := v1alpha1.LoadBalancer{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant1", Name: string(svc.UID)}, &lb)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-primary", Name: string(svc.UID)}, &lb)).To(Succeed())
 	Expect(len(lb.Spec.Endpoints)).To(Equal(1))
 	Expect(len(lb.Spec.Endpoints[0].Ports)).To(Equal(1))
 
 	Expect(lb.Spec.Endpoints[0].AddressesReference).ToNot(BeNil())
 	// Retrieve the endpoint addresses and make sure they are correct
 	addresses := v1alpha1.Addresses{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant1", Name: string(*&lb.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-primary", Name: string(*&lb.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
 	Expect(len(addresses.Spec.Addresses)).To(Equal(1))
 }
 
@@ -95,14 +95,14 @@ func TestMultiNodeService(t *testing.T) {
 	expectHTTPGet(testServiceURL, "nginx/1.24.0")
 
 	lb := v1alpha1.LoadBalancer{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(svc.UID)}, &lb)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(svc.UID)}, &lb)).To(Succeed())
 	Expect(len(lb.Spec.Endpoints)).To(Equal(1))
 	Expect(len(lb.Spec.Endpoints[0].Ports)).To(Equal(1))
 
 	Expect(lb.Spec.Endpoints[0].AddressesReference).ToNot(BeNil())
 	// Retrieve the endpoint addresses and make sure they are correct
 	addresses := v1alpha1.Addresses{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(*&lb.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(*&lb.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
 	Expect(len(addresses.Spec.Addresses)).To(Equal(4))
 }
 
@@ -123,14 +123,14 @@ func TestMultiPortService(t *testing.T) {
 	expectHTTPGet(fmt.Sprintf("%v:9901", testServiceURL), "envoy")
 
 	lb := v1alpha1.LoadBalancer{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant1", Name: string(svc.UID)}, &lb)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-primary", Name: string(svc.UID)}, &lb)).To(Succeed())
 	Expect(len(lb.Spec.Endpoints)).To(Equal(1))
 	Expect(len(lb.Spec.Endpoints[0].Ports)).To(Equal(2))
 
 	Expect(lb.Spec.Endpoints[0].AddressesReference).ToNot(BeNil())
 	// Retrieve the endpoint addresses and make sure they are correct
 	addresses := v1alpha1.Addresses{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(*&lb.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(*&lb.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
 	Expect(len(addresses.Spec.Addresses)).To(Equal(4))
 }
 
@@ -151,14 +151,14 @@ func TestMultiPortMultiNodeService(t *testing.T) {
 	expectHTTPGet(fmt.Sprintf("%v:9901", testServiceURL), "envoy")
 
 	lb := v1alpha1.LoadBalancer{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(svc.UID)}, &lb)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(svc.UID)}, &lb)).To(Succeed())
 	Expect(len(lb.Spec.Endpoints)).To(Equal(1))
 	Expect(len(lb.Spec.Endpoints[0].Ports)).To(Equal(2))
 
 	Expect(lb.Spec.Endpoints[0].AddressesReference).ToNot(BeNil())
 	// Retrieve the endpoint addresses and make sure they are correct
 	addresses := v1alpha1.Addresses{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(*&lb.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(*&lb.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
 	Expect(len(addresses.Spec.Addresses)).To(Equal(4))
 }
 
@@ -190,25 +190,25 @@ func TestDuplicateService(t *testing.T) {
 	expectHTTPGet(fmt.Sprintf("%v:8080", testServiceURL2), "envoy")
 
 	lb1 := v1alpha1.LoadBalancer{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant1", Name: string(svc1.UID)}, &lb1)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-primary", Name: string(svc1.UID)}, &lb1)).To(Succeed())
 	Expect(len(lb1.Spec.Endpoints)).To(Equal(1))
 	Expect(len(lb1.Spec.Endpoints[0].Ports)).To(Equal(2))
 
 	Expect(lb1.Spec.Endpoints[0].AddressesReference).ToNot(BeNil())
 	// Retrieve the endpoint addresses and make sure they are correct
 	addresses := v1alpha1.Addresses{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant1", Name: string(*&lb1.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-primary", Name: string(*&lb1.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
 	Expect(len(addresses.Spec.Addresses)).To(Equal(1))
 
 	lb2 := v1alpha1.LoadBalancer{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(svc2.UID)}, &lb2)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(svc2.UID)}, &lb2)).To(Succeed())
 	Expect(len(lb2.Spec.Endpoints)).To(Equal(1))
 	Expect(len(lb2.Spec.Endpoints[0].Ports)).To(Equal(2))
 
 	Expect(lb2.Spec.Endpoints[0].AddressesReference).ToNot(BeNil())
 	// Retrieve the endpoint addresses and make sure they are correct
 	addresses = v1alpha1.Addresses{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(*&lb2.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(*&lb2.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
 	Expect(len(addresses.Spec.Addresses)).To(Equal(4))
 }
 
@@ -252,24 +252,24 @@ func TestMultipleServices(t *testing.T) {
 	wg.Wait()
 
 	lb1 := v1alpha1.LoadBalancer{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(svc1.UID)}, &lb1)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(svc1.UID)}, &lb1)).To(Succeed())
 	Expect(len(lb1.Spec.Endpoints)).To(Equal(1))
 	Expect(len(lb1.Spec.Endpoints[0].Ports)).To(Equal(2))
 
 	Expect(lb1.Spec.Endpoints[0].AddressesReference).ToNot(BeNil())
 	// Retrieve the endpoint addresses and make sure they are correct
 	addresses := v1alpha1.Addresses{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(*&lb1.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(*&lb1.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
 	Expect(len(addresses.Spec.Addresses)).To(Equal(4))
 
 	lb2 := v1alpha1.LoadBalancer{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(svc2.UID)}, &lb2)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(svc2.UID)}, &lb2)).To(Succeed())
 	Expect(len(lb2.Spec.Endpoints)).To(Equal(1))
 	Expect(len(lb2.Spec.Endpoints[0].Ports)).To(Equal(2))
 
 	Expect(lb2.Spec.Endpoints[0].AddressesReference).ToNot(BeNil())
 	// Retrieve the endpoint addresses and make sure they are correct
 	addresses = v1alpha1.Addresses{}
-	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "cluster-tenant2", Name: string(*&lb2.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
+	Expect(kubelbK8sClient.Get(ctx, types.NamespacedName{Namespace: "tenant-secondary", Name: string(*&lb2.Spec.Endpoints[0].AddressesReference.Name)}, &addresses)).To(Succeed())
 	Expect(len(addresses.Spec.Addresses)).To(Equal(4))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
KubeLB will now automatically add `tenant-` prefix to cluster/tenant name if it was not provided by the user.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #71

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeLB will now automatically add `tenant-` prefix to cluster/tenant name if it was not provided by the user.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
