### PR TITLE
Addons v0.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ RECONCILE_HELPER_PATH = "internal/resources/reconciling/zz_generated_reconcile.g
 
 GATEWAY_RELEASE_CHANNEL ?= standard
 GATEWAY_API_VERSION ?= v1.4.1
-KUBELB_ADDONS_CHART_VERSION ?= v0.3.0
+KUBELB_ADDONS_CHART_VERSION ?= v0.3.1
 
 export GOPATH?=$(shell go env GOPATH)
 export CGO_ENABLED=0

--- a/charts/kubelb-addons/Chart.lock
+++ b/charts/kubelb-addons/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.14.1
+  version: 4.14.3
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: 1.6.2
+  version: 1.6.3
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.19.2
+  version: v1.19.3
 - name: external-dns
   repository: https://kubernetes-sigs.github.io/external-dns
   version: 1.20.0
@@ -20,5 +20,5 @@ dependencies:
 - name: kgateway
   repository: oci://cr.kgateway.dev/kgateway-dev/charts
   version: v2.1.2
-digest: sha256:689b3b2a24ab0263b918af3504df02e2b1e01b1cf76d783e32699de157ed2464
-generated: "2026-01-26T12:42:59.900961+05:00"
+digest: sha256:cfb89d8ef31b942c52f695696bb05d1e0c606ef33a110e43d3403328b4cac85d
+generated: "2026-02-03T11:20:56.317805+05:00"

--- a/charts/kubelb-addons/Chart.yaml
+++ b/charts/kubelb-addons/Chart.yaml
@@ -7,22 +7,22 @@ maintainers:
   - name: Kubermatic
     email: support@kubermatic.com
     url: https://kubermatic.com
-version: v0.3.0
-appVersion: v0.3.0
+version: v0.3.1
+appVersion: v0.3.1
 dependencies:
   - name: ingress-nginx
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
-    version: 4.14.1
+    version: 4.14.3
   - name: gateway-helm
     repository: oci://docker.io/envoyproxy
     condition: envoy-gateway.enabled
-    version: 1.6.2
+    version: 1.6.3
     alias: envoy-gateway
   - name: cert-manager
     repository: https://charts.jetstack.io
     condition: cert-manager.enabled
-    version: 1.19.2
+    version: 1.19.3
   - name: external-dns
     repository: https://kubernetes-sigs.github.io/external-dns
     condition: external-dns.enabled

--- a/charts/kubelb-manager/Chart.lock
+++ b/charts/kubelb-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-  - name: kubelb-addons
-    repository: oci://quay.io/kubermatic/helm-charts
-    version: v0.3.0
-digest: sha256:ac13bd59459796b112cbb348ae59dd91c7fa469ac5b0f8bd78f70f3510b3d527
-generated: "2025-11-10T12:24:37.381234+05:00"
+- name: kubelb-addons
+  repository: oci://quay.io/kubermatic/helm-charts
+  version: v0.3.0
+digest: sha256:78e3be56a6094c92fea102f549b782858ccdd3648cb158113f9b4716051c7303
+generated: "2026-02-03T11:20:45.077259+05:00"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kubelb-addons chart to v0.3.1 with dependency bumps: 
- ingress-nginx 4.14.3
- envoy-gateway 1.6.3
- cert-manager v1.19.3 
   
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated kubelb-addons chart to v0.3.1 with dependency bumps: 

#### ingress-nginx 4.14.1 → 4.14.3
- [CVE-2026-1580](https://github.com/kubernetes/kubernetes/issues/136677) - auth-method nginx configuration injection
- [CVE-2026-24512](https://github.com/kubernetes/kubernetes/issues/136678) - rules.http.paths.path nginx configuration injection
- [CVE-2026-24513](https://github.com/kubernetes/kubernetes/issues/136679) - auth-url protection bypass
- [CVE-2026-24514](https://github.com/kubernetes/kubernetes/issues/136680) - Admission Controller denial of service

#### envoy-gateway 1.6.2 → 1.6.3
- [CVE-2025-0913](https://nvd.nist.gov/vuln/detail/CVE-2025-0913) - Use-after-free in c-ares DNS resolver

#### cert-manager v1.19.2 → v1.19.3
- [GHSA-gx3x-vq4p-mhhv](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-gx3x-vq4p-mhhv) - DoS via malformed DNS response

### References
- [Envoy Gateway v1.6.3 Release](https://gateway.envoyproxy.io/news/releases/notes/v1.6.3/)
- [cert-manager v1.19.3 Release](https://github.com/cert-manager/cert-manager/releases/tag/v1.19.3)
- [ingress-nginx v1.14.3 Release](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.14.3)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
