### PR TITLE
Separate EDS from CDS in xDS snapshots

### DIFF
--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -75,6 +75,7 @@ const (
 func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route, portAllocator *portlookup.PortAllocator) (*envoycache.Snapshot, error) {
 	var listener []types.Resource
 	var cluster []types.Resource
+	var endpoints []types.Resource
 
 	addressesMap := make(map[string][]kubelbv1alpha1.EndpointAddress)
 	for _, lb := range loadBalancers {
@@ -122,6 +123,7 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 					listener = append(listener, makeUDPListener(key, key, port))
 				}
 				proxyProtocol := lbEndpointPort.Protocol == corev1.ProtocolTCP && lb.Annotations[kubelb.AnnotationProxyProtocol] == "v2"
+				endpoints = append(endpoints, makeClusterLoadAssignment(key, lbEndpoints))
 				cluster = append(cluster, makeCluster(key, lbEndpointPort.Protocol, "", proxyProtocol))
 			}
 		}
@@ -184,6 +186,7 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 				case corev1.ProtocolUDP:
 					listener = append(listener, makeUDPListener(key, key, listenerPort))
 				}
+				endpoints = append(endpoints, makeClusterLoadAssignment(key, lbEndpoints))
 				cluster = append(cluster, makeCluster(key, port.Protocol, routeKind, false))
 			}
 		}
@@ -193,6 +196,7 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 	var resources []types.Resource
 	resources = append(resources, cluster...)
 	resources = append(resources, listener...)
+	resources = append(resources, endpoints...)
 	for _, r := range resources {
 		mr, err := envoycache.MarshalResource(r)
 		if err != nil {
@@ -207,6 +211,7 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 		map[resource.Type][]types.Resource{
 			resource.ClusterType:  cluster,
 			resource.ListenerType: listener,
+			resource.EndpointType: endpoints,
 		},
 	)
 }

--- a/internal/envoy/resource_test.go
+++ b/internal/envoy/resource_test.go
@@ -19,18 +19,10 @@ package envoy
 import (
 	"testing"
 
-	envoyEndpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-
-	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestMakeCluster_ProxyProtocol(t *testing.T) {
-	endpoints := []*envoyEndpoint.LbEndpoint{
-		makeEndpoint(kubelbv1alpha1.EndpointAddress{IP: "10.0.0.1"}, 8080),
-	}
-
 	tests := []struct {
 		name          string
 		proxyProtocol bool
@@ -50,7 +42,7 @@ func TestMakeCluster_ProxyProtocol(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cluster := makeCluster("test-cluster", endpoints, corev1.ProtocolTCP, "", tt.proxyProtocol)
+			cluster := makeCluster("test-cluster", corev1.ProtocolTCP, "", tt.proxyProtocol)
 
 			if tt.wantTransport && cluster.TransportSocket == nil {
 				t.Error("expected TransportSocket to be set for proxy protocol v2")


### PR DESCRIPTION
**What this PR does / why we need it**:
Switches xDS cluster configuration from inline `LoadAssignment` (STRICT_DNS) to EDS discovery (`Cluster_EDS`). Endpoint resources now have separate entries in the snapshot under `EndpointType`.

With this, for endpoint or node IP changes in the tenant clusters, we don't have to trigger a full re-send to all the clusters and listeners, but only the affected `ClusterLoadAssignment` resources.

At scale, this significantly reduces xDS payload size on endpoint churn.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Separate EDS from CDS in xDS snapshots to reduce payload size on endpoint changes
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```