### PR TITLE
[release/v1.1] Retain permitted third-party annotations on resources

### DIFF
--- a/internal/controllers/kubelb/shared.go
+++ b/internal/controllers/kubelb/shared.go
@@ -61,16 +61,18 @@ func GetConfig(ctx context.Context, client ctrlclient.Client, configNamespace st
 
 func GetAnnotations(tenant *kubelbv1alpha1.Tenant, config *kubelbv1alpha1.Config) kubelbv1alpha1.AnnotationSettings {
 	var annotations kubelbv1alpha1.AnnotationSettings
-	if tenant.Spec.AnnotationSettings.PropagateAllAnnotations != nil && *tenant.Spec.AnnotationSettings.PropagateAllAnnotations {
-		annotations.PropagateAllAnnotations = tenant.Spec.AnnotationSettings.PropagateAllAnnotations
-	} else if tenant.Spec.AnnotationSettings.PropagatedAnnotations != nil {
-		annotations.PropagatedAnnotations = tenant.Spec.AnnotationSettings.PropagatedAnnotations
+	if config.Spec.PropagateAllAnnotations != nil && *config.Spec.PropagateAllAnnotations {
+		annotations.PropagateAllAnnotations = config.Spec.PropagateAllAnnotations
+	} else if config.Spec.PropagatedAnnotations != nil {
+		annotations.PropagatedAnnotations = config.Spec.PropagatedAnnotations
 	}
 
-	if config.Spec.AnnotationSettings.PropagateAllAnnotations != nil && *config.Spec.AnnotationSettings.PropagateAllAnnotations {
-		annotations.PropagateAllAnnotations = config.Spec.AnnotationSettings.PropagateAllAnnotations
-	} else if config.Spec.AnnotationSettings.PropagatedAnnotations != nil {
-		annotations.PropagatedAnnotations = config.Spec.AnnotationSettings.PropagatedAnnotations
+	// Tenant configuration has higher precedence than the annotations specified at the Config level.
+	if tenant.Spec.PropagateAllAnnotations != nil && *tenant.Spec.PropagateAllAnnotations {
+		annotations.PropagateAllAnnotations = tenant.Spec.PropagateAllAnnotations
+	} else if tenant.Spec.PropagatedAnnotations != nil {
+		annotations.PropagatedAnnotations = tenant.Spec.PropagatedAnnotations
 	}
+
 	return annotations
 }

--- a/internal/controllers/utils.go
+++ b/internal/controllers/utils.go
@@ -22,7 +22,6 @@ import (
 	"k8c.io/kubelb/internal/kubelb"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,18 +79,4 @@ func workqueueFilter(filter func(o ctrlruntimeclient.Object) bool) predicate.Fun
 			return filter(e.Object)
 		},
 	}
-}
-
-// CompareAnnotations compares two annotation maps while ignoring the last-applied-configuration annotation
-func CompareAnnotations(a, b map[string]string) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-
-	delete(a, corev1.LastAppliedConfigAnnotation)
-	delete(b, corev1.LastAppliedConfigAnnotation)
-	return equality.Semantic.DeepEqual(a, b)
 }

