### PR TITLE
Keep-alives for Envoy Proxy

### DIFF
--- a/charts/kubelb-manager/templates/deployment.yaml
+++ b/charts/kubelb-manager/templates/deployment.yaml
@@ -44,7 +44,6 @@ spec:
             {{ if .Values.kubelb.enableTenantMigration -}}
             - --enable-tenant-migration=true
             {{ end -}}
-            - --enable-tenant-envoy-monitoring={{ .Values.kubelb.enableTenantEnvoyMonitoring }}
             - --debug={{ .Values.kubelb.debug }}
             - --zap-log-level={{ .Values.kubelb.logLevel }}
           env:

--- a/charts/kubelb-manager/values.yaml
+++ b/charts/kubelb-manager/values.yaml
@@ -17,7 +17,6 @@ kubelb:
   skipConfigGeneration: false
   # -- enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start.
   enableGatewayAPI: false
-  enableTenantEnvoyMonitoring: true
   envoyProxy:
     # -- Topology defines the deployment topology for Envoy Proxy. Valid values are: shared and global.
     topology: shared

--- a/cmd/kubelb/main.go
+++ b/cmd/kubelb/main.go
@@ -47,7 +47,6 @@ type options struct {
 	probeAddr                       string
 	kubeconfig                      string
 	enableDebugMode                 bool
-	enableTenantEnvoyMonitoring     bool
 	namespace                       string
 	enableTenantMigrationController bool
 	enableGatewayAPI                bool
@@ -73,7 +72,6 @@ func main() {
 	flag.BoolVar(&opt.enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller kubelb. Enabling this will ensure there is only one active controller kubelb.")
 	flag.BoolVar(&opt.enableDebugMode, "debug", false, "Enables debug mode")
-	flag.BoolVar(&opt.enableTenantEnvoyMonitoring, "enable-tenant-envoy-monitoring", true, "Enables stats listener and cluster in Envoy control-plane for Prometheus scraping")
 	flag.StringVar(&opt.namespace, "namespace", "kubelb", "The namespace where the controller will run.")
 
 	flag.BoolVar(&opt.enableTenantMigrationController, "enable-tenant-migration", true, "Enables a controller that performs automated migration from namespaces to tenants")
@@ -132,7 +130,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	envoyServer, err := envoy.NewServer(opt.envoyListenAddress, opt.enableDebugMode, opt.enableTenantEnvoyMonitoring)
+	envoyServer, err := envoy.NewServer(opt.envoyListenAddress, opt.enableDebugMode)
 	if err != nil {
 		setupLog.Error(err, "unable to create envoy server")
 		os.Exit(1)
@@ -181,14 +179,13 @@ func main() {
 	}
 
 	if err = (&kubelb.EnvoyCPReconciler{
-		Client:                envoyMgr.GetClient(),
-		EnvoyCache:            envoyServer.Cache,
-		EnvoyProxyTopology:    kubelb.EnvoyProxyTopology(conf.GetEnvoyProxyTopology()),
-		PortAllocator:         portAllocator,
-		Namespace:             opt.namespace,
-		EnvoyBootstrap:        envoyServer.GenerateBootstrap(),
-		EnvoyTenantMonitoring: opt.enableTenantEnvoyMonitoring,
-		DisableGatewayAPI:     disableGatewayAPI,
+		Client:             envoyMgr.GetClient(),
+		EnvoyCache:         envoyServer.Cache,
+		EnvoyProxyTopology: kubelb.EnvoyProxyTopology(conf.GetEnvoyProxyTopology()),
+		PortAllocator:      portAllocator,
+		Namespace:          opt.namespace,
+		EnvoyBootstrap:     envoyServer.GenerateBootstrap(),
+		DisableGatewayAPI:  disableGatewayAPI,
 	}).SetupWithManager(ctx, envoyMgr); err != nil {
 		setupLog.Error(err, "unable to create envoy control-plane controller", "controller", "LoadBalancer")
 		os.Exit(1)

--- a/internal/controllers/kubelb/suite_test.go
+++ b/internal/controllers/kubelb/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	sigCtx := ctrl.SetupSignalHandler()
 	ctx, cancel = context.WithCancel(sigCtx)
 
-	envoyServer, err = envoy.NewServer(":8001", true, true)
+	envoyServer, err = envoy.NewServer(":8001", true)
 
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -34,7 +34,6 @@ import (
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -250,10 +249,7 @@ func makeTCPListener(clusterName string, listenerName string, listenerPort uint3
 	tcpProxyAccessLog := &envoyFileAccessLog.FileAccessLog{
 		Path: "/dev/stdout",
 	}
-	tcpProxyAccessLogAny, err := anypb.New(tcpProxyAccessLog)
-	if err != nil {
-		panic(err)
-	}
+	tcpProxyAccessLogAny := marshalAny(tcpProxyAccessLog)
 
 	tcpProxy := &envoyTcpProxy.TcpProxy{
 		StatPrefix: listenerName,
@@ -269,10 +265,7 @@ func makeTCPListener(clusterName string, listenerName string, listenerPort uint3
 			},
 		},
 	}
-	pbst, err := anypb.New(tcpProxy)
-	if err != nil {
-		panic(err)
-	}
+	pbst := marshalAny(tcpProxy)
 
 	return &envoyListener.Listener{
 		Name: listenerName,
@@ -306,10 +299,7 @@ func makeUDPListener(clusterName string, listenerName string, listenerPort uint3
 		},
 	}
 
-	pbst, err := anypb.New(udpProxy)
-	if err != nil {
-		panic(err)
-	}
+	pbst := marshalAny(udpProxy)
 
 	return &envoyListener.Listener{
 		Name: listenerName,

--- a/internal/envoy/server.go
+++ b/internal/envoy/server.go
@@ -51,14 +51,13 @@ func registerServer(grpcServer *grpc.Server, server serverv3.Server) {
 }
 
 type Server struct {
-	Cache                 cachev3.SnapshotCache
-	listenAddress         string
-	listenPort            uint32
-	enableDebug           bool
-	enableEnvoyMonitoring bool
+	Cache         cachev3.SnapshotCache
+	listenAddress string
+	listenPort    uint32
+	enableAdmin   bool
 }
 
-func NewServer(listenAddress string, enableDebug, enableMonitoring bool) (*Server, error) {
+func NewServer(listenAddress string, enableAdmin bool) (*Server, error) {
 	portString := strings.Split(listenAddress, ":")[1]
 	port, err := strconv.ParseUint(portString, 10, 32)
 	if err != nil {
@@ -66,11 +65,10 @@ func NewServer(listenAddress string, enableDebug, enableMonitoring bool) (*Serve
 	}
 
 	return &Server{
-		listenAddress:         listenAddress,
-		listenPort:            uint32(port),
-		Cache:                 cachev3.NewSnapshotCache(false, cachev3.IDHash{}, Logger{enableDebug}),
-		enableDebug:           enableDebug,
-		enableEnvoyMonitoring: enableMonitoring,
+		listenAddress: listenAddress,
+		listenPort:    uint32(port),
+		Cache:         cachev3.NewSnapshotCache(false, cachev3.IDHash{}, Logger{enableAdmin}),
+		enableAdmin:   enableAdmin,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently, we faced an issue where Envoy Proxy for a tenant stopped getting updated routing configuration from Envoy XDS. We observed that this was a side-affect due to an interim drop in connection from Envoy Proxy -> Envoy XDS and EP was unable to recover from it and kept serving the old configuration.

References:
- https://github.com/envoyproxy/envoy/issues/21107
- https://github.com/envoyproxy/go-control-plane/issues/91

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HTTP2 and TCP keep-alives have been configured for Envoy Proxy. This circumvents an issue where a drop in connection from the envoy proxy -> envoy XDS left the envoy proxy in a dead/blocked state.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
