### PR TITLE
Improve port mapping in service reconciliation (#91)

### DIFF
--- a/internal/controllers/utils.go
+++ b/internal/controllers/utils.go
@@ -22,6 +22,7 @@ import (
 	"k8c.io/kubelb/internal/kubelb"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,4 +80,18 @@ func workqueueFilter(filter func(o ctrlruntimeclient.Object) bool) predicate.Fun
 			return filter(e.Object)
 		},
 	}
+}
+
+// CompareAnnotations compares two annotation maps while ignoring the last-applied-configuration annotation
+func CompareAnnotations(a, b map[string]string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	delete(a, corev1.LastAppliedConfigAnnotation)
+	delete(b, corev1.LastAppliedConfigAnnotation)
+	return equality.Semantic.DeepEqual(a, b)
 }

--- a/internal/kubelb/loadbalancer.go
+++ b/internal/kubelb/loadbalancer.go
@@ -17,7 +17,9 @@ limitations under the License.
 package kubelb
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 
 	kubelbiov1alpha1 "k8c.io/kubelb/api/kubelb.k8c.io/v1alpha1"
 
@@ -32,14 +34,20 @@ func MapLoadBalancer(userService *corev1.Service, clusterEndpoints []string, use
 
 	// mapping into load balancing service and endpoint subset ports
 	for _, port := range userService.Spec.Ports {
+		// Add a name for port if not set.
+		name := fmt.Sprintf("%d-%s", port.Port, strings.ToLower(string(port.Protocol)))
+		if port.Name != "" {
+			name = strings.ToLower(port.Name)
+		}
+
 		lbServicePorts = append(lbServicePorts, kubelbiov1alpha1.LoadBalancerPort{
-			Name:     port.Name,
+			Name:     name,
 			Port:     port.Port,
 			Protocol: port.Protocol,
 		})
 
 		lbEndpointPorts = append(lbEndpointPorts, kubelbiov1alpha1.EndpointPort{
-			Name:     port.Name,
+			Name:     name,
 			Port:     port.NodePort,
 			Protocol: port.Protocol,
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of https://github.com/kubermatic/kubelb/pull/91

/kind bug


```release-note
Fix an issue with KubeLB not respecting the already allocated NodePort in the management cluster for load balancers with large amount of open Nodeports

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
