### PR TITLE
Add probes and enable metrics for envoy-proxies

### DIFF
--- a/charts/kubelb-manager/templates/deployment.yaml
+++ b/charts/kubelb-manager/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
             {{ if .Values.kubelb.enableTenantMigration -}}
             - --enable-tenant-migration=true
             {{ end -}}
+            - --enable-tenant-envoy-monitoring={{ .Values.kubelb.enableTenantEnvoyMonitoring }}
             - --debug={{ .Values.kubelb.debug }}
           env:
           - name: NAMESPACE

--- a/charts/kubelb-manager/values.yaml
+++ b/charts/kubelb-manager/values.yaml
@@ -15,6 +15,7 @@ kubelb:
   skipConfigGeneration: false
   # -- enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start.
   enableGatewayAPI: false
+  enableTenantEnvoyMonitoring: true
   envoyProxy:
     # -- Topology defines the deployment topology for Envoy Proxy. Valid values are: shared and global.
     topology: shared

--- a/internal/controllers/kubelb/suite_test.go
+++ b/internal/controllers/kubelb/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	sigCtx := ctrl.SetupSignalHandler()
 	ctx, cancel = context.WithCancel(sigCtx)
 
-	envoyServer, err = envoy.NewServer(":8001", true)
+	envoyServer, err = envoy.NewServer(":8001", true, true)
 
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -23,7 +23,13 @@ import (
 	envoyCluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoyCore "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyEndpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoyListener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoyRoute "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoyFiltersRouterV3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	envoyFiltersHcmV3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -32,19 +38,19 @@ const xdsClusterName = "xds_cluster"
 
 const controlPlaneAddress = "envoycp.kubelb.svc"
 
+const EnvoyAdminPort = 9001
+
+const EnvoyStatsPort = 19001
+const EnvoyProbePort = 19003
+
+// By default, the admin interface is only accessible from localhost, to prevent
+// potential security issues while keeping it available for the stats and probe listeners.
+var EnvoyAdminListenerAddress = "127.0.0.1"
+
 func (s *Server) GenerateBootstrap() string {
-	var adminCfg *envoyBootstrap.Admin
-	if s.enableAdmin {
-		adminCfg = &envoyBootstrap.Admin{
-			Address: &envoyCore.Address{
-				Address: &envoyCore.Address_SocketAddress{SocketAddress: &envoyCore.SocketAddress{
-					Address: "0.0.0.0",
-					PortSpecifier: &envoyCore.SocketAddress_PortValue{
-						PortValue: 9001,
-					},
-				}},
-			},
-		}
+	// If debug is enabled, allow external access to the admin interface
+	if s.enableDebug {
+		EnvoyAdminListenerAddress = "0.0.0.0"
 	}
 
 	cfg := &envoyBootstrap.Bootstrap{
@@ -87,25 +93,30 @@ func (s *Server) GenerateBootstrap() string {
 			},
 		},
 		StaticResources: &envoyBootstrap.Bootstrap_StaticResources{
-			Clusters: []*envoyCluster.Cluster{{
-				Name:                 xdsClusterName,
-				ConnectTimeout:       durationpb.New(5 * time.Second),
-				ClusterDiscoveryType: &envoyCluster.Cluster_Type{Type: envoyCluster.Cluster_STRICT_DNS},
-				LbPolicy:             envoyCluster.Cluster_ROUND_ROBIN,
-				LoadAssignment: &envoyEndpoint.ClusterLoadAssignment{
-					ClusterName: xdsClusterName,
-					Endpoints: []*envoyEndpoint.LocalityLbEndpoints{
-						{
-							LbEndpoints: []*envoyEndpoint.LbEndpoint{
-								{
-									HostIdentifier: &envoyEndpoint.LbEndpoint_Endpoint{
-										Endpoint: &envoyEndpoint.Endpoint{
-											Address: &envoyCore.Address{
-												Address: &envoyCore.Address_SocketAddress{
-													SocketAddress: &envoyCore.SocketAddress{
-														Address: controlPlaneAddress,
-														PortSpecifier: &envoyCore.SocketAddress_PortValue{
-															PortValue: s.listenPort,
+			Listeners: []*envoyListener.Listener{
+				getProbesListener(),
+			},
+			Clusters: []*envoyCluster.Cluster{
+				{
+					Name:                 xdsClusterName,
+					ConnectTimeout:       durationpb.New(5 * time.Second),
+					ClusterDiscoveryType: &envoyCluster.Cluster_Type{Type: envoyCluster.Cluster_STRICT_DNS},
+					LbPolicy:             envoyCluster.Cluster_ROUND_ROBIN,
+					LoadAssignment: &envoyEndpoint.ClusterLoadAssignment{
+						ClusterName: xdsClusterName,
+						Endpoints: []*envoyEndpoint.LocalityLbEndpoints{
+							{
+								LbEndpoints: []*envoyEndpoint.LbEndpoint{
+									{
+										HostIdentifier: &envoyEndpoint.LbEndpoint_Endpoint{
+											Endpoint: &envoyEndpoint.Endpoint{
+												Address: &envoyCore.Address{
+													Address: &envoyCore.Address_SocketAddress{
+														SocketAddress: &envoyCore.SocketAddress{
+															Address: controlPlaneAddress,
+															PortSpecifier: &envoyCore.SocketAddress_PortValue{
+																PortValue: s.listenPort,
+															},
 														},
 													},
 												},
@@ -116,29 +127,70 @@ func (s *Server) GenerateBootstrap() string {
 							},
 						},
 					},
-				},
-				Http2ProtocolOptions: &envoyCore.Http2ProtocolOptions{},
-				CircuitBreakers: &envoyCluster.CircuitBreakers{
-					Thresholds: []*envoyCluster.CircuitBreakers_Thresholds{
-						{
-							Priority:           envoyCore.RoutingPriority_HIGH,
-							MaxConnections:     &wrapperspb.UInt32Value{Value: 100000},
-							MaxPendingRequests: &wrapperspb.UInt32Value{Value: 100000},
-							MaxRequests:        &wrapperspb.UInt32Value{Value: 60000000},
-							MaxRetries:         &wrapperspb.UInt32Value{Value: 50},
-						},
-						{
-							Priority:           envoyCore.RoutingPriority_DEFAULT,
-							MaxConnections:     &wrapperspb.UInt32Value{Value: 100000},
-							MaxPendingRequests: &wrapperspb.UInt32Value{Value: 100000},
-							MaxRequests:        &wrapperspb.UInt32Value{Value: 60000000},
-							MaxRetries:         &wrapperspb.UInt32Value{Value: 50},
+					Http2ProtocolOptions: &envoyCore.Http2ProtocolOptions{},
+					CircuitBreakers: &envoyCluster.CircuitBreakers{
+						Thresholds: []*envoyCluster.CircuitBreakers_Thresholds{
+							{
+								Priority:           envoyCore.RoutingPriority_HIGH,
+								MaxConnections:     &wrapperspb.UInt32Value{Value: 100000},
+								MaxPendingRequests: &wrapperspb.UInt32Value{Value: 100000},
+								MaxRequests:        &wrapperspb.UInt32Value{Value: 60000000},
+								MaxRetries:         &wrapperspb.UInt32Value{Value: 50},
+							},
+							{
+								Priority:           envoyCore.RoutingPriority_DEFAULT,
+								MaxConnections:     &wrapperspb.UInt32Value{Value: 100000},
+								MaxPendingRequests: &wrapperspb.UInt32Value{Value: 100000},
+								MaxRequests:        &wrapperspb.UInt32Value{Value: 60000000},
+								MaxRetries:         &wrapperspb.UInt32Value{Value: 50},
+							},
 						},
 					},
 				},
-			}},
+				{
+					Name:                 "admin_cluster",
+					ConnectTimeout:       durationpb.New(1 * time.Second),
+					ClusterDiscoveryType: &envoyCluster.Cluster_Type{Type: envoyCluster.Cluster_STATIC},
+					LbPolicy:             envoyCluster.Cluster_ROUND_ROBIN,
+					LoadAssignment: &envoyEndpoint.ClusterLoadAssignment{
+						ClusterName: "admin_cluster",
+						Endpoints: []*envoyEndpoint.LocalityLbEndpoints{{
+							LbEndpoints: []*envoyEndpoint.LbEndpoint{{
+								HostIdentifier: &envoyEndpoint.LbEndpoint_Endpoint{
+									Endpoint: &envoyEndpoint.Endpoint{
+										Address: &envoyCore.Address{
+											Address: &envoyCore.Address_SocketAddress{
+												SocketAddress: &envoyCore.SocketAddress{
+													Address: EnvoyAdminListenerAddress,
+													PortSpecifier: &envoyCore.SocketAddress_PortValue{
+														PortValue: EnvoyAdminPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							}},
+						}},
+					},
+				},
+			},
 		},
-		Admin: adminCfg,
+		Admin: &envoyBootstrap.Admin{
+			Address: &envoyCore.Address{
+				Address: &envoyCore.Address_SocketAddress{SocketAddress: &envoyCore.SocketAddress{
+					Address: EnvoyAdminListenerAddress,
+					PortSpecifier: &envoyCore.SocketAddress_PortValue{
+						PortValue: EnvoyAdminPort,
+					},
+				}},
+			},
+		},
+	}
+
+	// Stats listener and cluster rely on admin being enabled
+	if s.enableEnvoyMonitoring {
+		cfg.StaticResources.Listeners = append(cfg.StaticResources.Listeners, getStatsListener())
 	}
 
 	jsonBytes, err := protojson.Marshal(cfg)
@@ -147,4 +199,142 @@ func (s *Server) GenerateBootstrap() string {
 	}
 
 	return string(jsonBytes)
+}
+
+func getProbesListener() *envoyListener.Listener {
+	typedRouterFilterConfig, err := anypb.New(&envoyFiltersRouterV3.Router{})
+	if err != nil {
+		panic(err)
+	}
+
+	hcm := &envoyFiltersHcmV3.HttpConnectionManager{
+		StatPrefix: "stats_probe",
+		HttpFilters: []*envoyFiltersHcmV3.HttpFilter{{
+			Name:       wellknown.Router,
+			ConfigType: &envoyFiltersHcmV3.HttpFilter_TypedConfig{TypedConfig: typedRouterFilterConfig},
+		}},
+		RouteSpecifier: &envoyFiltersHcmV3.HttpConnectionManager_RouteConfig{
+			RouteConfig: &envoyRoute.RouteConfiguration{
+				Name: "local_route",
+				VirtualHosts: []*envoyRoute.VirtualHost{{
+					Name:    "probe_service",
+					Domains: []string{"*"},
+					Routes: []*envoyRoute.Route{{
+						Match: &envoyRoute.RouteMatch{
+							PathSpecifier: &envoyRoute.RouteMatch_Path{
+								Path: "/ready",
+							},
+							Headers: []*envoyRoute.HeaderMatcher{{
+								Name: ":method",
+								HeaderMatchSpecifier: &envoyRoute.HeaderMatcher_ExactMatch{
+									ExactMatch: "GET",
+								},
+							}},
+						},
+						Action: &envoyRoute.Route_Route{
+							Route: &envoyRoute.RouteAction{
+								ClusterSpecifier: &envoyRoute.RouteAction_Cluster{
+									Cluster: "admin_cluster",
+								},
+							},
+						},
+					}},
+				}},
+			},
+		},
+	}
+
+	typedConfig, err := anypb.New(hcm)
+	if err != nil {
+		panic(err)
+	}
+
+	return &envoyListener.Listener{
+		Name: "probe_listener",
+		Address: &envoyCore.Address{
+			Address: &envoyCore.Address_SocketAddress{
+				SocketAddress: &envoyCore.SocketAddress{
+					Address: "0.0.0.0",
+					PortSpecifier: &envoyCore.SocketAddress_PortValue{
+						PortValue: EnvoyProbePort,
+					},
+				},
+			},
+		},
+		FilterChains: []*envoyListener.FilterChain{{
+			Filters: []*envoyListener.Filter{{
+				Name:       wellknown.HTTPConnectionManager,
+				ConfigType: &envoyListener.Filter_TypedConfig{TypedConfig: typedConfig},
+			}},
+		}},
+	}
+}
+
+func getStatsListener() *envoyListener.Listener {
+	typedRouterFilterConfig, err := anypb.New(&envoyFiltersRouterV3.Router{})
+	if err != nil {
+		panic(err)
+	}
+
+	hcm := &envoyFiltersHcmV3.HttpConnectionManager{
+		StatPrefix: "stats_http",
+		HttpFilters: []*envoyFiltersHcmV3.HttpFilter{{
+			Name:       wellknown.Router,
+			ConfigType: &envoyFiltersHcmV3.HttpFilter_TypedConfig{TypedConfig: typedRouterFilterConfig},
+		}},
+		RouteSpecifier: &envoyFiltersHcmV3.HttpConnectionManager_RouteConfig{
+			RouteConfig: &envoyRoute.RouteConfiguration{
+				Name: "local_route",
+				VirtualHosts: []*envoyRoute.VirtualHost{{
+					Name:    "stats_service",
+					Domains: []string{"*"},
+					Routes: []*envoyRoute.Route{{
+						Match: &envoyRoute.RouteMatch{
+							PathSpecifier: &envoyRoute.RouteMatch_Path{
+								Path: "/stats/prometheus",
+							},
+							Headers: []*envoyRoute.HeaderMatcher{{
+								Name: ":method",
+								HeaderMatchSpecifier: &envoyRoute.HeaderMatcher_ExactMatch{
+									ExactMatch: "GET",
+								},
+							}},
+						},
+						Action: &envoyRoute.Route_Route{
+							Route: &envoyRoute.RouteAction{
+								ClusterSpecifier: &envoyRoute.RouteAction_Cluster{
+									Cluster: "admin_cluster",
+								},
+							},
+						},
+					}},
+				}},
+			},
+		},
+	}
+
+	typedConfig, err := anypb.New(hcm)
+	if err != nil {
+		panic(err)
+	}
+
+	return &envoyListener.Listener{
+		Name: "stats_listener",
+		Address: &envoyCore.Address{
+			Address: &envoyCore.Address_SocketAddress{
+				SocketAddress: &envoyCore.SocketAddress{
+					Address: "0.0.0.0",
+					PortSpecifier: &envoyCore.SocketAddress_PortValue{
+						PortValue: EnvoyStatsPort,
+					},
+				},
+			},
+		},
+		FilterChains: []*envoyListener.FilterChain{{
+			Filters: []*envoyListener.Filter{{
+				Name:       wellknown.HTTPConnectionManager,
+				ConfigType: &envoyListener.Filter_TypedConfig{TypedConfig: typedConfig},
+			}},
+		}},
+	}
 }

--- a/internal/envoy/server.go
+++ b/internal/envoy/server.go
@@ -51,13 +51,14 @@ func registerServer(grpcServer *grpc.Server, server serverv3.Server) {
 }
 
 type Server struct {
-	Cache         cachev3.SnapshotCache
-	listenAddress string
-	listenPort    uint32
-	enableAdmin   bool
+	Cache                 cachev3.SnapshotCache
+	listenAddress         string
+	listenPort            uint32
+	enableDebug           bool
+	enableEnvoyMonitoring bool
 }
 
-func NewServer(listenAddress string, enableDebug bool) (*Server, error) {
+func NewServer(listenAddress string, enableDebug, enableMonitoring bool) (*Server, error) {
 	portString := strings.Split(listenAddress, ":")[1]
 	port, err := strconv.ParseUint(portString, 10, 32)
 	if err != nil {
@@ -65,10 +66,11 @@ func NewServer(listenAddress string, enableDebug bool) (*Server, error) {
 	}
 
 	return &Server{
-		listenAddress: listenAddress,
-		listenPort:    uint32(port),
-		Cache:         cachev3.NewSnapshotCache(false, cachev3.IDHash{}, Logger{enableDebug}),
-		enableAdmin:   enableDebug,
+		listenAddress:         listenAddress,
+		listenPort:            uint32(port),
+		Cache:                 cachev3.NewSnapshotCache(false, cachev3.IDHash{}, Logger{enableDebug}),
+		enableDebug:           enableDebug,
+		enableEnvoyMonitoring: enableMonitoring,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds probes to the envoy-proxies created by KubeLB and enables monitoring using the metrics already provided by envoy-proxy

This supersedes #144 and #145 as it implements both those features, but in a cleaner way.

Instead of exposing the admin interface and directly access it for metrics/probes, two static listeners are created on dedicated ports, and those listeners are routed to the admin listener for their respective endpoints (making sure to not allow access to the `server_info` and `config_dump` endpoints). This is similar to what other projects like istio or envoy-gateway do.

The thresholds for all probes, are identical to what envoy-gateway uses.

There is also a new flag for the kubelb-manager controller, which toggles the tenant envoy monitoring (called `--enable-tenant-envoy-monitoring`) which is enabled by default, but could still be disabled.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Replaces #144 #145
Improves #56

**What type of PR is this?**
/kind feature
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add startup-, liveness, and readiness probes to tenant envoy-proxy
Enable Prometheus metrics for tenant envoy-proxy
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
