### PR TITLE
chore: migrate addons sub-charts to OCI and bump versions

### DIFF
--- a/charts/kubelb-addons/Chart.lock
+++ b/charts/kubelb-addons/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.15.0
+  version: 4.15.1
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.7.1
 - name: cert-manager
-  repository: https://charts.jetstack.io
-  version: v1.20.0
+  repository: oci://quay.io/jetstack/charts
+  version: v1.20.2
 - name: external-dns
   repository: https://kubernetes-sigs.github.io/external-dns
   version: 1.20.0
 - name: metallb
-  repository: https://metallb.github.io/metallb
+  repository: oci://quay.io/metallb/chart
   version: 0.15.3
 - name: kgateway-crds
   repository: oci://cr.kgateway.dev/kgateway-dev/charts
-  version: v2.1.2
+  version: v2.2.3
 - name: kgateway
   repository: oci://cr.kgateway.dev/kgateway-dev/charts
-  version: v2.1.2
-digest: sha256:f0f8d9682f7b432d4df6f9dfa62c5f7e06afcdf83fa6c0ab681453c22e33ecdf
-generated: "2026-03-17T12:22:07.406273785Z"
+  version: v2.2.3
+digest: sha256:aa15d148097f3a35b9cae7ea3d374fc3137e462a1d1d2bf0e42b2dfd3983a900
+generated: "2026-04-14T15:01:57.332989+05:00"

--- a/charts/kubelb-addons/Chart.yaml
+++ b/charts/kubelb-addons/Chart.yaml
@@ -13,29 +13,29 @@ dependencies:
   - name: ingress-nginx
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
-    version: 4.15.0
+    version: 4.15.1
   - name: gateway-helm
     repository: oci://docker.io/envoyproxy
     condition: envoy-gateway.enabled
     version: 1.7.1
     alias: envoy-gateway
   - name: cert-manager
-    repository: https://charts.jetstack.io
+    repository: oci://quay.io/jetstack/charts
     condition: cert-manager.enabled
-    version: 1.20.0
+    version: v1.20.2
   - name: external-dns
     repository: https://kubernetes-sigs.github.io/external-dns
     condition: external-dns.enabled
     version: 1.20.0
   - name: metallb
-    repository: https://metallb.github.io/metallb
+    repository: oci://quay.io/metallb/chart
     condition: metallb.enabled
     version: 0.15.3
   - name: kgateway-crds
     repository: oci://cr.kgateway.dev/kgateway-dev/charts
     condition: kgateway.crds.enabled
-    version: v2.1.2
+    version: v2.2.3
   - name: kgateway
     repository: oci://cr.kgateway.dev/kgateway-dev/charts
     condition: kgateway.enabled
-    version: v2.1.2
+    version: v2.2.3

--- a/charts/kubelb-addons/README.md
+++ b/charts/kubelb-addons/README.md
@@ -87,13 +87,13 @@ These are the default values to use when Gateway API is disabled for KubeLB in f
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.jetstack.io | cert-manager | 1.20.0 |
 | https://kubernetes-sigs.github.io/external-dns | external-dns | 1.20.0 |
 | https://kubernetes.github.io/ingress-nginx | ingress-nginx | 4.15.0 |
-| https://metallb.github.io/metallb | metallb | 0.15.3 |
 | oci://cr.kgateway.dev/kgateway-dev/charts | kgateway | v2.1.2 |
 | oci://cr.kgateway.dev/kgateway-dev/charts | kgateway-crds | v2.1.2 |
 | oci://docker.io/envoyproxy | envoy-gateway(gateway-helm) | 1.7.1 |
+| oci://quay.io/jetstack/charts | cert-manager | 1.20.0 |
+| oci://quay.io/metallb/chart | metallb | 0.15.3 |
 
 ## Values
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrates cert-manager and metallb chart dependencies to OCI registries where available, and bumps all sub-charts to their latest versions.

**OCI migration:**
- cert-manager: `https://charts.jetstack.io` → `oci://quay.io/jetstack/charts`
- metallb: `https://metallb.github.io/metallb` → `oci://quay.io/metallb/chart`
- ingress-nginx and external-dns remain on Helm repos (no OCI published upstream)

**Version bumps:**
- ingress-nginx: 4.15.0 → 4.15.1
- cert-manager: 1.20.0 → v1.20.2
- kgateway: v2.1.2 → v2.2.3
- kgateway-crds: v2.1.2 → v2.2.3

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:
Switching from Helm repo to OCI between releases is transparent — Helm tracks releases by name/namespace, not source repository. The packaged chart content is identical.

The README diff is cosmetic — helm-docs re-sorted the dependency table alphabetically by repository URL.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Upgrade kubelb-addons sub charts to latest versions:
- ingress-nginx: 4.15.0 → 4.15.1
- cert-manager: 1.20.0 → v1.20.2
- kgateway: v2.1.2 → v2.2.3
- kgateway-crds: v2.1.2 → v2.2.3
```

**Documentation**:
```documentation
NONE
```