### PR TITLE
Don't modify IngressClassName if it's not set in the configuration

### DIFF
--- a/internal/resources/ingress/ingress.go
+++ b/internal/resources/ingress/ingress.go
@@ -60,14 +60,11 @@ func CreateOrUpdateIngress(ctx context.Context, log logr.Logger, client ctrlclie
 	}
 
 	// Class name depends on the chosen Ingress controller for the tenant or global cluster.
-	var className *string
 	if tenant.Spec.Ingress.Class != nil {
-		className = tenant.Spec.Ingress.Class
+		object.Spec.IngressClassName = tenant.Spec.Ingress.Class
 	} else if config.Spec.Ingress.Class != nil {
-		className = config.Spec.Ingress.Class
+		object.Spec.IngressClassName = config.Spec.Ingress.Class
 	}
-
-	object.Spec.IngressClassName = className
 
 	// Process annotations.
 	object.Annotations = kubelb.PropagateAnnotations(object.Annotations, annotations, kubelbv1alpha1.AnnotatedResourceIngress)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where `IngressClassName` was being set as `nil` if it was not configured at Config or Tenant level.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't modify IngressClassName if it's not set in the configuration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
