### PR TITLE
Allow overriding kube-rbac-proxy image via Helm Values

### DIFF
--- a/charts/kubelb-ccm/templates/deployment.yaml
+++ b/charts/kubelb-ccm/templates/deployment.yaml
@@ -109,8 +109,8 @@ spec:
             {{- toYaml . | nindent 8 }}
           {{- end }}
         - name: kube-rbac-proxy
-          image: quay.io/brancz/kube-rbac-proxy:v0.20.1
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.kubeRbacProxy.image.pullPolicy }}
           args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:{{ .Values.metrics.port }}/

--- a/charts/kubelb-ccm/values.yaml
+++ b/charts/kubelb-ccm/values.yaml
@@ -4,6 +4,13 @@ image:
   repository: quay.io/kubermatic/kubelb-ccm
   pullPolicy: IfNotPresent
   tag: v1.2.0
+
+kubeRbacProxy:
+  image:
+    repository: quay.io/brancz/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: v0.20.1
+
 imagePullSecrets: []
 
 kubelb:

--- a/charts/kubelb-manager/templates/deployment.yaml
+++ b/charts/kubelb-manager/templates/deployment.yaml
@@ -81,8 +81,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: kube-rbac-proxy
-          image: quay.io/brancz/kube-rbac-proxy:v0.20.1
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.kubeRbacProxy.image.pullPolicy }}
           args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:{{ .Values.metrics.port }}/

--- a/charts/kubelb-manager/values.yaml
+++ b/charts/kubelb-manager/values.yaml
@@ -4,6 +4,13 @@ image:
   repository: quay.io/kubermatic/kubelb-manager
   pullPolicy: IfNotPresent
   tag: v1.2.0
+
+kubeRbacProxy:
+  image:
+    repository: quay.io/brancz/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: v0.20.1
+
 imagePullSecrets: []
 
 kubelb:


### PR DESCRIPTION
**What this PR does / why we need it**:
Making kube-rbac-proxy image configurable in Helm charts. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow overriding kube-rbac-proxy image via Helm Values
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
