### PR TITLE
Addons: support global.imageRegistry for registry mirrors

### DIFF
--- a/charts/kubelb-addons/README.md
+++ b/charts/kubelb-addons/README.md
@@ -125,8 +125,10 @@ These are the default values to use when Gateway API is disabled for KubeLB in f
 | external-dns.sources[5] | string | `"gateway-tcproute"` |  |
 | external-dns.sources[6] | string | `"gateway-udproute"` |  |
 | external-dns.txtOwnerId | string | `"kubelb-management"` |  |
-| gatewayClass.create | bool | `false` |  |
-| ingress-nginx | object | `{"enabled":false}` | ---------------------------------------------------------- Ingress Nginx |
+| gatewayClass | object | `{"create":false}` | ---------------------------------------------------------- |
+| global.imagePullSecrets | list | `[]` | Global image pull secrets propagated to supported addon charts. |
+| global.imageRegistry | string | `""` | Override the registry for all images (prefix replacement). When set, all supported addon images are rewritten to this registry host. |
+| ingress-nginx | object | `{"enabled":false}` | ---------------------------------------------------------- |
 | kgateway-crds.enabled | bool | `false` |  |
 | kgateway.agentgateway.enabled | bool | `false` |  |
 | kgateway.enabled | bool | `false` |  |

--- a/charts/kubelb-addons/templates/gateway-class.yaml
+++ b/charts/kubelb-addons/templates/gateway-class.yaml
@@ -1,4 +1,30 @@
 {{ if and (index .Values "envoy-gateway").enabled .Values.gatewayClass.create }}
+{{- $egValues := index .Values "envoy-gateway" -}}
+{{- $envoyProxyImage := "" -}}
+{{- if .Values.global.imageRegistry -}}
+  {{- $defaultImage := "docker.io/envoyproxy/envoy:distroless-v1.37.1" -}}
+  {{- $imageParts := splitn "/" 2 $defaultImage -}}
+  {{- $repositoryTag := $imageParts._1 -}}
+  {{- $envoyProxyImage = printf "%s/%s" (trimSuffix "/" .Values.global.imageRegistry) $repositoryTag -}}
+{{- end -}}
+{{- if $envoyProxyImage }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: kubelb-proxy-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          image: {{ $envoyProxyImage }}
+---
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
@@ -8,4 +34,11 @@ metadata:
     "helm.sh/hook-weight": "1"
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
+{{- if $envoyProxyImage }}
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: kubelb-proxy-config
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{ end }}

--- a/charts/kubelb-addons/values.yaml
+++ b/charts/kubelb-addons/values.yaml
@@ -1,3 +1,10 @@
+global:
+  # -- Override the registry for all images (prefix replacement).
+  # When set, all supported addon images are rewritten to this registry host.
+  imageRegistry: ""
+  # -- Global image pull secrets propagated to supported addon charts.
+  imagePullSecrets: []
+
 # ------------------------------------------------------------
 # Addons configuration
 # ------------------------------------------------------------
@@ -9,15 +16,12 @@ gatewayClass:
 # Upstream Addons configuration
 # ------------------------------------------------------------
 
-# Ingress Nginx
 ingress-nginx:
   enabled: false
 
-# Envoy Gateway
 envoy-gateway:
   enabled: false
 
-# Cert Manager
 cert-manager:
   enabled: false
   crds:
@@ -27,7 +31,6 @@ cert-manager:
     kind: ControllerConfiguration
     enableGatewayAPI: true
 
-# External DNS
 external-dns:
   enabled: false
   # do not allow any domain that are now below these base domains
@@ -57,8 +60,6 @@ external-dns:
     - gateway-tlsroute
     - gateway-tcproute
     - gateway-udproute
-
-# Metallb
 metallb:
   enabled: false
 

