### PR TITLE
Normalize parentRefs for Gateway API resources

### DIFF
--- a/internal/resources/gatewayapi/gatewayapi.go
+++ b/internal/resources/gatewayapi/gatewayapi.go
@@ -15,3 +15,14 @@ limitations under the License.
 */
 
 package gatewayapi
+
+import (
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func NormalizeParentRefs(parentRefs []gwapiv1.ParentReference) []gwapiv1.ParentReference {
+	for i := range parentRefs {
+		parentRefs[i].Namespace = nil
+	}
+	return parentRefs
+}

--- a/internal/resources/gatewayapi/grpcroute/grpcroute.go
+++ b/internal/resources/gatewayapi/grpcroute/grpcroute.go
@@ -24,6 +24,7 @@ import (
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 	"k8c.io/kubelb/internal/kubelb"
+	gatewayapihelpers "k8c.io/kubelb/internal/resources/gatewayapi"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -90,6 +91,9 @@ func CreateOrUpdateGRPCRoute(ctx context.Context, log logr.Logger, client ctrlcl
 			}
 		}
 	}
+
+	// Normalize Parent References
+	object.Spec.ParentRefs = gatewayapihelpers.NormalizeParentRefs(object.Spec.ParentRefs)
 
 	// Process annotations.
 	object.Annotations = kubelb.PropagateAnnotations(object.Annotations, annotations, kubelbv1alpha1.AnnotatedResourceGRPCRoute)

--- a/internal/resources/gatewayapi/httproute/httproute.go
+++ b/internal/resources/gatewayapi/httproute/httproute.go
@@ -25,6 +25,7 @@ import (
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 	utils "k8c.io/kubelb/internal/controllers"
 	"k8c.io/kubelb/internal/kubelb"
+	gatewayapihelpers "k8c.io/kubelb/internal/resources/gatewayapi"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -92,6 +93,9 @@ func CreateOrUpdateHTTPRoute(ctx context.Context, log logr.Logger, client ctrlcl
 			}
 		}
 	}
+
+	// Normalize Parent References
+	object.Spec.ParentRefs = gatewayapihelpers.NormalizeParentRefs(object.Spec.ParentRefs)
 
 	// Process annotations.
 	object.Annotations = kubelb.PropagateAnnotations(object.Annotations, annotations, kubelbv1alpha1.AnnotatedResourceHTTPRoute)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug in community edition where namespace for parentRefs of Gateway API resources like HTTPRoute was not being removed or normalized. 

P.s. we were already performing this transformation in Enterprise Edition and this was only missing in CE.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #141

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[CE Only] Remove namespace from parentRefs for Gateway API resources
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
