### PR TITLE
Widen MetalLB IP pool from 51 to 100 IPs for e2e tests

### DIFF
--- a/hack/e2e/deploy.sh
+++ b/hack/e2e/deploy.sh
@@ -308,7 +308,7 @@ configure_metallb_pool() {
     # Auto-detect from Kind's Docker network (IPv4 only, filter out nulls and IPv6)
     local metallb_gw
     metallb_gw=$(docker network inspect -f json kind | jq --raw-output '.[].IPAM.Config[].Gateway | select(. != null) | select(contains(":") | not)' | sed -e 's/\(.*\..*\).*\..*\..*/\1/')
-    metallb_ip_range="${metallb_gw}.255.200-${metallb_gw}.255.250"
+    metallb_ip_range="${metallb_gw}.255.50-${metallb_gw}.255.149"
   fi
 
   echodate "MetalLB IP pool: ${metallb_ip_range}"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
