### PR TITLE
Fix name generation to normalize resource names greater than 63 characters

### DIFF
--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -56,15 +56,19 @@ const DefaultRouteStatus = "{}"
 const ServiceKind = "Service"
 const NameSuffixLength = 4
 
+// We limit the name length slightly lower than the kubernetes limit of 63 characters to avoid issues with the name length.
+// In case if the name exceeds the limit, we truncate the name and append a suffix ensuring that it's always less than 63 characters.
+const MaxNameLength = 60
+
 const AnnotationRequestWildcardDomain = "kubelb.k8c.io/request-wildcard-domain"
 
 func GenerateName(appendUID bool, uid, name, namespace string) string {
 	output := fmt.Sprintf("%s-%s", namespace, name)
 	uidSuffix := uid[len(uid)-NameSuffixLength:]
 
-	// If the output is longer than 63 characters, truncate the name and append a suffix
-	if len(output) > 63 || (appendUID && len(output)+len(uidSuffix) > 63) {
-		output = output[:63-NameSuffixLength+1]
+	// If the output is longer than 60 characters, truncate the name and append a suffix
+	if len(output) >= MaxNameLength || (appendUID && (len(output)+len(uidSuffix)+1) >= MaxNameLength) {
+		output = output[:MaxNameLength-(NameSuffixLength+1)]
 		output = fmt.Sprintf("%s-%s", output, uidSuffix)
 	} else if appendUID {
 		output = fmt.Sprintf("%s-%s", output, uidSuffix)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug where resource names, specially for services, were not being truncated properly to avoid 63 character limit from Kubernetes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where resource names, specially for services, were not being truncated properly to avoid 63 character limit from Kubernetes 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