--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -113,7 +113,7 @@ func PropagateAnnotations(loadbalancer map[string]string, annotations kubelbv1al
 	permittedMap := make(map[string][]string)
 	for k, v := range permitted {
 		if _, found := permittedMap[k]; !found {
-			if len(v) == 0 || v == "" {
+			if v == "" {
 				permittedMap[k] = []string{}
 			} else {
 				filterValues := strings.Split(v, ",")

--- a/internal/resources/gatewayapi/gateway/gateway.go
+++ b/internal/resources/gatewayapi/gateway/gateway.go
@@ -24,7 +24,7 @@ import (
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/kubelb.k8c.io/v1alpha1"
 	"k8c.io/kubelb/internal/kubelb"
-	util "k8c.io/kubelb/internal/util/kubernetes"
+	k8sutils "k8c.io/kubelb/internal/util/kubernetes"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,7 +69,7 @@ func CreateOrUpdateGateway(ctx context.Context, log logr.Logger, client ctrlclie
 	for i, listener := range object.Spec.Listeners {
 		if listener.TLS != nil {
 			for j, reference := range listener.TLS.CertificateRefs {
-				secretName := util.GetSecretNameIfExists(ctx, client, string(reference.Name), object.Namespace, namespace)
+				secretName := k8sutils.GetSecretNameIfExists(ctx, client, string(reference.Name), object.Namespace, namespace)
 				if secretName != "" {
 					object.Spec.Listeners[i].TLS.CertificateRefs[j].Name = gwapiv1.ObjectName(secretName)
 				}
@@ -105,10 +105,13 @@ func CreateOrUpdateGateway(ctx context.Context, log logr.Logger, client ctrlclie
 		return nil
 	}
 
+	// Merge the annotations with the existing annotations to allow annotations that are configured by third party controllers on the existing service to be preserved.
+	object.Annotations = k8sutils.MergeAnnotations(existingGateway.Annotations, object.Annotations)
+
 	// Update the Gateway object if it is different from the existing one.
 	if equality.Semantic.DeepEqual(existingGateway.Spec, object.Spec) &&
 		equality.Semantic.DeepEqual(existingGateway.Labels, object.Labels) &&
-		equality.Semantic.DeepEqual(existingGateway.Annotations, object.Annotations) {
+		k8sutils.CompareAnnotations(existingGateway.Annotations, object.Annotations) {
 		return nil
 	}
 

--- a/internal/resources/gatewayapi/grpcroute/grpcroute.go
+++ b/internal/resources/gatewayapi/grpcroute/grpcroute.go
@@ -25,6 +25,7 @@ import (
 	kubelbv1alpha1 "k8c.io/kubelb/api/kubelb.k8c.io/v1alpha1"
 	"k8c.io/kubelb/internal/kubelb"
 	gatewayapihelpers "k8c.io/kubelb/internal/resources/gatewayapi"
+	k8sutils "k8c.io/kubelb/internal/util/kubernetes"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -120,10 +121,13 @@ func CreateOrUpdateGRPCRoute(ctx context.Context, log logr.Logger, client ctrlcl
 		return nil
 	}
 
+	// Merge the annotations with the existing annotations to allow annotations that are configured by third party controllers on the existing service to be preserved.
+	object.Annotations = k8sutils.MergeAnnotations(existingObject.Annotations, object.Annotations)
+
 	// Update the Ingress object if it is different from the existing one.
 	if equality.Semantic.DeepEqual(existingObject.Spec, object.Spec) &&
 		equality.Semantic.DeepEqual(existingObject.Labels, object.Labels) &&
-		equality.Semantic.DeepEqual(existingObject.Annotations, object.Annotations) {
+		k8sutils.CompareAnnotations(existingObject.Annotations, object.Annotations) {
 		return nil
 	}
 

--- a/internal/resources/gatewayapi/httproute/httproute.go
+++ b/internal/resources/gatewayapi/httproute/httproute.go
@@ -25,6 +25,7 @@ import (
 	kubelbv1alpha1 "k8c.io/kubelb/api/kubelb.k8c.io/v1alpha1"
 	"k8c.io/kubelb/internal/kubelb"
 	gatewayapihelpers "k8c.io/kubelb/internal/resources/gatewayapi"
+	k8sutils "k8c.io/kubelb/internal/util/kubernetes"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -120,10 +121,13 @@ func CreateOrUpdateHTTPRoute(ctx context.Context, log logr.Logger, client ctrlcl
 		return nil
 	}
 
+	// Merge the annotations with the existing annotations to allow annotations that are configured by third party controllers on the existing service to be preserved.
+	object.Annotations = k8sutils.MergeAnnotations(existingObject.Annotations, object.Annotations)
+
 	// Update the Ingress object if it is different from the existing one.
 	if equality.Semantic.DeepEqual(existingObject.Spec, object.Spec) &&
 		equality.Semantic.DeepEqual(existingObject.Labels, object.Labels) &&
-		equality.Semantic.DeepEqual(existingObject.Annotations, object.Annotations) {
+		k8sutils.CompareAnnotations(existingObject.Annotations, object.Annotations) {
 		return nil
 	}
 

--- a/internal/util/kubernetes/secret.go
+++ b/internal/util/kubernetes/secret.go
@@ -19,15 +19,18 @@ package kubernetes
 import (
 	"context"
 
-	"k8c.io/kubelb/internal/kubelb"
-
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	labelOriginName      = "kubelb.k8c.io/origin-name"
+	labelOriginNamespace = "kubelb.k8c.io/origin-ns"
+)
+
 func GetSecretNameIfExists(ctx context.Context, client ctrlclient.Client, name, namespace string, tenantNamespace string) string {
 	secrets := corev1.SecretList{}
-	err := client.List(ctx, &secrets, ctrlclient.InNamespace(tenantNamespace), ctrlclient.MatchingLabels{kubelb.LabelOriginName: name, kubelb.LabelOriginNamespace: namespace})
+	err := client.List(ctx, &secrets, ctrlclient.InNamespace(tenantNamespace), ctrlclient.MatchingLabels{labelOriginName: name, labelOriginNamespace: namespace})
 	if err != nil {
 		return ""
 	}

--- a/internal/util/kubernetes/util.go
+++ b/internal/util/kubernetes/util.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// CompareAnnotations compares two annotation maps while ignoring the last-applied-configuration annotation
+func CompareAnnotations(a, b map[string]string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	// Early check to avoid creating copies of the maps.
+	if equality.Semantic.DeepEqual(a, b) {
+		return true
+	}
+
+	// Create copies to avoid mutating the original maps.
+	aCopy := make(map[string]string)
+	bCopy := make(map[string]string)
+	maps.Copy(aCopy, a)
+	maps.Copy(bCopy, b)
+	delete(aCopy, corev1.LastAppliedConfigAnnotation)
+	delete(bCopy, corev1.LastAppliedConfigAnnotation)
+	return equality.Semantic.DeepEqual(aCopy, bCopy)
+}
+
+func MergeAnnotations(existing, desired map[string]string) map[string]string {
+	// First, check if both are equal. If they are, return the existing annotations.
+	if CompareAnnotations(existing, desired) {
+		return existing
+	}
+
+	// Merge desired annotations with the existing annotations.
+	// While creating native resources against the KubeLB CRs, we don't care about the annotation settings and would like to retain all the annotations
+	// configured by third party controllers on the existing resource.
+	maps.Copy(existing, desired)
+	return desired
+}


### PR DESCRIPTION
This is an manual cherry-pick of #170

/assign ahmedwaleedmalik

```release-note
KubeLB will retain annotations on generated/propagated resources like service, Ingress, Gateway API objects if they were added either manually or by an external controllers.
```