### PR TITLE
Disable standalone e2e setup by default

### DIFF
--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -161,7 +161,7 @@ presubmits:
               start-docker.sh
               docker load --input /kindest.tar
               make download-gocache
-              make e2e-kind
+              ENABLE_STANDALONE=true make e2e-kind
           resources:
             requests:
               memory: 16Gi

--- a/Makefile
+++ b/Makefile
@@ -277,16 +277,21 @@ E2E_DIR ?= ./test/e2e
 KUBECONFIGS_DIR ?= $(shell pwd)/.e2e-kubeconfigs
 CHAINSAW_CONFIG ?= $(E2E_DIR)/config.yaml
 CHAINSAW_VALUES ?= $(E2E_DIR)/values.yaml
-# All 4 clusters: kubelb (manager), tenant1 (multi-node), tenant2 (single-node), standalone (conversion)
+ENABLE_STANDALONE ?= false
+# Core clusters: kubelb (manager), tenant1 (multi-node), tenant2 (single-node)
 CHAINSAW_CLUSTERS ?= --cluster kubelb=$(KUBECONFIGS_DIR)/kubelb.kubeconfig \
 	--cluster tenant1=$(KUBECONFIGS_DIR)/tenant1.kubeconfig \
-	--cluster tenant2=$(KUBECONFIGS_DIR)/tenant2.kubeconfig \
-	--cluster standalone=$(KUBECONFIGS_DIR)/standalone.kubeconfig
-CHAINSAW_FLAGS ?= --config $(CHAINSAW_CONFIG) --values $(CHAINSAW_VALUES) $(CHAINSAW_CLUSTERS)
+	--cluster tenant2=$(KUBECONFIGS_DIR)/tenant2.kubeconfig
+ifeq ($(ENABLE_STANDALONE),true)
+CHAINSAW_CLUSTERS += --cluster standalone=$(KUBECONFIGS_DIR)/standalone.kubeconfig
+else
+CHAINSAW_EXCLUDE ?= --exclude-selector suite=conversion
+endif
+CHAINSAW_FLAGS ?= --config $(CHAINSAW_CONFIG) --values $(CHAINSAW_VALUES) $(CHAINSAW_CLUSTERS) $(CHAINSAW_EXCLUDE)
 
 .PHONY: e2e-setup-kind
-e2e-setup-kind: ## Setup Kind clusters for e2e tests (kubelb, tenant1, tenant2, standalone)
-	./hack/e2e/setup-kind.sh
+e2e-setup-kind: ## Setup Kind clusters for e2e tests (kubelb, tenant1, tenant2; standalone if ENABLE_STANDALONE=true)
+	ENABLE_STANDALONE=$(ENABLE_STANDALONE) ./hack/e2e/setup-kind.sh
 
 .PHONY: e2e-cleanup-kind
 e2e-cleanup-kind: ## Cleanup Kind clusters
@@ -294,11 +299,11 @@ e2e-cleanup-kind: ## Cleanup Kind clusters
 
 .PHONY: e2e-deploy
 e2e-deploy: ## Deploy KubeLB to all Kind clusters
-	KUBECONFIGS_DIR=$(KUBECONFIGS_DIR) ./hack/e2e/deploy.sh
+	KUBECONFIGS_DIR=$(KUBECONFIGS_DIR) ENABLE_STANDALONE=$(ENABLE_STANDALONE) ./hack/e2e/deploy.sh
 
 .PHONY: e2e-reload
 e2e-reload: ## Quick reload of kubelb/ccm after code changes (faster than e2e-deploy)
-	KUBECONFIGS_DIR=$(KUBECONFIGS_DIR) ./hack/e2e/reload.sh
+	KUBECONFIGS_DIR=$(KUBECONFIGS_DIR) ENABLE_STANDALONE=$(ENABLE_STANDALONE) ./hack/e2e/reload.sh
 
 .PHONY: e2e-kind
 e2e-kind: e2e-setup-kind e2e-deploy e2e ## Full e2e with Kind setup

