### PR TITLE
Add CCM binaries to release artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,11 +71,28 @@ gomod:
   proxy: false
 
 archives:
-  - id: binaries
+  - id: kubelb-archive
+    builds:
+      - kubelb
     formats:
       - tar.gz
     name_template: >-
-      {{ .ProjectName }}_
+      kubelb_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+    files:
+      - LICENSE*
+      - README*
+      - SBOM.md
+
+  - id: ccm-archive
+    builds:
+      - ccm
+    formats:
+      - tar.gz
+    name_template: >-
+      ccm_
       {{- .Version }}_
       {{- .Os }}_
       {{- .Arch }}


### PR DESCRIPTION
**What this PR does / why we need it**:
The single archive definition in `.goreleaser.yaml` used `{{ .ProjectName }}` (= `kubelb`) as the name template and had no `builds` filter. Both kubelb and CCM binaries were packaged into archives named `kubelb_*`, so CCM tarballs (`ccm_*_linux_{amd64,arm64}.tar.gz`) were missing from releases.

Fix: split into two archives filtered by build ID with explicit name templates.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

```documentation
NONE
```
