### PR TITLE
Disable github actions for v1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ env:
 
 jobs:
   release:
-    if: ${{ !startsWith(github.ref_name, 'addons-') && inputs.release_type != 'addons' }}
+    if: ${{ !startsWith(github.ref_name, 'addons-') && inputs.release_type != 'addons' && !startsWith(github.ref, 'refs/tags/v1.2') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed for GoReleaser to create releases
@@ -223,7 +223,7 @@ jobs:
           oras logout ${{ env.REGISTRY }} || true
 
   helm:
-    if: ${{ !startsWith(github.ref_name, 'addons-') && inputs.release_type != 'addons' }}
+    if: ${{ !startsWith(github.ref_name, 'addons-') && inputs.release_type != 'addons' && !startsWith(github.ref, 'refs/tags/v1.2') }}
     needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
**What this PR does / why we need it**:
`release/v1.2` use prow jobs and GitHub actions are from v1.3 onwards.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
