### PR TITLE
Pin Trivy install script to commit SHA for supply chain security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,8 +135,9 @@ jobs:
 
       - name: Install Trivy
         if: ${{ !inputs.skip_vulnerability_scans }}
+        # v0.69.2
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/refs/tags/v0.69.2/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.2
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/cfa322ed23f2e33ef1632ae3a5a8c7172f06a5c3/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.2
 
       - name: Scan images for vulnerabilities
         if: ${{ !inputs.skip_vulnerability_scans }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Pins the Trivy install script URL in the release workflow to a commit SHA instead of a mutable tag ref. 

**Which issue(s) this PR fixes**:


**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```