--- a/hack/build-addons-chart-deps.sh
+++ b/hack/build-addons-chart-deps.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The KubeLB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Downloads upstream addon chart dependencies, extracts each .tgz, and applies
+# air-gap patches that thread global.imageRegistry through addon templates.
+# Patches live in hack/patches/<chart-name>.patch.
+#
+# Usage:
+#   ./hack/build-addons-chart-deps.sh [chart-dir]
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+source hack/lib.sh
+
+CHART_DIR="${1:-charts/kubelb-addons}"
+CHARTS_SUBDIR="${CHART_DIR}/charts"
+PATCH_DIR="hack/patches"
+
+# GitHub release asset 500s are a recurring flake when pulling ingress-nginx
+# over the https://kubernetes.github.io/ingress-nginx → github.com redirect.
+retry 5 helm dependency build "${CHART_DIR}"
+
+for tgz in "${CHARTS_SUBDIR}"/*.tgz; do
+  [ -f "$tgz" ] || continue
+  chart_name=$(tar -tzf "$tgz" | head -1 | cut -d/ -f1 || true)
+  patch_file="${PATCH_DIR}/${chart_name}.patch"
+
+  # If a patch exists, always re-extract so it applies fresh against the
+  # pristine upstream chart. Without this, a stale dir from a prior run could
+  # silently remain unpatched.
+  if [ -d "${CHARTS_SUBDIR}/${chart_name}" ]; then
+    if [ -f "$patch_file" ]; then
+      rm -rf "${CHARTS_SUBDIR}/${chart_name}"
+    else
+      rm -f "$tgz"
+      continue
+    fi
+  fi
+
+  tar -xzf "$tgz" -C "${CHARTS_SUBDIR}"
+  rm -f "$tgz"
+
+  if [ -f "$patch_file" ]; then
+    echo "Applying patch: ${patch_file}"
+    if command -v patch > /dev/null 2>&1; then
+      patch -d "${CHARTS_SUBDIR}" -p1 < "$patch_file"
+    else
+      git apply --unsafe-paths --directory="${CHARTS_SUBDIR}" -p1 "$patch_file"
+    fi
+  fi
+done

--- a/hack/patches/cert-manager.patch
+++ b/hack/patches/cert-manager.patch
@@ -1,0 +1,128 @@
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/cert-manager/templates/_helpers.tpl b/cert-manager/templates/_helpers.tpl
+--- a/cert-manager/templates/_helpers.tpl	2026-04-16 16:54:14
++++ b/cert-manager/templates/_helpers.tpl	2026-04-16 16:54:54
+@@ -190,7 +190,7 @@
+ usage through tuple/variable indirection.
+ */ -}}
+ 
+-{{- if ne (len .) 4 -}}
++{{- if lt (len .) 4 -}}
+     {{- fail (printf "ERROR: template \"image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
+ {{- end -}}
+ 
+@@ -199,15 +199,28 @@
+ {{- $imageNamespace := index . 2 | default "" -}}
+ {{- $defaultReference := index . 3 -}}
+ 
++{{- $globalRegistry := "" -}}
++{{- if ge (len .) 5 -}}
++  {{- $root := index . 4 -}}
++  {{- if and $root.Values $root.Values.global $root.Values.global.imageRegistry -}}
++    {{- $globalRegistry = trimSuffix "/" $root.Values.global.imageRegistry -}}
++  {{- end -}}
++{{- end -}}
++
+ {{- $repository := "" -}}
+ {{- if $image.repository -}}
+     {{- $repository = $image.repository -}}
+ 
+-    {{- /*
+-        Backwards compatibility: if image.registry is set, additionally prefix the repository with this registry.
+-    */ -}}
+-    {{- if $image.registry -}}
+-        {{- $repository = printf "%s/%s" $image.registry $repository -}}
++    {{- if $globalRegistry -}}
++        {{- $parts := splitList "/" $repository -}}
++        {{- if and (gt (len $parts) 1) (or (contains "." (index $parts 0)) (contains ":" (index $parts 0))) -}}
++            {{- $repository = join "/" (slice $parts 1) -}}
++        {{- end -}}
++        {{- $repository = printf "%s/%s" $globalRegistry $repository -}}
++    {{- else -}}
++        {{- if $image.registry -}}
++            {{- $repository = printf "%s/%s" $image.registry $repository -}}
++        {{- end -}}
+     {{- end -}}
+ {{- else -}}
+     {{- $name := required "ERROR: image.name must be set when image.repository is empty" $image.name -}}
+@@ -217,15 +230,15 @@
+         {{- $repository = printf "%s/%s" $imageNamespace $repository -}}
+     {{- end -}}
+ 
+-    {{- if $imageRegistry -}}
+-        {{- $repository = printf "%s/%s" $imageRegistry $repository -}}
+-    {{- end -}}
+-
+-    {{- /*
+-        Backwards compatibility: if image.registry is set, additionally prefix the repository with this registry.
+-    */ -}}
+-    {{- if $image.registry -}}
+-        {{- $repository = printf "%s/%s" $image.registry $repository -}}
++    {{- if $globalRegistry -}}
++        {{- $repository = printf "%s/%s" $globalRegistry $repository -}}
++    {{- else -}}
++        {{- if $imageRegistry -}}
++            {{- $repository = printf "%s/%s" $imageRegistry $repository -}}
++        {{- end -}}
++        {{- if $image.registry -}}
++            {{- $repository = printf "%s/%s" $image.registry $repository -}}
++        {{- end -}}
+     {{- end -}}
+ {{- end -}}
+ 
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/cert-manager/templates/cainjector-deployment.yaml b/cert-manager/templates/cainjector-deployment.yaml
+--- a/cert-manager/templates/cainjector-deployment.yaml	2026-04-16 16:54:14
++++ b/cert-manager/templates/cainjector-deployment.yaml	2026-04-16 16:55:11
+@@ -76,7 +76,7 @@
+       {{- end }}
+       containers:
+         - name: {{ .Chart.Name }}-cainjector
+-          image: "{{ template "image" (tuple .Values.cainjector.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
++          image: "{{ template "image" (tuple .Values.cainjector.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion) $) }}"
+           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
+           args:
+           {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/cert-manager/templates/deployment.yaml b/cert-manager/templates/deployment.yaml
+--- a/cert-manager/templates/deployment.yaml	2026-04-16 16:54:14
++++ b/cert-manager/templates/deployment.yaml	2026-04-16 16:55:11
+@@ -86,7 +86,7 @@
+       {{- end }}
+       containers:
+         - name: {{ .Chart.Name }}-controller
+-          image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
++          image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion) $) }}"
+           imagePullPolicy: {{ .Values.image.pullPolicy }}
+           args:
+           {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
+@@ -114,7 +114,7 @@
+           - --leader-election-retry-period={{ .retryPeriod }}
+           {{- end }}
+           {{- end }}
+-          - --acme-http01-solver-image={{ template "image" (tuple .Values.acmesolver.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}
++          - --acme-http01-solver-image={{ template "image" (tuple .Values.acmesolver.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion) $) }}
+           {{- with .Values.extraArgs }}
+           {{- toYaml . | nindent 10 }}
+           {{- end }}
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/cert-manager/templates/startupapicheck-job.yaml b/cert-manager/templates/startupapicheck-job.yaml
+--- a/cert-manager/templates/startupapicheck-job.yaml	2026-04-16 16:54:14
++++ b/cert-manager/templates/startupapicheck-job.yaml	2026-04-16 16:55:11
+@@ -54,7 +54,7 @@
+       {{- end }}
+       containers:
+         - name: {{ .Chart.Name }}-startupapicheck
+-          image: "{{ template "image" (tuple .Values.startupapicheck.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
++          image: "{{ template "image" (tuple .Values.startupapicheck.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion) $) }}"
+           imagePullPolicy: {{ .Values.startupapicheck.image.pullPolicy }}
+           args:
+           - check
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/cert-manager/templates/webhook-deployment.yaml b/cert-manager/templates/webhook-deployment.yaml
+--- a/cert-manager/templates/webhook-deployment.yaml	2026-04-16 16:54:14
++++ b/cert-manager/templates/webhook-deployment.yaml	2026-04-16 16:55:11
+@@ -81,7 +81,7 @@
+       {{- end }}
+       containers:
+         - name: {{ .Chart.Name }}-webhook
+-          image: "{{ template "image" (tuple .Values.webhook.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
++          image: "{{ template "image" (tuple .Values.webhook.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion) $) }}"
+           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
+           args:
+           {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}

--- a/hack/patches/external-dns.patch
+++ b/hack/patches/external-dns.patch
@@ -1,0 +1,37 @@
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/external-dns/templates/_helpers.tpl b/external-dns/templates/_helpers.tpl
+--- a/external-dns/templates/_helpers.tpl	2026-01-02 20:35:00
++++ b/external-dns/templates/_helpers.tpl	2026-04-14 12:05:22
+@@ -68,7 +68,15 @@
+ The image to use
+ */}}
+ {{- define "external-dns.image" -}}
+-{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
++{{- $repository := .Values.image.repository -}}
++{{- if .Values.global.imageRegistry -}}
++  {{- $parts := splitList "/" $repository -}}
++  {{- if and (gt (len $parts) 1) (or (contains "." (index $parts 0)) (contains ":" (index $parts 0))) -}}
++    {{- $repository = join "/" (slice $parts 1) -}}
++  {{- end -}}
++  {{- $repository = printf "%s/%s" (trimSuffix "/" .Values.global.imageRegistry) $repository -}}
++{{- end -}}
++{{- printf "%s:%s" $repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+ {{- end }}
+ 
+ {{/*
+@@ -91,7 +99,15 @@
+ {{- if or (empty .repository) (empty .tag) }}
+ {{- fail "ERROR: webhook provider needs an image repository and a tag" }}
+ {{- end }}
+-{{- printf "%s:%s" .repository .tag }}
++{{- $repository := .repository -}}
++{{- if $.Values.global.imageRegistry -}}
++  {{- $parts := splitList "/" $repository -}}
++  {{- if and (gt (len $parts) 1) (or (contains "." (index $parts 0)) (contains ":" (index $parts 0))) -}}
++    {{- $repository = join "/" (slice $parts 1) -}}
++  {{- end -}}
++  {{- $repository = printf "%s/%s" (trimSuffix "/" $.Values.global.imageRegistry) $repository -}}
++{{- end -}}
++{{- printf "%s:%s" $repository .tag }}
+ {{- end }}
+ {{- end }}
+ 

--- a/hack/patches/ingress-nginx.patch
+++ b/hack/patches/ingress-nginx.patch
@@ -1,0 +1,151 @@
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/ingress-nginx/templates/_helpers.tpl b/ingress-nginx/templates/_helpers.tpl
+--- a/ingress-nginx/templates/_helpers.tpl	2026-03-10 01:29:38
++++ b/ingress-nginx/templates/_helpers.tpl	2026-04-14 12:05:22
+@@ -94,6 +94,29 @@
+ {{- end -}}
+ 
+ {{/*
++Rewrite an image to the configured global mirror registry.
++*/}}
++{{- define "ingress-nginx.imageRef" -}}
++{{- $path := "" -}}
++{{- if .repository -}}
++  {{- $path = .repository -}}
++{{- else -}}
++  {{- $path = printf "%s/%s" .registry .image -}}
++{{- end -}}
++{{- if .globalRegistry -}}
++  {{- $parts := splitList "/" $path -}}
++  {{- if and (gt (len $parts) 1) (or (contains "." (index $parts 0)) (contains ":" (index $parts 0))) -}}
++    {{- $path = join "/" (slice $parts 1) -}}
++  {{- end -}}
++  {{- $path = printf "%s/%s" (trimSuffix "/" .globalRegistry) $path -}}
++{{- end -}}
++{{- printf "%s:%s" $path .tag -}}
++{{- if .digest -}}
++  {{- printf "@%s" .digest -}}
++{{- end -}}
++{{- end -}}
++
++{{/*
+ Create a default fully qualified controller name.
+ We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+ */}}
+@@ -241,7 +264,7 @@
+ {{- define "extraModules" -}}
+ - name: {{ .name }}
+   {{- with .image }}
+-  image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{ end }}:{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}
++  image: {{ include "ingress-nginx.imageRef" (dict "repository" .repository "registry" .registry "image" .image "tag" .tag "digest" .digest "globalRegistry" $.Values.global.imageRegistry) }}
+   command:
+   {{- if .distroless }}
+     - /init_module
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml b/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+--- a/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml	2026-03-10 01:29:38
++++ b/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml	2026-04-14 12:05:22
+@@ -40,13 +40,13 @@
+     {{- if .Values.controller.admissionWebhooks.patch.runtimeClassName }}
+       runtimeClassName: {{ .Values.controller.admissionWebhooks.patch.runtimeClassName | quote }}
+     {{- end }}
+-    {{- if .Values.imagePullSecrets }}
+-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
++    {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
++      imagePullSecrets: {{ toYaml . | nindent 8 }}
+     {{- end }}
+       containers:
+         - name: create
+           {{- with (merge .Values.controller.admissionWebhooks.patch.image .Values.global.image) }}
+-          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{ end }}:{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}
++          image: {{ include "ingress-nginx.imageRef" (dict "repository" .repository "registry" .registry "image" .image "tag" .tag "digest" .digest "globalRegistry" $.Values.global.imageRegistry) }}
+           {{- end }}
+           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
+           args:
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml b/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+--- a/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml	2026-03-10 01:29:38
++++ b/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml	2026-04-14 12:05:22
+@@ -40,13 +40,13 @@
+     {{- if .Values.controller.admissionWebhooks.patch.runtimeClassName }}
+       runtimeClassName: {{ .Values.controller.admissionWebhooks.patch.runtimeClassName | quote }}
+     {{- end }}
+-    {{- if .Values.imagePullSecrets }}
+-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
++    {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
++      imagePullSecrets: {{ toYaml . | nindent 8 }}
+     {{- end }}
+       containers:
+         - name: patch
+           {{- with (merge .Values.controller.admissionWebhooks.patch.image .Values.global.image) }}
+-          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{ end }}:{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}
++          image: {{ include "ingress-nginx.imageRef" (dict "repository" .repository "registry" .registry "image" .image "tag" .tag "digest" .digest "globalRegistry" $.Values.global.imageRegistry) }}
+           {{- end }}
+           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
+           args:
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/ingress-nginx/templates/controller-daemonset.yaml b/ingress-nginx/templates/controller-daemonset.yaml
+--- a/ingress-nginx/templates/controller-daemonset.yaml	2026-03-10 01:29:38
++++ b/ingress-nginx/templates/controller-daemonset.yaml	2026-04-14 12:05:22
+@@ -51,8 +51,8 @@
+       hostname: {{ toYaml .Values.controller.hostname | nindent 8 }}
+     {{- end }}
+       dnsPolicy: {{ .Values.controller.dnsPolicy }}
+-    {{- if .Values.imagePullSecrets }}
+-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
++    {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
++      imagePullSecrets: {{ toYaml . | nindent 8 }}
+     {{- end }}
+     {{- if .Values.controller.priorityClassName }}
+       priorityClassName: {{ .Values.controller.priorityClassName | quote }}
+@@ -79,7 +79,7 @@
+       containers:
+         - name: {{ .Values.controller.containerName }}
+           {{- with (merge .Values.controller.image .Values.global.image) }}
+-          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ include "ingress-nginx.image" . }}{{ end }}:{{ .tag }}{{ include "ingress-nginx.imageDigest" . }}
++          image: {{ include "ingress-nginx.imageRef" (dict "repository" .repository "registry" .registry "image" (include "ingress-nginx.image" .) "tag" .tag "digest" (trimPrefix "@" (include "ingress-nginx.imageDigest" .)) "globalRegistry" $.Values.global.imageRegistry) }}
+           {{- end }}
+           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+         {{- if .Values.controller.lifecycle }}
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/ingress-nginx/templates/controller-deployment.yaml b/ingress-nginx/templates/controller-deployment.yaml
+--- a/ingress-nginx/templates/controller-deployment.yaml	2026-03-10 01:29:38
++++ b/ingress-nginx/templates/controller-deployment.yaml	2026-04-14 12:05:22
+@@ -57,8 +57,8 @@
+       hostname: {{ toYaml .Values.controller.hostname | nindent 8 }}
+     {{- end }}
+       dnsPolicy: {{ .Values.controller.dnsPolicy }}
+-    {{- if .Values.imagePullSecrets }}
+-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
++    {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
++      imagePullSecrets: {{ toYaml . | nindent 8 }}
+     {{- end }}
+     {{- if .Values.controller.priorityClassName }}
+       priorityClassName: {{ .Values.controller.priorityClassName | quote }}
+@@ -85,7 +85,7 @@
+       containers:
+         - name: {{ .Values.controller.containerName }}
+           {{- with (merge .Values.controller.image .Values.global.image) }}
+-          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ include "ingress-nginx.image" . }}{{ end }}:{{ .tag }}{{ include "ingress-nginx.imageDigest" . }}
++          image: {{ include "ingress-nginx.imageRef" (dict "repository" .repository "registry" .registry "image" (include "ingress-nginx.image" .) "tag" .tag "digest" (trimPrefix "@" (include "ingress-nginx.imageDigest" .)) "globalRegistry" $.Values.global.imageRegistry) }}
+           {{- end }}
+           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+         {{- if .Values.controller.lifecycle }}
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/ingress-nginx/templates/default-backend-deployment.yaml b/ingress-nginx/templates/default-backend-deployment.yaml
+--- a/ingress-nginx/templates/default-backend-deployment.yaml	2026-03-10 01:29:38
++++ b/ingress-nginx/templates/default-backend-deployment.yaml	2026-04-14 12:05:22
+@@ -39,8 +39,8 @@
+         {{- toYaml .Values.defaultBackend.podLabels | nindent 8 }}
+       {{- end }}
+     spec:
+-    {{- if .Values.imagePullSecrets }}
+-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
++    {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
++      imagePullSecrets: {{ toYaml . | nindent 8 }}
+     {{- end }}
+     {{- if .Values.defaultBackend.priorityClassName }}
+       priorityClassName: {{ .Values.defaultBackend.priorityClassName }}
+@@ -54,7 +54,7 @@
+       containers:
+         - name: {{ template "ingress-nginx.name" . }}-default-backend
+           {{- with (merge .Values.defaultBackend.image .Values.global.image) }}
+-          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{ end }}:{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}
++          image: {{ include "ingress-nginx.imageRef" (dict "repository" .repository "registry" .registry "image" .image "tag" .tag "digest" .digest "globalRegistry" $.Values.global.imageRegistry) }}
+           {{- end }}
+           imagePullPolicy: {{ .Values.defaultBackend.image.pullPolicy }}
+         {{- if .Values.defaultBackend.extraArgs }}

