### PR TITLE
Suppress git warnings in Makefile for Docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export CGO_ENABLED=0
 export GOPROXY?=https://proxy.golang.org
 export GO111MODULE=on
 export GOFLAGS?=-mod=readonly -trimpath
-export GIT_TAG ?= $(shell git tag --points-at HEAD | head -n1)
+export GIT_TAG ?= $(shell git tag --points-at HEAD 2>/dev/null | head -n1)
 
 GIT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
@@ -36,7 +36,7 @@ LDFLAGS := -X 'k8c.io/kubelb/internal/version.GitVersion=$(GIT_VERSION)' \
 	-X 'k8c.io/kubelb/internal/version.BuildDate=$(BUILD_DATE)'
 
 IMAGE_TAG = \
-		$(shell echo $$(git rev-parse HEAD && if [[ -n $$(git status --porcelain) ]]; then echo '-dirty'; fi)|tr -d ' ')
+		$(shell echo $$(git rev-parse HEAD 2>/dev/null && if [[ -n $$(git status --porcelain 2>/dev/null) ]]; then echo '-dirty'; fi)|tr -d ' ')
 
 VERSION = $(shell cat VERSION)
 

--- a/charts/kubelb-manager/README.md
+++ b/charts/kubelb-manager/README.md
@@ -25,7 +25,7 @@ helm install kubelb-manager kubelb-manager/ --namespace kubelb -f values.yaml --
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://quay.io/kubermatic/helm-charts | kubelb-addons | v0.1.0 |
+| oci://quay.io/kubermatic/helm-charts | kubelb-addons | v0.2.0 |
 
 ## Values
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Suppress stderr from git commands in Makefile to prevent "fatal: not a git repository" warnings during CI Docker builds.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
