### PR TITLE
Improve go cache handling

### DIFF
--- a/hack/ci/upload-gocache.sh
+++ b/hack/ci/upload-gocache.sh
@@ -33,8 +33,8 @@ if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
   exit 1
 fi
 
-# The gocache needs a matching go version to work, so append that to the name
-GO_VERSION="$(go version | awk '{ print $3 }' | sed 's/go//g')"
+# Use major.minor Go version for cache key so patch bumps don't invalidate caches
+GO_VERSION="$(go version | awk '{ print $3 }' | sed 's/go//g' | cut -d. -f1,2)"
 GOARCH="$(go env GOARCH)"
 
 GOCACHE_DIR="$(mktemp -d)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves CI go cache scripts:

1. **Cache key uses major.minor Go version** — patch bumps no longer invalidate caches
2. **Download walks up to 5 parent commits** instead of just 1 to find a usable cache (handles failed/delayed uploads after merges)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
