### PR TITLE
Use arbitrary ports for load balancer ports irrespective of envoy topology

### DIFF
--- a/cmd/kubelb/main.go
+++ b/cmd/kubelb/main.go
@@ -150,7 +150,7 @@ func main() {
 		setupLog.Error(err, "unable to load controller config")
 		os.Exit(1)
 	}
-	// For Global topology, we need to ensure that the port lookup table exists. If it doesn't, we create it since it's managed by this controller.
+	// We need to ensure that the port lookup table exists. If it doesn't, we create it since it's managed by this controller.
 	portAllocator := portlookup.NewPortAllocator()
 	if err := portAllocator.LoadState(ctx, mgr.GetAPIReader()); err != nil {
 		setupLog.Error(err, ("unable to load port lookup state"))

--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -99,14 +99,11 @@ func (r *EnvoyCPReconciler) reconcile(ctx context.Context, req ctrl.Request) err
 		return fmt.Errorf("failed to update Envoy proxy: %w", err)
 	}
 
-	// For Global topology, we need to ensure that an arbitrary port has been assigned to the endpoint ports of the LoadBalancer.
-	if r.EnvoyProxyTopology == EnvoyProxyTopologyGlobal {
-		lbList := kubelbv1alpha1.LoadBalancerList{
-			Items: lbs,
-		}
-		if err := r.PortAllocator.AllocatePortsForLoadBalancers(lbList); err != nil {
-			return err
-		}
+	lbList := kubelbv1alpha1.LoadBalancerList{
+		Items: lbs,
+	}
+	if err := r.PortAllocator.AllocatePortsForLoadBalancers(lbList); err != nil {
+		return err
 	}
 
 	if err := r.PortAllocator.AllocatePortsForRoutes(routes); err != nil {
@@ -118,7 +115,7 @@ func (r *EnvoyCPReconciler) reconcile(ctx context.Context, req ctrl.Request) err
 
 func (r *EnvoyCPReconciler) updateCache(ctx context.Context, snapshotName string, lbs []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route) error {
 	log := ctrl.LoggerFrom(ctx)
-	desiredSnapshot, err := envoycp.MapSnapshot(ctx, r.Client, lbs, routes, r.PortAllocator, r.EnvoyProxyTopology == EnvoyProxyTopologyGlobal)
+	desiredSnapshot, err := envoycp.MapSnapshot(ctx, r.Client, lbs, routes, r.PortAllocator)
 	if err != nil {
 		return err
 	}

--- a/internal/controllers/kubelb/loadbalancer_controller_test.go
+++ b/internal/controllers/kubelb/loadbalancer_controller_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Lb deployment and service creation", func() {
 				snapshot, err := envoyServer.Cache.GetSnapshot(snapshotName)
 				Expect(err).ToNot(HaveOccurred())
 
-				testSnapshot, err := envoycp.MapSnapshot(ctx, k8sClient, getLoadBalancerList(*lb), nil, ecpr.PortAllocator, t.topology == EnvoyProxyTopologyGlobal)
+				testSnapshot, err := envoycp.MapSnapshot(ctx, k8sClient, getLoadBalancerList(*lb), nil, ecpr.PortAllocator)
 				Expect(err).ToNot(HaveOccurred())
 				diff := deep.Equal(snapshot, testSnapshot)
 				if len(diff) > 0 {
@@ -187,7 +187,7 @@ var _ = Describe("Lb deployment and service creation", func() {
 				snapshot, err := envoyServer.Cache.GetSnapshot(snapshotName)
 				Expect(err).ToNot(HaveOccurred())
 
-				testSnapshot, err := envoycp.MapSnapshot(ctx, k8sClient, getLoadBalancerList(*existingLb), nil, ecpr.PortAllocator, t.topology == EnvoyProxyTopologyGlobal)
+				testSnapshot, err := envoycp.MapSnapshot(ctx, k8sClient, getLoadBalancerList(*existingLb), nil, ecpr.PortAllocator)
 				Expect(err).ToNot(HaveOccurred())
 				diff := deep.Equal(snapshot, testSnapshot)
 				if len(diff) > 0 {

--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -57,7 +57,7 @@ const (
 	defaultHealthCheckNoTrafficIntervalSeconds = 5
 )
 
-func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route, portAllocator *portlookup.PortAllocator, globalEnvoyProxyTopology bool) (*envoycache.Snapshot, error) {
+func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route, portAllocator *portlookup.PortAllocator) (*envoycache.Snapshot, error) {
 	var listener []types.Resource
 	var cluster []types.Resource
 
@@ -92,7 +92,7 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 				}
 
 				port := uint32(lbEndpointPort.Port)
-				if globalEnvoyProxyTopology && portAllocator != nil {
+				if portAllocator != nil {
 					endpointKey := fmt.Sprintf(kubelb.EnvoyEndpointPattern, lb.Namespace, lb.Name, i)
 					portKey := fmt.Sprintf(kubelb.EnvoyListenerPattern, lbEndpointPort.Port, lbEndpointPort.Protocol)
 					if value, exists := portAllocator.Lookup(endpointKey, portKey); exists {

--- a/internal/kubelb/loadbalancer.go
+++ b/internal/kubelb/loadbalancer.go
@@ -287,7 +287,7 @@ type PortAllocator interface {
 }
 
 // CreateServicePorts creates service ports for the load balancer
-func CreateServicePorts(loadBalancer *kubelbiov1alpha1.LoadBalancer, existingService *corev1.Service, portAllocator PortAllocator, topology string) []corev1.ServicePort {
+func CreateServicePorts(loadBalancer *kubelbiov1alpha1.LoadBalancer, existingService *corev1.Service, portAllocator PortAllocator) []corev1.ServicePort {
 	// Validate that endpoints exist
 	if len(loadBalancer.Spec.Endpoints) == 0 {
 		return []corev1.ServicePort{}
@@ -305,13 +305,11 @@ func CreateServicePorts(loadBalancer *kubelbiov1alpha1.LoadBalancer, existingSer
 			}
 		}
 
-		// For global topology, look up allocated port
-		if topology == "global" {
-			endpointKey := fmt.Sprintf(EnvoyEndpointPattern, loadBalancer.Namespace, loadBalancer.Name, 0)
-			portKey := fmt.Sprintf(EnvoyListenerPattern, targetPort, lbPort.Protocol)
-			if value, exists := portAllocator.Lookup(endpointKey, portKey); exists {
-				targetPort = int32(value)
-			}
+		// Look up allocated port
+		endpointKey := fmt.Sprintf(EnvoyEndpointPattern, loadBalancer.Namespace, loadBalancer.Name, 0)
+		portKey := fmt.Sprintf(EnvoyListenerPattern, targetPort, lbPort.Protocol)
+		if value, exists := portAllocator.Lookup(endpointKey, portKey); exists {
+			targetPort = int32(value)
 		}
 
 		// Try to find matching existing port to preserve NodePort if possible


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of using NodePorts as the target port for Envoy, we should completely rely on arbitrary ports to avoid any overlap between the port that's being assigned. By default, the NodePort of the service from tenant cluster is used as the TargetPort in the corresponding service that gets created in the management cluster.

Envoy doesn't expect duplicate listeners and it'll just stop serving any traffic if duplicate listeners are found. Although it's rare but we can face this issue when two tenants have the same NodePort for their LB service.

```
`[2025-08-04 07:53:48.737][1][warning][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:138] gRPC config for [type.googleapis.com/envoy.config.listener.v3.Listener](http://type.googleapis.com/envoy.config.listener.v3.Listener) rejected: Error adding/updating listener(s) tenant-shroud-testing2-ep-0-port-31863-TCP: error adding listener: ‘tenant-shroud-testing2-ep-0-port-31863-TCP’ has duplicate address ‘0.0.0.0:31863’ as existing listener
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use arbitrary ports as target port for load balancer services
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
