### PR TITLE
Generate RBAC for KKP integration using helm chart

### DIFF
--- a/charts/kubelb-manager/README.md
+++ b/charts/kubelb-manager/README.md
@@ -35,6 +35,7 @@ helm install kubelb-manager kubelb-manager --namespace kubelb -f values.yaml --c
 | image.repository | string | `"quay.io/kubermatic/kubelb-manager"` |  |
 | image.tag | string | `"v1.1.0"` |  |
 | imagePullSecrets | list | `[]` |  |
+| kkpintegration.rbac | bool | `false` | Create RBAC for KKP integration. |
 | kubelb.debug | bool | `true` |  |
 | kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
 | kubelb.enableLeaderElection | bool | `true` |  |

--- a/charts/kubelb-manager/templates/kkp-rbac.yaml
+++ b/charts/kubelb-manager/templates/kkp-rbac.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.kkpintegration.rbac -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubelb-kkp
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubelb-kkp
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  # Required to copy kubelb-ccm-kubeconfig secret for the tenant in the KKP seed cluster.
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kubelb.k8c.io
+  resources:
+  - tenants
+  - configs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - kubelb.k8c.io
+  resources:
+  - routes
+  - loadbalancers
+  - addresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelb-kkp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubelb-kkp
+subjects:
+  - kind: ServiceAccount
+    name: kubelb-kkp
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubelb-kkp-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: kubelb-kkp
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/kubelb-manager/values.yaml
+++ b/charts/kubelb-manager/values.yaml
@@ -33,6 +33,11 @@ kubelb:
   # -- Propagate all annotations from the LB resource to the LB service.
   propagateAllAnnotations: false
 
+# Create required resources for KKP integration.
+kkpintegration:
+  # -- Create RBAC for KKP integration.
+  rbac: false
+
 #################################################################################
 # Further configurations for the KubeLB Manager.
 #################################################################################


### PR DESCRIPTION
**What this PR does / why we need it**:
For KKP integration, a Kubeconfig of the management cluster is required. KKP then automates tenant creation, etc. In the future, we'll also have integration in the KKP dashboard. 

Documenting the RBAC for users doesn't sound adequate since they'll have to update/manage it for KubeLB upgrades manually. Hence, we are adding the RBAC as part of the KubeLB management helm chart; KubeLB will take care of the RBAC.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #77

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeLB now maintains the required RBAC attached to the kubeconfig for KKP integration. `kkpintegration.rbac: true` can be used to manage the RBAC using KubeLB helm chart.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
