### PR TITLE
Fix envoy proxy readiness probe failures under stats scrape contention

### DIFF
--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -374,6 +374,11 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(namespace, appName, snapshotNam
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{
+				Name:          "healthcheck",
+				ContainerPort: envoycp.EnvoyHealthCheckPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+			{
 				Name:          "metrics",
 				ContainerPort: envoycp.EnvoyStatsPort,
 				Protocol:      corev1.ProtocolTCP,
@@ -395,8 +400,8 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(namespace, appName, snapshotNam
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   envoycp.EnvoyReadinessPath,
-					Port:   intstr.IntOrString{Type: intstr.Int, IntVal: envoycp.EnvoyReadinessPort},
+					Path:   envoycp.EnvoyHealthCheckPath,
+					Port:   intstr.IntOrString{Type: intstr.Int, IntVal: envoycp.EnvoyHealthCheckPort},
 					Scheme: corev1.URISchemeHTTP,
 				},
 			},
@@ -408,8 +413,8 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(namespace, appName, snapshotNam
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   envoycp.EnvoyReadinessPath,
-					Port:   intstr.IntOrString{Type: intstr.Int, IntVal: envoycp.EnvoyReadinessPort},
+					Path:   envoycp.EnvoyHealthCheckPath,
+					Port:   intstr.IntOrString{Type: intstr.Int, IntVal: envoycp.EnvoyHealthCheckPort},
 					Scheme: corev1.URISchemeHTTP,
 				},
 			},

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	envoyListener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoyConfigOverloadV3 "github.com/envoyproxy/go-control-plane/envoy/config/overload/v3"
 	envoyRoute "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoyFiltersHealthCheckV3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	envoyFiltersRouterV3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	envoyFiltersHcmV3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoyDownstreamConnections "github.com/envoyproxy/go-control-plane/envoy/extensions/resource_monitors/downstream_connections/v3"
@@ -50,6 +51,9 @@ const EnvoyStatsPath = "/stats/prometheus"
 
 const EnvoyReadinessPort = 19003
 const EnvoyReadinessPath = "/ready"
+
+const EnvoyHealthCheckPort = 19004
+const EnvoyHealthCheckPath = "/healthz"
 
 // Shutdown manager constants
 const ShutdownManagerPort = 19002
@@ -140,6 +144,7 @@ func (s *Server) GenerateBootstrap() string {
 		StaticResources: &envoyBootstrap.Bootstrap_StaticResources{
 			Listeners: []*envoyListener.Listener{
 				getReadinessProbeListener(),
+				getHealthCheckListener(),
 				getStatsListener(),
 			},
 			Clusters: []*envoyCluster.Cluster{
@@ -306,6 +311,76 @@ func getReadinessProbeListener() *envoyListener.Listener {
 					Address: "0.0.0.0",
 					PortSpecifier: &envoyCore.SocketAddress_PortValue{
 						PortValue: EnvoyReadinessPort,
+					},
+				},
+			},
+		},
+		FilterChains: []*envoyListener.FilterChain{{
+			Filters: []*envoyListener.Filter{{
+				Name:       wellknown.HTTPConnectionManager,
+				ConfigType: &envoyListener.Filter_TypedConfig{TypedConfig: typedConfig},
+			}},
+		}},
+	}
+}
+
+func getHealthCheckListener() *envoyListener.Listener {
+	healthCheckFilter := marshalAny(&envoyFiltersHealthCheckV3.HealthCheck{
+		PassThroughMode: &wrapperspb.BoolValue{Value: false},
+		Headers: []*envoyRoute.HeaderMatcher{{
+			Name: ":path",
+			HeaderMatchSpecifier: &envoyRoute.HeaderMatcher_ExactMatch{
+				ExactMatch: EnvoyHealthCheckPath,
+			},
+		}},
+	})
+	typedRouterFilterConfig := marshalAny(&envoyFiltersRouterV3.Router{})
+
+	hcm := &envoyFiltersHcmV3.HttpConnectionManager{
+		StatPrefix: "health_check",
+		HttpFilters: []*envoyFiltersHcmV3.HttpFilter{
+			{
+				Name:       wellknown.HealthCheck,
+				ConfigType: &envoyFiltersHcmV3.HttpFilter_TypedConfig{TypedConfig: healthCheckFilter},
+			},
+			{
+				Name:       wellknown.Router,
+				ConfigType: &envoyFiltersHcmV3.HttpFilter_TypedConfig{TypedConfig: typedRouterFilterConfig},
+			},
+		},
+		RouteSpecifier: &envoyFiltersHcmV3.HttpConnectionManager_RouteConfig{
+			RouteConfig: &envoyRoute.RouteConfiguration{
+				Name: "local_health_check",
+				VirtualHosts: []*envoyRoute.VirtualHost{{
+					Name:    "health_check_service",
+					Domains: []string{"*"},
+					Routes: []*envoyRoute.Route{{
+						Match: &envoyRoute.RouteMatch{
+							PathSpecifier: &envoyRoute.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						Action: &envoyRoute.Route_DirectResponse{
+							DirectResponse: &envoyRoute.DirectResponseAction{
+								Status: 404,
+							},
+						},
+					}},
+				}},
+			},
+		},
+	}
+
+	typedConfig := marshalAny(hcm)
+
+	return &envoyListener.Listener{
+		Name: "health_check_listener",
+		Address: &envoyCore.Address{
+			Address: &envoyCore.Address_SocketAddress{
+				SocketAddress: &envoyCore.SocketAddress{
+					Address: "0.0.0.0",
+					PortSpecifier: &envoyCore.SocketAddress_PortValue{
+						PortValue: EnvoyHealthCheckPort,
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Here is a summary for the changes:
- Readiness/liveness probes on port 19003 proxy to `admin_cluster` → envoy main thread. Concurrent `/stats/prometheus` scrapes block main thread, causing probe latency to spike 50-100x. At a high scale (100+ LBs / 1000+ endpoints), this exceeds probe timeout → pod restarts ~1/min.
- Add `envoy.filters.http.health_check` listener on port 19004 (`/healthz`) that responds on worker threads, bypassing main thread entirely. Move readiness/liveness probes to 19004, keep startup probe on 19003 for initial xDS validation.

We ran some tests in our e2e infra to reproduce the latency issue which causes the probes to fail in #289

| Test | Avg | Max |
|---|---|---|
| baseline-19003 (no contention) | 1.8ms | 4.5ms |
| contention-19003 (before fix) | 54.6ms | 93.5ms |
| **contention-19004 (after fix)** | **0.5ms** | **1.2ms** |

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #289

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix envoy proxy readiness probe failures under stats scrape contention at scale
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```