### PR TITLE
Expose admin port as containerport on envoy-proxies

### DIFF
--- a/cmd/kubelb/main.go
+++ b/cmd/kubelb/main.go
@@ -185,6 +185,7 @@ func main() {
 		PortAllocator:      portAllocator,
 		Namespace:          opt.namespace,
 		EnvoyBootstrap:     envoyServer.GenerateBootstrap(),
+		EnvoyDebugMode:     opt.enableDebugMode,
 		DisableGatewayAPI:  disableGatewayAPI,
 	}).SetupWithManager(ctx, envoyMgr); err != nil {
 		setupLog.Error(err, "unable to create envoy control-plane controller", "controller", "LoadBalancer")

--- a/internal/controllers/kubelb/suite_test.go
+++ b/internal/controllers/kubelb/suite_test.go
@@ -87,7 +87,8 @@ var _ = BeforeSuite(func() {
 	sigCtx := ctrl.SetupSignalHandler()
 	ctx, cancel = context.WithCancel(sigCtx)
 
-	envoyServer, err = envoy.NewServer(":8001", true)
+	envoyDebugMode := true
+	envoyServer, err = envoy.NewServer(":8001", envoyDebugMode)
 
 	Expect(err).ToNot(HaveOccurred())
 
@@ -148,6 +149,7 @@ var _ = BeforeSuite(func() {
 		EnvoyCache:         envoyServer.Cache,
 		EnvoyProxyTopology: EnvoyProxyTopologyShared,
 		EnvoyBootstrap:     envoyServer.GenerateBootstrap(),
+		EnvoyDebugMode:     envoyDebugMode,
 		Namespace:          LBNamespace,
 		PortAllocator:      portAllocator,
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR exposes the admin port, as container port, so that it can be accessed from outside the pod.
This allows to also set the prometheus scrape annotations, to get some envoy-proxy related metrics.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Improves #56
This does not yet fix the issue, but already exposes some metrics to the user, which can help debug issues with kubelb/envoy-proxies.

**What type of PR is this?**
/kind feature
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable scraping of envoy-proxies metrics endpoints.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
