### PR TITLE
Add explicit namespace to all namespaced scoped resources in helm charts

### DIFF
--- a/charts/kubelb-ccm/templates/deployment.yaml
+++ b/charts/kubelb-ccm/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubelb-ccm.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubelb-ccm.labels" . | nindent 4 }}
 spec:

--- a/charts/kubelb-ccm/templates/hpa.yaml
+++ b/charts/kubelb-ccm/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kubelb-ccm.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubelb-ccm.labels" . | nindent 4 }}
 spec:

--- a/charts/kubelb-ccm/templates/serviceaccount.yaml
+++ b/charts/kubelb-ccm/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubelb-ccm.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubelb-ccm.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/kubelb-manager/templates/config.yaml
+++ b/charts/kubelb-manager/templates/config.yaml
@@ -3,6 +3,7 @@ apiVersion: kubelb.k8c.io/v1alpha1
 kind: Config
 metadata:
   name: default
+  namespace: {{ .Release.Namespace }}
 spec:
   envoyProxy:
     replicas: {{ .Values.kubelb.envoyProxy.replicas }}

--- a/charts/kubelb-manager/templates/deployment.yaml
+++ b/charts/kubelb-manager/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubelb-manager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubelb-manager.labels" . | nindent 4 }}
 spec:

--- a/charts/kubelb-manager/templates/hpa.yaml
+++ b/charts/kubelb-manager/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kubelb-manager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubelb-manager.labels" . | nindent 4 }}
 spec:

--- a/charts/kubelb-manager/templates/serviceaccount.yaml
+++ b/charts/kubelb-manager/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubelb-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubelb-manager.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add explicit `namespace: {{ .Release.Namespace }}` to all namespaced resources in kubelb-manager and kubelb-ccm chart templates that were missing it. This fixes `helm template` output for tools like Kustomize and ArgoCD that can't infer namespace from cluster state. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #288

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add explicit namespace to all namespaced scoped resources in helm charts
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
