### PR TITLE
Print out trivy scan result in pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,16 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=min,scope=${{ matrix.image.name }}
 
-      - name: Scan ${{ matrix.image.name }}
+      - name: Scan ${{ matrix.image.name }} (table)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ matrix.image.name }}:pr-scan
+          exit-code: "0"
+          severity: "HIGH,CRITICAL"
+          ignore-unfixed: true
+          format: "table"
+
+      - name: Scan ${{ matrix.image.name }} (sarif)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ matrix.image.name }}:pr-scan
@@ -82,21 +91,3 @@ jobs:
         with:
           sarif_file: trivy-${{ matrix.image.name }}.sarif
           category: ${{ matrix.image.name }}
-
-  scan-summary:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    needs: scan-images
-    if: failure()
-    steps:
-      - name: Comment PR on failure
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '⚠️ **Security Scan Failed** - HIGH or CRITICAL vulnerabilities found. Check the workflow logs for details.'
-            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,8 +150,11 @@ jobs:
           for img in kubelb-manager kubelb-ccm; do
             echo "=== Scanning quay.io/kubermatic/${img}:${VERSION} ==="
             trivy image --exit-code 1 --severity HIGH,CRITICAL --ignore-unfixed \
-              --format sarif --output "trivy-${img}.sarif" \
+              --format table \
               "quay.io/kubermatic/${img}:${VERSION}" || EXIT_CODE=1
+            trivy image --exit-code 0 --severity HIGH,CRITICAL --ignore-unfixed \
+              --format sarif --output "trivy-${img}.sarif" \
+              "quay.io/kubermatic/${img}:${VERSION}"
           done
           exit $EXIT_CODE
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently had a release failure due to trivy finding some vulnerabilities but it didn't print the results out in the pipeline itself which was inconvenient.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
