### PR TITLE
ci: migrate Prow jobs off monolithic build image

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -28,14 +28,16 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-1
+        - image: golang:1.26
           command:
             - /bin/bash
             - -c
             - |
-              set -euo pipefail &&
-              start-docker.sh
-              docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io &&
+              set -euo pipefail
+              VERSION=29.4.0 curl -fsSL https://get.docker.com | sh
+              dockerd &>/dev/null &
+              timeout 30 bash -c 'while ! docker info &>/dev/null; do sleep 0.5; done'
+              docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io
               make download-gocache docker-image-publish
           # docker-in-docker needs privileged mode
           securityContext:
@@ -58,7 +60,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-1
+        - image: golang:1.26
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -14,7 +14,7 @@
 
 ---
 presubmits:
-  - name: pull-kubelb-mod-verify
+  - name: pull-kubelb-verify
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubelb.git"
@@ -24,12 +24,11 @@ presubmits:
       containers:
         - image: golang:1.26
           command:
-            - make
-          args:
-            - check-dependencies
+            - ./hack/ci/verify.sh
           resources:
             requests:
-              cpu: 1
+              memory: 2Gi
+              cpu: 2
 
   - name: pull-kubelb-lint
     always_run: true
@@ -41,75 +40,16 @@ presubmits:
       containers:
         - image: golangci/golangci-lint:v2.10.1
           command:
-            - make
+            - bash
           args:
-            - lint
+            - -c
+            - |
+              make download-gocache
+              make lint
           resources:
             requests:
-              cpu: 1
+              cpu: 4
               memory: 6Gi
-
-  - name: pull-kubelb-yamllint
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubelb.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-1
-          command:
-            - make
-          args:
-            - yamllint
-          resources:
-            requests:
-              cpu: 200m
-
-  - name: pull-kubelb-verify-boilerplate
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubelb.git"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-1
-          command:
-            - make
-          args:
-            - verify-boilerplate
-
-  - name: pull-kubelb-verify-imports
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubelb.git"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-1
-          command:
-            - make
-          args:
-            - verify-imports
-
-  - name: pull-kubelb-build
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubelb.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: golang:1.26
-          command:
-            - make
-          args:
-            - build
-          resources:
-            requests:
-              memory: 1Gi
-              cpu: 1
-            limits:
-              memory: 2Gi
-              cpu: 2
 
   - name: pull-kubelb-unit-tests
     always_run: true
@@ -121,9 +61,12 @@ presubmits:
       containers:
         - image: golang:1.26
           command:
-            - make
+            - bash
           args:
-            - test
+            - -c
+            - |
+              make download-gocache
+              make test
           resources:
             requests:
               memory: 4Gi
@@ -183,50 +126,6 @@ presubmits:
               memory: 16Gi
               cpu: 4
 
-  - name: pull-kubelb-verify-shfmt
-    run_if_changed: "^hack/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubelb.git"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-1
-          command:
-            - shfmt
-          args:
-            #   -l        list files whose formatting differs from shfmt's
-            #   -d        error with a diff when the formatting differs
-            #   -i uint   indent: 0 for tabs (default), >0 for number of spaces
-            #   -sr       redirect operators will be followed by a space
-            - "-l"
-            - "-sr"
-            - "-i"
-            - "2"
-            - "-d"
-            - "hack"
-          resources:
-            requests:
-              memory: 32Mi
-              cpu: 50m
-            limits:
-              memory: 256Mi
-              cpu: 250m
-
-  - name: pull-kubelb-license-validation
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubelb.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-1
-          command:
-            - ./hack/verify-licenses.sh
-          resources:
-            requests:
-              memory: 2Gi
-              cpu: 2
-
   - name: pull-kubelb-gorelease-verify
     run_if_changed: "^(\\.goreleaser\\.ya?ml|go\\.(mod|sum))$|Dockerfile|\\.dockerfile$"
     decorate: true
@@ -235,7 +134,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-1
+        - image: goreleaser/goreleaser:v2.15.2
           command:
             - goreleaser
           args:

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The KubeLB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+export PATH=$PATH:$(go env GOPATH)/bin
+
+EXIT_CODE=0
+SUMMARY=
+
+echodate "Installing tools..."
+
+apt-get update -qq && apt-get install -y -qq yamllint > /dev/null 2>&1 &
+go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 &
+go install go.xrstf.de/gimps@v0.6.2 &
+go install github.com/kubermatic-labs/boilerplate@v0.3.0 &
+go install github.com/frapposelli/wwhrd@v0.4.0 &
+wait
+
+echodate "Tools installed."
+
+try() {
+  local title="$1"
+  shift
+
+  echodate "=== $title ==="
+  echo
+
+  start_time=$(date +%s)
+
+  set +e
+  "$@"
+  exitCode=$?
+  set -e
+
+  elapsed_time=$(($(date +%s) - $start_time))
+  TEST_NAME="$title" write_junit $exitCode "$elapsed_time"
+
+  local status
+  if [[ $exitCode -eq 0 ]]; then
+    echo -e "\n[${elapsed_time}s] PASS"
+    status=PASS
+  else
+    echo -e "\n[${elapsed_time}s] FAIL"
+    status=FAIL
+    EXIT_CODE=1
+  fi
+
+  SUMMARY="$SUMMARY\n$(printf "%-40s %s" "$title" "$status")"
+
+  git reset --hard --quiet
+  git clean --force
+
+  echo
+}
+
+try "Verify go.mod" make check-dependencies
+try "Verify YAML" yamllint -c .yamllint.conf .
+try "Verify boilerplate" make verify-boilerplate
+try "Verify imports" make verify-imports
+try "Verify shfmt" shfmt -l -sr -i 2 -d hack
+try "Verify licenses" ./hack/verify-licenses.sh
+
+echo
+echo "SUMMARY"
+echo "======="
+echo
+echo "Check                                    Result"
+echo "-----------------------------------------------"
+echo -e "$SUMMARY"
+
+exit $EXIT_CODE


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces `quay.io/kubermatic/build` with independent images in all Prow jobs except e2e. The build image blocks Go patch bumps — when `go.mod` is updated to e.g. `go 1.26.2`, any job using a build image with Go 1.26.1 fails to compile (Go 1.21+ enforces the `go` directive as a minimum version).

Changes:
- Consolidate 6 verification jobs (mod-verify, yamllint, boilerplate, imports, shfmt, licenses) into a single `pull-kubelb-verify` job running `hack/ci/verify.sh`. Script installs tools in parallel, runs all checks, continues on failure, prints summary.
- Remove redundant `pull-kubelb-build` job (covered by unit-tests and goreleaser-verify)
- Migrate `goreleaser-verify` to `goreleaser/goreleaser:v2.15.2`
- Migrate `ci-push` to `golang:1.26` with runtime Docker 29.4.0 install
- Migrate `upload-gocache` to `golang:1.26`

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```