### PR TITLE
[release/v1.1] Fix name generation to normalize resource names greater than 63 characters 

### DIFF
--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -55,6 +55,7 @@ const DefaultRouteStatus = "{}"
 const ServiceKind = "Service"
 
 const NameSuffixLength = 4
+
 // We limit the name length slightly lower than the kubernetes limit of 63 characters to avoid issues with the name length.
 // In case if the name exceeds the limit, we truncate the name and append a suffix ensuring that it's always less than 63 characters.
 const MaxNameLength = 60


### PR DESCRIPTION
This is an manual cherry-pick of #147

/assign ahmedwaleedmalik
/kind bug

```release-note
Fix a bug where resource names, specially for services, were not being truncated properly to avoid 63 character limit from Kubernetes
```