### PR TITLE
Add e2e tests for metrics endpoint scraping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ Run `make generate-helm-docs` after chart changes.
 
 PRs and issues must use the templates in `.github/`. For PRs, use `.github/PULL_REQUEST_TEMPLATE.md` — fill in all sections (description, kind, release note, documentation).
 
+When I ask for PR description always use the template and fill in appropriate sections.
+
 ## Documentation
 
 Official documentation for KubeLB is available at <https://docs.kubermatic.com/kubelb>. Please refer to this documentation for the latest information about the project. If and when you find gaps in the documentation, please prompt the user to update the documentation.

--- a/test/e2e/tests/features/metrics/ccm/chainsaw-test.yaml
+++ b/test/e2e/tests/features/metrics/ccm/chainsaw-test.yaml
@@ -1,0 +1,64 @@
+# Copyright 2026 The KubeLB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ccm-metrics
+  labels:
+    all:
+    feature: metrics
+    resource: metrics
+    test: ccm-metrics
+spec:
+  description: Verify KubeLB CCM metrics endpoint is scrapable and exposes expected metrics.
+  steps:
+    - name: scrape-ccm-metrics
+      cluster: tenant1
+      try:
+        - script:
+            skipCommandOutput: true
+            timeout: 60s
+            content: |
+              set -e
+              NAMESPACE=kubelb
+              POD=$(kubectl get pod -n "$NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+                | grep -E '^kubelb-ccm-' | head -1)
+              if [ -z "$POD" ]; then
+                echo "FAILED: Could not find CCM pod"
+                exit 1
+              fi
+              POD_IP=$(kubectl get pod -n "$NAMESPACE" "$POD" -o jsonpath='{.status.podIP}')
+              if [ -z "$POD_IP" ]; then
+                echo "FAILED: Could not find CCM pod IP"
+                exit 1
+              fi
+
+              METRICS=$(kubectl run metrics-probe-ccm --image=busybox:1.36 --rm -i --restart=Never \
+                -n "$NAMESPACE" -- wget -qO- "http://${POD_IP}:9445/metrics" 2>/dev/null)
+              if [ -z "$METRICS" ]; then
+                echo "FAILED: No metrics returned"
+                exit 1
+              fi
+
+              echo "$METRICS" | grep -q "kubelb_ccm_managed_services"
+              echo "$METRICS" | grep -q "kubelb_ccm_kubelb_cluster_connected"
+
+              echo "SUCCESS: All expected CCM metrics found"
+            check:
+              ($error == null): true
+      finally:
+        - script:
+            content: |
+              kubectl delete pod metrics-probe-ccm -n kubelb --ignore-not-found=true 2>/dev/null || true

--- a/test/e2e/tests/features/metrics/manager/chainsaw-test.yaml
+++ b/test/e2e/tests/features/metrics/manager/chainsaw-test.yaml
@@ -1,0 +1,65 @@
+# Copyright 2026 The KubeLB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: manager-metrics
+  labels:
+    all:
+    feature: metrics
+    resource: metrics
+    test: manager-metrics
+spec:
+  description: Verify KubeLB manager metrics endpoint is scrapable and exposes expected metrics.
+  steps:
+    - name: scrape-manager-metrics
+      cluster: kubelb
+      try:
+        - script:
+            skipCommandOutput: true
+            timeout: 60s
+            content: |
+              set -e
+              NAMESPACE=kubelb
+              POD=$(kubectl get pod -n "$NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+                | grep -E '^kubelb-[a-f0-9]' | head -1)
+              if [ -z "$POD" ]; then
+                echo "FAILED: Could not find manager pod"
+                exit 1
+              fi
+              POD_IP=$(kubectl get pod -n "$NAMESPACE" "$POD" -o jsonpath='{.status.podIP}')
+              if [ -z "$POD_IP" ]; then
+                echo "FAILED: Could not find manager pod IP"
+                exit 1
+              fi
+
+              METRICS=$(kubectl run metrics-probe-manager --image=busybox:1.36 --rm -i --restart=Never \
+                -n "$NAMESPACE" -- wget -qO- "http://${POD_IP}:9443/metrics" 2>/dev/null)
+              if [ -z "$METRICS" ]; then
+                echo "FAILED: No metrics returned"
+                exit 1
+              fi
+
+              echo "$METRICS" | grep -q "kubelb_manager_loadbalancers"
+              echo "$METRICS" | grep -q "kubelb_manager_routes"
+              echo "$METRICS" | grep -q "kubelb_manager_envoycp_snapshot_updates_total"
+
+              echo "SUCCESS: All expected manager metrics found"
+            check:
+              ($error == null): true
+      finally:
+        - script:
+            content: |
+              kubectl delete pod metrics-probe-manager -n kubelb --ignore-not-found=true 2>/dev/null || true


### PR DESCRIPTION
**What this PR does / why we need it**:
Add e2e chainsaw tests verifying metrics endpoints are scrapable for both manager and CCM.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```