### PR TITLE
Make Config optional for manager startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ test/e2e/reports/*
 .claude
 prd.md
 claude-plan.md
+ai/
+pr-reviews/

--- a/charts/kubelb-manager/README.md
+++ b/charts/kubelb-manager/README.md
@@ -86,7 +86,7 @@ cosign verify quay.io/kubermatic/kubelb-manager:v1.3.5 \
 | kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
 | kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the LB resource to the LB service. |
 | kubelb.propagatedAnnotations | object | `{}` | Allowed annotations that will be propagated from the LB resource to the LB service. |
-| kubelb.skipConfigGeneration | bool | `false` | Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually. |
+| kubelb.skipConfigGeneration | bool | `true` | Set to false to enable the generation of the Config CR. Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually. |
 | metrics.port | int | `9443` | Port where the manager exposes metrics (includes both manager and envoycp metrics) |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/kubelb-manager/values.yaml
+++ b/charts/kubelb-manager/values.yaml
@@ -18,8 +18,8 @@ kubelb:
   debug: true
   # -- To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity.
   logLevel: info
-  # -- Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually.
-  skipConfigGeneration: false
+  # -- Set to false to enable the generation of the Config CR. Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually.
+  skipConfigGeneration: true
   # -- enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start.
   enableGatewayAPI: false
   envoyProxy:

--- a/cmd/kubelb/main.go
+++ b/cmd/kubelb/main.go
@@ -137,7 +137,6 @@ func main() {
 	// setup signal handler
 	ctx := ctrl.SetupSignalHandler()
 
-	// Load the Config for controller
 	conf, err := config.GetConfig(ctx, mgr.GetAPIReader(), opt.namespace)
 	if err != nil {
 		setupLog.Error(err, "unable to load controller config")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,7 +36,21 @@ func GetConfig(ctx context.Context, apiReader client.Reader, namespace string) (
 		Namespace: namespace,
 		Name:      DefaultConfigResourceName,
 	}, &conf); err != nil {
+		if apierrors.IsNotFound(err) {
+			return DefaultConfig(), nil
+		}
 		return conf, err
 	}
 	return conf, nil
+}
+
+func DefaultConfig() v1alpha1.Config {
+	return v1alpha1.Config{
+		Spec: v1alpha1.ConfigSpec{
+			EnvoyProxy: v1alpha1.EnvoyProxy{
+				Topology: v1alpha1.EnvoyProxyTopologyShared,
+				Replicas: 3,
+			},
+		},
+	}
 }

--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -80,14 +80,12 @@ func (r *EnvoyCPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	log.V(2).Info("reconciling LoadBalancer")
 
-	// Retrieve updated config.
 	config, err := GetConfig(ctx, r.Client, r.Namespace)
 	if err != nil {
 		managermetrics.EnvoyCPReconcileTotal.WithLabelValues(metricsutil.ResultError).Inc()
 		return ctrl.Result{}, fmt.Errorf("failed to retrieve config: %w", err)
 	}
 	r.Config = config
-	// Update EnvoyServer config so GenerateBootstrap() uses the latest config
 	r.EnvoyServer.UpdateConfig(config)
 
 	if err := r.reconcile(ctx, req); err != nil {
@@ -665,7 +663,7 @@ func configSpecChangedPredicate() predicate.Predicate {
 			return !reflect.DeepEqual(oldConfig.Spec.EnvoyProxy, newConfig.Spec.EnvoyProxy)
 		},
 		CreateFunc:  func(_ event.CreateEvent) bool { return true },
-		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
 }

--- a/internal/controllers/kubelb/shared.go
+++ b/internal/controllers/kubelb/shared.go
@@ -22,6 +22,7 @@ import (
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 	configpkg "k8c.io/kubelb/internal/config"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -54,6 +55,10 @@ func GetConfig(ctx context.Context, client ctrlclient.Client, configNamespace st
 		Namespace: configNamespace,
 		Name:      configpkg.DefaultConfigResourceName,
 	}, config); err != nil {
+		if apierrors.IsNotFound(err) {
+			defaultConf := configpkg.DefaultConfig()
+			return &defaultConf, nil
+		}
 		return nil, err
 	}
 	return config, nil

--- a/internal/controllers/kubelb/tenant_controller.go
+++ b/internal/controllers/kubelb/tenant_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/go-logr/logr"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	configpkg "k8c.io/kubelb/internal/config"
 	tenantresources "k8c.io/kubelb/internal/controllers/kubelb/resources/tenant"
 	envoycp "k8c.io/kubelb/internal/envoy"
 	"k8c.io/kubelb/internal/kubelb"
@@ -569,10 +570,11 @@ func (r *TenantReconciler) buildTenantState(ctx context.Context, tenant *kubelbv
 		Conditions:  existingConditions,
 	}
 
-	// Try to get Config to populate configuration-dependent fields
 	config, configErr := GetConfig(ctx, r.Client, r.Namespace)
 	if configErr != nil {
 		r.Log.V(2).Info("Could not get Config resource, using default values", "error", configErr)
+		defaultConf := configpkg.DefaultConfig()
+		config = &defaultConf
 	}
 
 	loadBalancerState := kubelbv1alpha1.LoadBalancerState{}

--- a/test/e2e/manifests/kubelb-manager/values.yaml
+++ b/test/e2e/manifests/kubelb-manager/values.yaml
@@ -26,7 +26,6 @@ resources:
 kubelb:
   enableGatewayAPI: true
   debug: true
-  skipConfigGeneration: true
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the Config CR optional. Previously the manager would crash on startup if the Config CR didn't exist, creating a chicken-and-egg problem; you couldn't deploy the manager without first having the Config CR, but the Config CR CRD is installed by the manager's chart.

Previously, this was required because of the different toplogies that KubeLB supported. Those topologies couldn't be changed once they were configured. But now since we only support "shared" topology, we can remove this dependency.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The manager now operates with sensible defaults (shared topology, 3 replicas) when the Config CR is absent.
```

**Documentation**:
```documentation
NONE
```