--- a/hack/patches/kgateway.patch
+++ b/hack/patches/kgateway.patch
@@ -1,0 +1,58 @@
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/kgateway/templates/_helpers.tpl b/kgateway/templates/_helpers.tpl
+--- a/kgateway/templates/_helpers.tpl	2026-04-16 16:54:14
++++ b/kgateway/templates/_helpers.tpl	2026-04-16 16:55:38
+@@ -74,3 +74,24 @@
+ {{- printf "ERROR: Invalid validation.level '%s'. Must be 'standard' or 'strict' (case-insensitive). Current value: '%s'" $level .Values.validation.level | fail -}}
+ {{- end -}}
+ {{- end }}
++
++{{/*
++Resolve the mirrored image registry path for kgateway-managed images.
++*/}}
++{{- define "kgateway.imageRegistry" -}}
++{{- $registry := .Values.controller.image.registry | default .Values.image.registry -}}
++{{- if .Values.global.imageRegistry -}}
++  {{- $path := $registry -}}
++  {{- $parts := splitList "/" $path -}}
++  {{- if and (gt (len $parts) 1) (or (contains "." (index $parts 0)) (contains ":" (index $parts 0))) -}}
++    {{- $path = join "/" (slice $parts 1) -}}
++  {{- end -}}
++  {{- if $path -}}
++    {{- printf "%s/%s" (trimSuffix "/" .Values.global.imageRegistry) $path -}}
++  {{- else -}}
++    {{- trimSuffix "/" .Values.global.imageRegistry -}}
++  {{- end -}}
++{{- else -}}
++  {{- $registry -}}
++{{- end -}}
++{{- end }}
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/kgateway/templates/deployment.yaml b/kgateway/templates/deployment.yaml
+--- a/kgateway/templates/deployment.yaml	2026-04-16 16:54:14
++++ b/kgateway/templates/deployment.yaml	2026-04-16 16:55:25
+@@ -27,7 +27,7 @@
+       labels:
+         {{- include "kgateway.selectorLabels" . | nindent 8 }}
+     spec:
+-      {{- with .Values.imagePullSecrets }}
++      {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
+       imagePullSecrets:
+         {{- toYaml . | nindent 8 }}
+       {{- end }}
+@@ -42,7 +42,7 @@
+           securityContext:
+             {{- toYaml . | nindent 12 }}
+           {{- end }}
+-          image: "{{ .Values.controller.image.registry | default .Values.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
++          image: "{{ include "kgateway.imageRegistry" . }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+           imagePullPolicy: {{ .Values.controller.image.pullPolicy | default .Values.image.pullPolicy }}
+           ports:
+             - containerPort: {{ .Values.controller.service.ports.grpc }}
+@@ -86,7 +86,7 @@
+             - name: KGW_XDS_SERVICE_PORT
+               value: {{ .Values.controller.service.ports.grpc | quote }}
+             - name: KGW_DEFAULT_IMAGE_REGISTRY
+-              value: {{ .Values.image.registry }}
++              value: {{ include "kgateway.imageRegistry" . | quote }}
+             - name: KGW_DEFAULT_IMAGE_TAG
+               value: {{ .Values.image.tag | default .Chart.AppVersion }}
+             - name: KGW_DEFAULT_IMAGE_PULL_POLICY

--- a/hack/patches/metallb.patch
+++ b/hack/patches/metallb.patch
@@ -1,0 +1,295 @@
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8s/templates/_helpers.tpl b/metallb/charts/frr-k8s/templates/_helpers.tpl
+--- a/metallb/charts/frr-k8s/templates/_helpers.tpl	2025-12-04 20:20:55
++++ b/metallb/charts/frr-k8s/templates/_helpers.tpl	2026-04-14 12:05:23
+@@ -61,3 +61,18 @@
+ {{- default "default" .Values.frrk8s.serviceAccount.name }}
+ {{- end }}
+ {{- end }}
++
++{{/*
++Rewrite a repository to the configured global mirror registry.
++*/}}
++{{- define "frrk8s.imageRepository" -}}
++{{- $repository := .repository -}}
++{{- if .context.Values.global.imageRegistry -}}
++  {{- $parts := splitList "/" $repository -}}
++  {{- if and (gt (len $parts) 1) (or (contains "." (index $parts 0)) (contains ":" (index $parts 0))) -}}
++    {{- $repository = join "/" (slice $parts 1) -}}
++  {{- end -}}
++  {{- $repository = printf "%s/%s" (trimSuffix "/" .context.Values.global.imageRegistry) $repository -}}
++{{- end -}}
++{{- $repository -}}
++{{- end }}
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8s/templates/controller.yaml b/metallb/charts/frr-k8s/templates/controller.yaml
+--- a/metallb/charts/frr-k8s/templates/controller.yaml	2025-12-04 20:20:55
++++ b/metallb/charts/frr-k8s/templates/controller.yaml	2026-04-14 12:05:23
+@@ -132,7 +132,7 @@
+       {{- if .Values.frrk8s.runtimeClassName }}
+       runtimeClassName: {{ .Values.frrk8s.runtimeClassName }}
+       {{- end }}
+-      {{- with .Values.imagePullSecrets }}
++      {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
+       imagePullSecrets:
+         {{- toYaml . | nindent 8 }}
+       {{- end }}
+@@ -161,7 +161,7 @@
+       initContainers:
+         # Copies the initial config files with the right permissions to the shared volume.
+         - name: cp-frr-files
+-          image: {{ .Values.frrk8s.frr.image.repository }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
++          image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.frr.image.repository "context" .) }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
+           securityContext:
+             runAsUser: 100
+             runAsGroup: 101
+@@ -173,20 +173,20 @@
+               mountPath: /etc/frr
+         # Copies the reloader to the shared volume between the speaker and reloader.
+         - name: cp-reloader
+-          image: {{ .Values.frrk8s.image.repository }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
++          image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.image.repository "context" .) }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
+           command: ["/bin/sh", "-c", "cp -f /frr-reloader.sh /etc/frr_reloader/"]
+           volumeMounts:
+             - name: reloader
+               mountPath: /etc/frr_reloader
+         # Copies the metrics exporter
+         - name: cp-metrics
+-          image: {{ .Values.frrk8s.image.repository }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
++          image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.image.repository "context" .) }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
+           command: ["/bin/sh", "-c", "cp -f /frr-metrics /etc/frr_metrics/"]
+           volumeMounts:
+             - name: metrics
+               mountPath: /etc/frr_metrics
+         - name: cp-frr-status
+-          image: {{ .Values.frrk8s.image.repository }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
++          image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.image.repository "context" .) }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
+           command: ["/bin/sh", "-c", "cp -f /frr-status /etc/frr_status/"]
+           volumeMounts:
+             - name: frr-status
+@@ -194,7 +194,7 @@
+       shareProcessNamespace: true
+       containers:
+       - name: controller
+-        image: {{ .Values.frrk8s.image.repository }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
++        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.image.repository "context" .) }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
+         {{- if .Values.frrk8s.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.frrk8s.image.pullPolicy }}
+         {{- end }}
+@@ -273,7 +273,7 @@
+             - NET_RAW
+             - SYS_ADMIN
+             - NET_BIND_SERVICE
+-        image: {{ .Values.frrk8s.frr.image.repository }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
++        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.frr.image.repository "context" .) }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
+         {{- if .Values.frrk8s.frr.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.frrk8s.frr.image.pullPolicy }}
+         {{- end }}
+@@ -322,7 +322,7 @@
+           periodSeconds: {{ .Values.frrk8s.startupProbe.periodSeconds }}
+         {{- end }}
+       - name: reloader
+-        image: {{ .Values.frrk8s.frr.image.repository }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
++        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.frr.image.repository "context" .) }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
+         {{- if .Values.frrk8s.frr.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.frrk8s.frr.image.pullPolicy }}
+         {{- end }}
+@@ -339,7 +339,7 @@
+           {{- toYaml . | nindent 12 }}
+         {{- end }}
+       - name: frr-metrics
+-        image: {{ .Values.frrk8s.frr.image.repository }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
++        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.frr.image.repository "context" .) }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
+         command: ["/etc/frr_metrics/frr-metrics"]
+         args:
+           - --metrics-port={{ .Values.frrk8s.frr.metricsPort }}
+@@ -381,7 +381,7 @@
+             valueFrom:
+               fieldRef:
+                 fieldPath: metadata.name
+-        image: {{ .Values.frrk8s.frr.image.repository }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
++        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.frr.image.repository "context" .) }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
+         volumeMounts:
+           - mountPath: /var/run/frr
+             name: frr-sockets
+@@ -394,7 +394,7 @@
+           {{- toYaml . | nindent 12 }}
+         {{- end }}
+       - name: kube-rbac-proxy
+-        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
++        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag }}
+         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
+         args:
+           - --logtostderr
+@@ -420,7 +420,7 @@
+             readOnly: true
+         {{- end }}
+       - name: kube-rbac-proxy-frr
+-        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
++        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
+         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
+         args:
+           - --logtostderr
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8s/templates/status-cleaner.yaml b/metallb/charts/frr-k8s/templates/status-cleaner.yaml
+--- a/metallb/charts/frr-k8s/templates/status-cleaner.yaml	2025-12-04 20:20:55
++++ b/metallb/charts/frr-k8s/templates/status-cleaner.yaml	2026-04-14 12:05:23
+@@ -23,7 +23,7 @@
+       {{- if .Values.frrk8s.runtimeClassName }}
+       runtimeClassName: {{ .Values.frrk8s.runtimeClassName }}
+       {{- end }}
+-      {{- with .Values.imagePullSecrets }}
++      {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
+       imagePullSecrets:
+         {{- toYaml . | nindent 8 }}
+       {{- end }}
+@@ -47,7 +47,7 @@
+           valueFrom:
+             fieldRef:
+               fieldPath: metadata.namespace
+-        image: {{ .Values.frrk8s.image.repository }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
++        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.image.repository "context" .) }}:{{ .Values.frrk8s.image.tag | default .Chart.AppVersion }}
+         {{- if .Values.frrk8s.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.frrk8s.image.pullPolicy }}
+         {{- end }}
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/_helpers.tpl b/metallb/templates/_helpers.tpl
+--- a/metallb/templates/_helpers.tpl	2025-12-04 20:20:55
++++ b/metallb/templates/_helpers.tpl	2026-04-14 12:05:23
+@@ -112,3 +112,17 @@
+ {{- end }}
+ {{- end }}
+ 
++{{/*
++Rewrite a repository to the configured global mirror registry.
++*/}}
++{{- define "metallb.imageRepository" -}}
++{{- $repository := .repository -}}
++{{- if .context.Values.global.imageRegistry -}}
++  {{- $parts := splitList "/" $repository -}}
++  {{- if and (gt (len $parts) 1) (or (contains "." (index $parts 0)) (contains ":" (index $parts 0))) -}}
++    {{- $repository = join "/" (slice $parts 1) -}}
++  {{- end -}}
++  {{- $repository = printf "%s/%s" (trimSuffix "/" .context.Values.global.imageRegistry) $repository -}}
++{{- end -}}
++{{- $repository -}}
++{{- end }}
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/controller.yaml b/metallb/templates/controller.yaml
+--- a/metallb/templates/controller.yaml	2025-12-04 20:20:55
++++ b/metallb/templates/controller.yaml	2026-04-14 12:05:23
+@@ -40,7 +40,7 @@
+       {{- with .Values.controller.runtimeClassName }}
+       runtimeClassName: {{ . | quote }}
+       {{- end }}
+-      {{- with .Values.imagePullSecrets }}
++      {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
+       imagePullSecrets:
+         {{- toYaml . | nindent 8 }}
+       {{- end }}
+@@ -52,7 +52,7 @@
+ {{- end }}
+       containers:
+       - name: controller
+-        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}
++        image: {{ include "metallb.imageRepository" (dict "repository" .Values.controller.image.repository "context" .) }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}
+         {{- if .Values.controller.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+         {{- end }}
+@@ -138,7 +138,7 @@
+             - ALL
+       {{- if .Values.prometheus.secureMetricsPort }}
+       - name: kube-rbac-proxy
+-        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
++        image: {{ include "metallb.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag }}
+         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
+         securityContext:
+           readOnlyRootFilesystem: true
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/speaker.yaml b/metallb/templates/speaker.yaml
+--- a/metallb/templates/speaker.yaml	2025-12-04 20:20:55
++++ b/metallb/templates/speaker.yaml	2026-04-14 12:05:23
+@@ -162,7 +162,7 @@
+       {{- if .Values.speaker.runtimeClassName }}
+       runtimeClassName: {{ .Values.speaker.runtimeClassName }}
+       {{- end }}
+-      {{- with .Values.imagePullSecrets }}
++      {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
+       imagePullSecrets:
+         {{- toYaml . | nindent 8 }}
+       {{- end }}
+@@ -212,7 +212,7 @@
+       initContainers:
+         # Copies the initial config files with the right permissions to the shared volume.
+         - name: cp-frr-files
+-          image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
++          image: {{ include "metallb.imageRepository" (dict "repository" .Values.speaker.frr.image.repository "context" .) }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+           securityContext:
+             runAsUser: 100
+             runAsGroup: 101
+@@ -228,7 +228,7 @@
+           {{- end }}
+         # Copies the reloader to the shared volume between the speaker and reloader.
+         - name: cp-reloader
+-          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
++          image: {{ include "metallb.imageRepository" (dict "repository" .Values.speaker.image.repository "context" .) }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
+           command: ["/cp-tool","/frr-reloader.sh","/etc/frr_reloader/frr-reloader.sh"]
+           volumeMounts:
+             - name: reloader
+@@ -239,7 +239,7 @@
+           {{- end }}
+         # Copies the metrics exporter
+         - name: cp-metrics
+-          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
++          image: {{ include "metallb.imageRepository" (dict "repository" .Values.speaker.image.repository "context" .) }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
+           command: ["/cp-tool","/frr-metrics","/etc/frr_metrics/frr-metrics"]
+           volumeMounts:
+             - name: metrics
+@@ -252,7 +252,7 @@
+       {{- end }}
+       containers:
+       - name: speaker
+-        image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
++        image: {{ include "metallb.imageRepository" (dict "repository" .Values.speaker.image.repository "context" .) }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
+         {{- if .Values.speaker.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
+         {{- end }}
+@@ -399,7 +399,7 @@
+             - NET_RAW
+             - SYS_ADMIN
+             - NET_BIND_SERVICE
+-        image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
++        image: {{ include "metallb.imageRepository" (dict "repository" .Values.speaker.frr.image.repository "context" .) }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+         {{- if .Values.speaker.frr.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
+         {{- end }}
+@@ -459,7 +459,7 @@
+           periodSeconds: {{ .Values.speaker.startupProbe.periodSeconds }}
+         {{- end }}
+       - name: reloader
+-        image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
++        image: {{ include "metallb.imageRepository" (dict "repository" .Values.speaker.frr.image.repository "context" .) }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+         {{- if .Values.speaker.frr.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
+         {{- end }}
+@@ -481,7 +481,7 @@
+           {{- toYaml . | nindent 12 }}
+         {{- end }}
+       - name: frr-metrics
+-        image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
++        image: {{ include "metallb.imageRepository" (dict "repository" .Values.speaker.frr.image.repository "context" .) }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+         securityContext:
+           readOnlyRootFilesystem: true
+           allowPrivilegeEscalation: false
+@@ -511,7 +511,7 @@
+       {{- end }}
+       {{- if .Values.prometheus.secureMetricsPort }}
+       - name: kube-rbac-proxy
+-        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
++        image: {{ include "metallb.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag }}
+         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
+         securityContext:
+           readOnlyRootFilesystem: true
+@@ -543,7 +543,7 @@
+       {{- if .Values.speaker.frr.enabled }}
+       {{- if .Values.speaker.frr.secureMetricsPort }}
+       - name: kube-rbac-proxy-frr
+-        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
++        image: {{ include "metallb.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
+         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
+         securityContext:
+           readOnlyRootFilesystem: true

--- a/hack/release-helm-charts.sh
+++ b/hack/release-helm-charts.sh
@@ -78,7 +78,7 @@ if [ "$RELEASE_ADDONS_ONLY" = "true" ]; then
 
   echodate "Packaging helm chart ${CHART_PACKAGE_ADDONS}"
 
-  helm dependency build charts/${ADDONS}
+  ./hack/build-addons-chart-deps.sh charts/${ADDONS}
   helm package charts/${ADDONS} --version ${CHART_VERSION} --destination ./
 
   echodate "Publishing helm chart to OCI registry ${REGISTRY_HOST}/${REPOSITORY_PREFIX}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the public `kubelb-addons` chart honor `global.imageRegistry`, so all transitive container images (cert-manager, external-dns, ingress-nginx, metallb, kgateway, envoy-gateway) can be prefix-rewritten to a mirror registry at `helm install` time.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
