### PR TITLE
Skip nodes that are not ready from upstream address pool

### DIFF
--- a/internal/controllers/ccm/node_controller.go
+++ b/internal/controllers/ccm/node_controller.go
@@ -142,6 +142,18 @@ func (r *KubeLBNodeReconciler) GenerateAddresses(nodes *corev1.NodeList) (*kubel
 func (r *KubeLBNodeReconciler) getEndpoints(nodes *corev1.NodeList) []string {
 	var clusterEndpoints []string
 	for _, node := range nodes.Items {
+		// Only process nodes that are ready and have an IP address.
+		isReady := false
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				isReady = true
+				break
+			}
+		}
+		if !isReady {
+			continue
+		}
+
 		var internalIP string
 		for _, address := range node.Status.Addresses {
 			if address.Type == r.EndpointAddressType {


### PR DESCRIPTION
**What this PR does / why we need it**:
Nodes that are not in the `Ready` state don't serve traffic through the NodePorts and thus just end up being unhealthy upstream endpoints. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip nodes that are not ready from upstream address pool
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
