### PR TITLE
Fix HTTPRoute reconciliation storm with ClusterIP backend services

### DIFF
--- a/internal/controllers/kubelb/route_controller.go
+++ b/internal/controllers/kubelb/route_controller.go
@@ -40,6 +40,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -576,6 +577,7 @@ func updateServiceStatus(routeStatus *kubelbv1alpha1.RouteStatus, svc *corev1.Se
 	originalName := serviceHelpers.GetServiceName(*svc)
 	originalNamespace := serviceHelpers.GetServiceNamespace(*svc)
 
+	key := fmt.Sprintf(kubelb.RouteServiceMapKey, originalNamespace, originalName)
 	status := kubelbv1alpha1.RouteServiceStatus{
 		ResourceState: kubelbv1alpha1.ResourceState{
 			GeneratedName: svc.GetName(),
@@ -584,7 +586,10 @@ func updateServiceStatus(routeStatus *kubelbv1alpha1.RouteStatus, svc *corev1.Se
 		},
 		Ports: svc.Spec.Ports,
 	}
-	status.Conditions = generateConditions(err)
+	if existing, ok := routeStatus.Resources.Services[key]; ok {
+		status.Conditions = existing.Conditions
+	}
+	setCondition(&status.Conditions, err)
 
 	svcStatus, err := json.Marshal(svc.Status)
 	if err != nil {
@@ -598,7 +603,6 @@ func updateServiceStatus(routeStatus *kubelbv1alpha1.RouteStatus, svc *corev1.Se
 	if routeStatus.Resources.Services == nil {
 		routeStatus.Resources.Services = make(map[string]kubelbv1alpha1.RouteServiceStatus)
 	}
-	key := fmt.Sprintf(kubelb.RouteServiceMapKey, originalNamespace, originalName)
 	routeStatus.Resources.Services[key] = status
 }
 
@@ -609,8 +613,9 @@ func updateResourceStatus(routeStatus *kubelbv1alpha1.RouteStatus, obj ctrlrunti
 		Name:          kubelb.GetName(obj),
 		APIVersion:    obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
 		Kind:          obj.GetObjectKind().GroupVersionKind().Kind,
+		Conditions:    routeStatus.Resources.Route.Conditions,
 	}
-	status.Conditions = generateConditions(err)
+	setCondition(&status.Conditions, err)
 
 	switch resource := obj.(type) {
 	case *v1.Ingress:
@@ -639,7 +644,7 @@ func getResourceStatus(v any) runtime.RawExtension {
 	}
 }
 
-func generateConditions(err error) []metav1.Condition {
+func setCondition(conditions *[]metav1.Condition, err error) {
 	conditionMessage := "Success"
 	conditionStatus := metav1.ConditionTrue
 	conditionReason := "InstallationSuccessful"
@@ -648,17 +653,12 @@ func generateConditions(err error) []metav1.Condition {
 		conditionStatus = metav1.ConditionFalse
 		conditionReason = "InstallationFailed"
 	}
-	return []metav1.Condition{
-		{
-			Type:   kubelbv1alpha1.ConditionResourceAppliedSuccessfully.String(),
-			Reason: conditionReason,
-			Status: conditionStatus,
-			LastTransitionTime: metav1.Time{
-				Time: time.Now(),
-			},
-			Message: conditionMessage,
-		},
-	}
+	apimeta.SetStatusCondition(conditions, metav1.Condition{
+		Type:    kubelbv1alpha1.ConditionResourceAppliedSuccessfully.String(),
+		Reason:  conditionReason,
+		Status:  conditionStatus,
+		Message: conditionMessage,
+	})
 }
 
 func (r *RouteReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/resources/service/service.go
+++ b/internal/resources/service/service.go
@@ -156,7 +156,11 @@ func CreateOrUpdateService(ctx context.Context, client ctrlclient.Client, obj *c
 		return nil
 	}
 
-	// Update the Service object if it is different from the existing one.
+	if obj.Spec.ClusterIP == "" && existingObj.Spec.ClusterIP != "" {
+		obj.Spec.ClusterIP = existingObj.Spec.ClusterIP
+		obj.Spec.ClusterIPs = existingObj.Spec.ClusterIPs
+	}
+
 	if equality.Semantic.DeepEqual(existingObj.Spec, obj.Spec) &&
 		equality.Semantic.DeepEqual(existingObj.Labels, obj.Labels) &&
 		equality.Semantic.DeepEqual(existingObj.Annotations, obj.Annotations) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Creating an HTTPRoute with ClusterIP backend services triggers a reconciliation storm (~10+ reconciliations in <1s) across both CCM and Manager. Two root causes:

1. `generateConditions` sets `LastTransitionTime: time.Now()` on every reconcile, guaranteeing a status diff even when nothing changed. This defeats the `reflect.DeepEqual` guard in `UpdateRouteStatus`, causing a status patch every cycle → CCM re-triggered via Route watch → loop.

2. `cleanseService` clears `ClusterIP: ""` for all non-headless services. `CreateOrUpdateService` sees a spec diff (empty vs server-assigned) → spurious update → service watch re-enqueue → loop.

Fixes:
- Replace `generateConditions` with `meta.SetStatusCondition` which preserves `LastTransitionTime` when condition status hasn't transitioned (standard K8s convention). Same fix applied to tunnel_controller.
- Preserve existing `ClusterIP`/`ClusterIPs` from server in `CreateOrUpdateService` before comparison.

**Which issue(s) this PR fixes**:
Fixes #331

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix lengthy reconciliation loop when creating HTTPRoutes with ClusterIP backend services
```

**Documentation**:
```documentation
NONE
```