### PR TITLE
Add well-known labels to envoy-proxy deployments created by kubelb

### DIFF
--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -226,6 +226,11 @@ func (r *EnvoyCPReconciler) ensureEnvoyProxy(ctx context.Context, namespace, app
 	objMeta := metav1.ObjectMeta{
 		Name:      fmt.Sprintf(envoyResourcePattern, appName),
 		Namespace: namespace,
+		Labels: map[string]string{
+			kubelb.LabelAppKubernetesName:      "kubelb-envoy-proxy",
+			kubelb.LabelAppKubernetesInstance:  appName,
+			kubelb.LabelAppKubernetesManagedBy: "kubelb",
+		},
 	}
 	if r.Config.Spec.EnvoyProxy.UseDaemonset {
 		envoyProxy = &appsv1.DaemonSet{
@@ -289,7 +294,10 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(namespace, appName, snapshotNam
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: namespace,
-			Labels:    map[string]string{kubelb.LabelAppKubernetesName: appName},
+			Labels: map[string]string{
+				kubelb.LabelAppKubernetesName:      appName,
+				kubelb.LabelAppKubernetesManagedBy: "kubelb",
+			},
 			Annotations: map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/port":   fmt.Sprintf("%d", envoycp.EnvoyStatsPort),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a few [well-known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/) to the envoy-proxy deployments created by KubeLB.

This allows to easily select all KubeLB related deployments using a label-selector, e.g. `kubectl get deployments -l app.kubernetes.io/managed-by=kubelb`

**Which issue(s) this PR fixes**:
No issue created for this.

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:
Not required for 1.2.1 but would be nice to have this in 1.3 or another 1.2.x patch release

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Annotate KubeLB created envoy-proxies with well-known labels.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
