### PR TITLE
Enable WebSocket upgrade support in envoy HTTP connection manager

### DIFF
--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -524,6 +524,9 @@ func makeHTTPListener(listenerName string, clusterName string, listenerPort uint
 		CommonHttpProtocolOptions: &envoyCore.HttpProtocolOptions{
 			IdleTimeout: durationpb.New(60 * time.Second),
 		},
+		UpgradeConfigs: []*envoyHttpManager.HttpConnectionManager_UpgradeConfig{
+			{UpgradeType: "websocket"},
+		},
 		// XFF and remote address handling
 		UseRemoteAddress:  &wrapperspb.BoolValue{Value: true},
 		XffNumTrustedHops: 1, // Trust 1 hop (Ingress/Gateway controller in front)

--- a/test/e2e/tests/layer7/ingress/websocket/chainsaw-test.yaml
+++ b/test/e2e/tests/layer7/ingress/websocket/chainsaw-test.yaml
@@ -1,0 +1,249 @@
+# Copyright 2026 The KubeLB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WebSocket Upgrade Test (Ingress)
+# Verifies:
+# - WebSocket connections work through KubeLB Envoy proxy via Ingress
+# - Without UpgradeConfigs in Envoy HttpConnectionManager, WebSocket upgrades fail
+#   with 400 Bad Request because Envoy strips the Upgrade/Connection headers
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: websocket-ingress
+  labels:
+    all:
+    test: websocket
+    resource: ingress
+    layer: layer7
+spec:
+  description: |
+    Test WebSocket upgrade through KubeLB Envoy proxy via Ingress.
+    Deploys jmalloc/echo-server (supports HTTP + WebSocket), creates Ingress,
+    then attempts a WebSocket handshake through the full proxy chain.
+    Without UpgradeConfigs, Envoy strips upgrade headers causing 400 from nginx.
+  bindings:
+    - name: name
+      value: ws-ingress
+    - name: backend
+      value: ws-echo-server
+    - name: kubelb_namespace
+      value: tenant-primary
+  steps:
+    # Step 1: Deploy WebSocket-capable echo server
+    - name: deploy-backend
+      description: Deploy jmalloc/echo-server (supports HTTP and WebSocket)
+      cluster: tenant1
+      try:
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ws-echo-server
+                namespace: default
+                labels:
+                  app: ws-echo-server
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    app: ws-echo-server
+                template:
+                  metadata:
+                    labels:
+                      app: ws-echo-server
+                  spec:
+                    containers:
+                      - name: echo
+                        image: jmalloc/echo-server:v0.3.7
+                        imagePullPolicy: IfNotPresent
+                        ports:
+                          - containerPort: 8080
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: ws-echo-server
+                namespace: default
+              spec:
+                type: ClusterIP
+                selector:
+                  app: ws-echo-server
+                ports:
+                  - port: 80
+                    targetPort: 8080
+        - assert:
+            timeout: 60s
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ws-echo-server
+                namespace: default
+              status:
+                readyReplicas: 1
+
+    # Step 2: Create Ingress
+    - name: create-ingress
+      description: Create Ingress with kubelb class
+      cluster: tenant1
+      try:
+        - apply:
+            resource:
+              apiVersion: networking.k8s.io/v1
+              kind: Ingress
+              metadata:
+                name: ($name)
+                namespace: default
+              spec:
+                ingressClassName: kubelb
+                rules:
+                  - host: ws-ingress.test.local
+                    http:
+                      paths:
+                        - path: /
+                          pathType: Prefix
+                          backend:
+                            service:
+                              name: ($backend)
+                              port:
+                                number: 80
+
+    # Step 3: Verify Route CRD
+    - name: verify-route-crd
+      description: Verify Route CRD exists with correct labels
+      use:
+        template: ../../../../step-templates/common/verify-route-crd.yaml
+        with:
+          bindings:
+            - name: resource_name
+              value: ($name)
+            - name: expected_kind
+              value: Ingress.networking.k8s.io
+            - name: kubelb_namespace
+              value: ($kubelb_namespace)
+
+    # Step 4: Wait for Ingress status
+    - name: wait-ingress-status
+      description: Wait for Ingress to get LoadBalancer IP
+      use:
+        template: ../../../../step-templates/ingress/verify-ingress-status.yaml
+        with:
+          bindings:
+            - name: ingress_name
+              value: ($name)
+
+    # Step 5: Verify normal HTTP works (route is functional)
+    - name: verify-http
+      description: Verify normal HTTP connectivity through the proxy
+      cluster: tenant1
+      try:
+        - script:
+            skipCommandOutput: true
+            timeout: 60s
+            content: |
+              set -e
+              NAMESPACE=default
+              IP=$(kubectl get ingress ws-ingress -n "$NAMESPACE" \
+                -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+              for i in $(seq 1 15); do
+                RESPONSE=$(curl -s --max-time 5 -H "Host: ws-ingress.test.local" "http://${IP}/" 2>/dev/null || true)
+                if echo "$RESPONSE" | grep -q "Request served by"; then
+                  echo "HTTP OK: $RESPONSE"
+                  exit 0
+                fi
+                echo "Attempt $i: waiting for route..."
+                sleep 2
+              done
+              echo "FAILED: Normal HTTP not working"
+              exit 1
+            check:
+              ($error == null): true
+
+    # Step 6: Attempt WebSocket upgrade handshake through the proxy
+    - name: verify-websocket
+      description: Attempt WebSocket handshake through KubeLB Envoy proxy
+      cluster: tenant1
+      try:
+        - script:
+            skipCommandOutput: true
+            timeout: 60s
+            content: |
+              set -e
+              NAMESPACE=default
+              IP=$(kubectl get ingress ws-ingress -n "$NAMESPACE" \
+                -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+              HOST="ws-ingress.test.local"
+
+              # Send WebSocket upgrade request (GET) and capture response status line
+              HEADER_FILE=$(mktemp)
+              curl -s -o /dev/null -D "$HEADER_FILE" --max-time 5 \
+                --http1.1 \
+                -H "Host: ${HOST}" \
+                -H "Upgrade: websocket" \
+                -H "Connection: Upgrade" \
+                -H "Sec-WebSocket-Version: 13" \
+                -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+                "http://${IP}/" 2>/dev/null || true
+
+              STATUS_LINE=$(head -1 "$HEADER_FILE")
+              rm -f "$HEADER_FILE"
+
+              if echo "$STATUS_LINE" | grep -q "101"; then
+                echo "WebSocket upgrade OK: $STATUS_LINE"
+                exit 0
+              fi
+
+              echo "FAILED: Expected HTTP 101 Switching Protocols"
+              echo "Response: $STATUS_LINE"
+              echo "Envoy HttpConnectionManager is missing UpgradeConfigs for websocket."
+              exit 1
+            check:
+              ($error == null): true
+
+    # Step 7: Cleanup
+    - name: cleanup
+      description: Delete resources
+      cluster: tenant1
+      try:
+        - script:
+            skipCommandOutput: true
+            timeout: 60s
+            content: |
+              kubectl delete ingress ws-ingress -n default --wait=false
+              echo "Ingress deletion initiated"
+            check:
+              ($error == null): true
+      finally:
+        - script:
+            skipCommandOutput: true
+            cluster: tenant1
+            timeout: 60s
+            content: |
+              kubectl delete ingress ws-ingress -n default --ignore-not-found
+              kubectl delete deployment ws-echo-server -n default --ignore-not-found
+              kubectl delete service ws-echo-server -n default --ignore-not-found
+
+    - name: verify-cleanup
+      description: Verify Route CRD removed
+      use:
+        template: ../../../../step-templates/common/verify-route-cleanup.yaml
+        with:
+          bindings:
+            - name: resource_name
+              value: ($name)
+            - name: kubelb_namespace
+              value: ($kubelb_namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
The L7 HTTP proxy listeners (for Ingress/HTTPRoute/GRPCRoute) were missing `UpgradeConfigs` for WebSocket in the Envoy `HttpConnectionManager`. Without explicit `upgrade_configs`, Envoy strips `Upgrade`/`Connection` headers, causing WebSocket upgrade requests to fail with 400 instead of being forwarded upstream.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix WebSocket connections failing through KubeLB Layer 7 proxy by adding UpgradeConfigs to Envoy HttpConnectionManager
```

**Documentation**:
```documentation
NONE
```