--- a/hack/e2e/cleanup-kind.sh
+++ b/hack/e2e/cleanup-kind.sh
@@ -20,7 +20,6 @@ export ROOT_DIR="$(git rev-parse --show-toplevel)"
 source "${ROOT_DIR}/hack/lib.sh"
 
 KUBECONFIGS_DIR="${KUBECONFIGS_DIR:-${ROOT_DIR}/.e2e-kubeconfigs}"
-
 echodate "Deleting Kind clusters"
 kind delete clusters kubelb tenant1 tenant2 standalone || true
 

--- a/hack/e2e/deploy.sh
+++ b/hack/e2e/deploy.sh
@@ -36,11 +36,12 @@ GIT_COMMIT="${GIT_COMMIT:-$(git rev-parse --short HEAD)}"
 BUILD_DATE="${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
 # Cluster type detection
-USE_KIND="${USE_KIND:-auto}"                # auto, true, false
-SKIP_BUILD="${SKIP_BUILD:-false}"           # Skip image building (use pre-built images)
-SKIP_IMAGE_LOAD="${SKIP_IMAGE_LOAD:-false}" # Skip image loading
-METALLB_IP_RANGE="${METALLB_IP_RANGE:-}"    # Override MetalLB IP range for cloud
-CONVERSION_MODE="${CONVERSION_MODE:-false}" # Deploy CCM in standalone conversion mode
+USE_KIND="${USE_KIND:-auto}"                    # auto, true, false
+SKIP_BUILD="${SKIP_BUILD:-false}"               # Skip image building (use pre-built images)
+SKIP_IMAGE_LOAD="${SKIP_IMAGE_LOAD:-false}"     # Skip image loading
+METALLB_IP_RANGE="${METALLB_IP_RANGE:-}"        # Override MetalLB IP range for cloud
+CONVERSION_MODE="${CONVERSION_MODE:-false}"     # Deploy CCM in standalone conversion mode
+ENABLE_STANDALONE="${ENABLE_STANDALONE:-false}" # Enable standalone cluster for conversion tests
 
 mkdir -p "${LOGS_DIR}"
 
