### PR TITLE
Move workflow permissions to job-level for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,13 +10,14 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pull-requests: write
-  security-events: write
+permissions: {}
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,6 +36,9 @@ jobs:
 
   scan-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -82,6 +85,8 @@ jobs:
 
   scan-summary:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     needs: scan-images
     if: failure()
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,10 @@ Three charts in `charts/`:
 
 Run `make generate-helm-docs` after chart changes.
 
+## GitHub Templates
+
+PRs and issues must use the templates in `.github/`. For PRs, use `.github/PULL_REQUEST_TEMPLATE.md` — fill in all sections (description, kind, release note, documentation).
+
 ## Documentation
 
 Official documentation for KubeLB is available at <https://docs.kubermatic.com/kubelb>. Please refer to this documentation for the latest information about the project. If and when you find gaps in the documentation, please prompt the user to update the documentation.


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves top-level `permissions` to per-job declarations in `pr.yml` and `codeql-analysis.yml`. Sets top-level to `permissions: {}` (least privilege). 

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```