### PR TITLE
Pick local version for addons chart in e2e tests

### DIFF
--- a/hack/e2e/deploy.sh
+++ b/hack/e2e/deploy.sh
@@ -247,6 +247,13 @@ EOF
     "${temp_chart_dir}/kubelb-manager/Chart.yaml"
   rm -f "${temp_chart_dir}/kubelb-manager/Chart.yaml.bak"
 
+  # Patch dependency version to match local addons chart version
+  local addons_version
+  addons_version=$(grep '^version:' "${temp_chart_dir}/kubelb-addons/Chart.yaml" | awk '{print $2}')
+  sed -i.bak "/name: kubelb-addons/,/version:/{s|version: .*|version: ${addons_version}|}" \
+    "${temp_chart_dir}/kubelb-manager/Chart.yaml"
+  rm -f "${temp_chart_dir}/kubelb-manager/Chart.yaml.bak"
+
   # Update helm dependencies (skip if unchanged)
   local chart_hash
   chart_hash=$(sha256sum "${CHARTS_DIR}/kubelb-manager/Chart.yaml" "${CHARTS_DIR}/kubelb-addons/Chart.yaml" 2> /dev/null | sha256sum | cut -c1-8)


### PR DESCRIPTION
**What this PR does / why we need it**:
E2E tests deploy `addons` chart from source instead of from quay repository. This ensures that with each e2e run in CI we are also testing our addons.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