@@ -71,7 +72,11 @@ get_helm_command() {
 # Verify prerequisites
 #######################################
 verify_kubeconfigs() {
-  for cluster in kubelb tenant1 tenant2 standalone; do
+  local clusters="kubelb tenant1 tenant2"
+  if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+    clusters="${clusters} standalone"
+  fi
+  for cluster in ${clusters}; do
     if [[ ! -f "${KUBECONFIGS_DIR}/${cluster}.kubeconfig" ]]; then
       echo "Error: ${KUBECONFIGS_DIR}/${cluster}.kubeconfig not found"
       echo "Run 'make e2e-setup-kind' first"
@@ -150,7 +155,9 @@ load_images() {
   kind load docker-image --name=kubelb "${KUBELB_IMAGE}" "${CCM_IMAGE}" &
   kind load docker-image --name=tenant1 "${CCM_IMAGE}" &
   kind load docker-image --name=tenant2 "${CCM_IMAGE}" &
-  kind load docker-image --name=standalone "${CCM_IMAGE}" &
+  if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+    kind load docker-image --name=standalone "${CCM_IMAGE}" &
+  fi
   wait
 
   printElapsed "image_loads" ${load_start}
@@ -680,9 +687,11 @@ deploy_test_apps() {
       kubectl apply -f "${E2E_MANIFESTS_DIR}/test-apps/echo-server.yaml" &
   done
 
-  # Also deploy to standalone cluster
-  KUBECONFIG="${KUBECONFIGS_DIR}/standalone.kubeconfig" \
-    kubectl apply -f "${E2E_MANIFESTS_DIR}/test-apps/echo-server.yaml" &
+  # Also deploy to standalone cluster if enabled
+  if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+    KUBECONFIG="${KUBECONFIGS_DIR}/standalone.kubeconfig" \
+      kubectl apply -f "${E2E_MANIFESTS_DIR}/test-apps/echo-server.yaml" &
+  fi
 
   wait
   echodate "Test apps deployed (pods starting in background)"
@@ -733,11 +742,13 @@ load_images
 # Ensure helm repos configured once before parallel deploys
 ensure_helm_repos_once
 
-# Deploy kubelb manager and standalone addons in parallel (both do similar helm work)
+# Deploy kubelb manager (and standalone addons in parallel if enabled)
 deploy_kubelb_manager &
 manager_pid=$!
-deploy_standalone_addons &
-standalone_addons_pid=$!
+if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+  deploy_standalone_addons &
+  standalone_addons_pid=$!
+fi
 
 # Wait for manager before tenant setup (tenants need manager CRDs)
 wait ${manager_pid}
@@ -746,18 +757,24 @@ setup_tenants
 deploy_ccms &
 ccm_pid=$!
 
-# Wait for standalone addons before CCM deploy
-wait ${standalone_addons_pid}
-deploy_standalone_ccm &
-standalone_ccm_pid=$!
+if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+  # Wait for standalone addons before CCM deploy
+  wait ${standalone_addons_pid}
+  deploy_standalone_ccm &
+  standalone_ccm_pid=$!
+fi
 
 # Wait for CCMs to finish
 wait ${ccm_pid}
-wait ${standalone_ccm_pid}
+if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+  wait ${standalone_ccm_pid}
+fi
 
 # Wait for all clusters to be ready in parallel
 wait_for_ready &
-wait_for_standalone_ready &
+if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+  wait_for_standalone_ready &
+fi
 wait
 
 deploy_test_apps
@@ -781,6 +798,8 @@ echodate "Clusters ready:"
 echodate "  kubelb:     export KUBECONFIG=${KUBECONFIGS_DIR}/kubelb.kubeconfig"
 echodate "  tenant1:    export KUBECONFIG=${KUBECONFIGS_DIR}/tenant1.kubeconfig"
 echodate "  tenant2:    export KUBECONFIG=${KUBECONFIGS_DIR}/tenant2.kubeconfig"
-echodate "  standalone: export KUBECONFIG=${KUBECONFIGS_DIR}/standalone.kubeconfig"
+if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+  echodate "  standalone: export KUBECONFIG=${KUBECONFIGS_DIR}/standalone.kubeconfig"
+fi
 echodate ""
 printElapsed "total_deploy" ${SCRIPT_START}

--- a/hack/e2e/reload.sh
+++ b/hack/e2e/reload.sh
@@ -29,13 +29,18 @@ BIN_DIR="${ROOT_DIR}/bin"
 IMAGE_TAG="${IMAGE_TAG:-e2e}"
 KUBELB_IMAGE="kubelb:${IMAGE_TAG}"
 CCM_IMAGE="kubelb-ccm:${IMAGE_TAG}"
+ENABLE_STANDALONE="${ENABLE_STANDALONE:-false}"
 
 # Hash tracking for change detection
 HASH_DIR="${KUBECONFIGS_DIR}/.reload-hashes"
 mkdir -p "${HASH_DIR}"
 
 # Verify kubeconfigs exist
-for cluster in kubelb tenant1 tenant2 standalone; do
+clusters="kubelb tenant1 tenant2"
+if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+  clusters="${clusters} standalone"
+fi
+for cluster in ${clusters}; do
   if [[ ! -f "${KUBECONFIGS_DIR}/${cluster}.kubeconfig" ]]; then
     echo "Error: ${KUBECONFIGS_DIR}/${cluster}.kubeconfig not found"
     echo "Run 'make e2e-setup-kind' first"
@@ -141,10 +146,12 @@ if [[ "${ccm_changed}" == "true" ]]; then
   echodate "Building ccm image..."
   docker build -q -t "${CCM_IMAGE}" -f "${ROOT_DIR}/ccm.goreleaser.dockerfile" "${BIN_DIR}/"
 
-  echodate "Loading ccm image into tenant and standalone clusters..."
+  echodate "Loading ccm image into tenant clusters..."
   kind load docker-image --name=tenant1 "${CCM_IMAGE}" &
   kind load docker-image --name=tenant2 "${CCM_IMAGE}" &
-  kind load docker-image --name=standalone "${CCM_IMAGE}" &
+  if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+    kind load docker-image --name=standalone "${CCM_IMAGE}" &
+  fi
   wait
 
   echodate "Restarting CCM deployments..."
@@ -152,8 +159,10 @@ if [[ "${ccm_changed}" == "true" ]]; then
     rollout restart deployment/kubelb-ccm -n kubelb &
   kubectl --kubeconfig="${KUBECONFIGS_DIR}/tenant2.kubeconfig" \
     rollout restart deployment/kubelb-ccm -n kubelb &
-  kubectl --kubeconfig="${KUBECONFIGS_DIR}/standalone.kubeconfig" \
-    rollout restart deployment/kubelb-ccm -n kubelb &
+  if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+    kubectl --kubeconfig="${KUBECONFIGS_DIR}/standalone.kubeconfig" \
+      rollout restart deployment/kubelb-ccm -n kubelb &
+  fi
   wait
 
   store_hash "ccm" "${ccm_hash}"

--- a/hack/e2e/setup-kind.sh
+++ b/hack/e2e/setup-kind.sh
@@ -26,7 +26,11 @@ cleanup() {
   set +e
   if [[ "${CLEANUP_ON_EXIT:-false}" == "true" ]] && [[ "${TEST_FAILED}" == "true" ]]; then
     echodate "Test failed, cleaning up clusters..."
-    kind delete clusters kubelb tenant1 tenant2 standalone &> /dev/null || true
+    local clusters="kubelb tenant1 tenant2"
+    if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+      clusters="${clusters} standalone"
+    fi
+    kind delete clusters ${clusters} &> /dev/null || true
   fi
 }
 
@@ -79,18 +83,21 @@ CHAINSAW_PID=""
 CHAINSAW_PID=$!
 
 KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.35.0}"
+ENABLE_STANDALONE="${ENABLE_STANDALONE:-false}"
 
 # Cluster definitions: name -> type (empty = single node, multinode = 3 workers)
 # - kubelb: manager cluster (single-node)
 # - tenant1: normal CCM hub-and-spoke (multi-node for endpoint/node tests)
 # - tenant2: normal CCM hub-and-spoke (single-node for edge cases)
-# - standalone: standalone conversion CCM (single-node)
+# - standalone: standalone conversion CCM (single-node, opt-in via ENABLE_STANDALONE)
 declare -A CLUSTERS=(
   ["kubelb"]=""
   ["tenant1"]="multinode"
   ["tenant2"]=""
-  ["standalone"]=""
 )
+if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
+  CLUSTERS["standalone"]=""
+fi
 
 #######################################
 # Helper functions
@@ -334,9 +341,9 @@ prepull_images() {
     wait ${pid} || true
   done
 
-  # Load standalone cluster images
+  # Load standalone cluster images (only when standalone is enabled)
   local standalone_images_file="${ROOT_DIR}/hack/e2e/images-standalone.yaml"
-  if [[ -f "${standalone_images_file}" ]]; then
+  if [[ "${ENABLE_STANDALONE}" == "true" ]] && [[ -f "${standalone_images_file}" ]]; then
     local standalone_images=()
     while IFS= read -r line; do
       if [[ "${line}" =~ ^[[:space:]]*-[[:space:]]+(.+)$ ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
We create additional kind cluster and infra for standalone that is not required locally. The flag `ENABLE_STANDALONE` can now be used to toggle the standalone infra and tests. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
