### PR TITLE
Force TCP listener for ingress ssl-passthrough

### DIFF
--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -610,13 +610,18 @@ func makeRouteListener(key string, listenerPort uint32, protocol corev1.Protocol
 // the backend untouched (the HTTP Connection Manager would otherwise
 // interpret the TLS ClientHello as HTTP and break the handshake).
 //
-// The only signal we trust is the nginx ingress backend-protocol annotation
-// on an Ingress resource: it is the explicit user intent that nginx will
-// open a TLS connection to the upstream. appProtocol, port name and port
-// number are intentionally NOT used — they are informational and do not
-// change wire behavior, so trusting them would silently strip L7 features
-// from routes whose backends only happen to live on port 443 / be named
-// "https".
+// The only signals we trust are nginx ingress annotations on an Ingress
+// resource that encode explicit user intent for nginx to open a TLS
+// connection to the upstream:
+//   - backend-protocol: HTTPS / GRPCS — nginx terminates client TLS and
+//     re-encrypts to the backend.
+//   - ssl-passthrough: "true" — nginx forwards the client TLS stream
+//     directly to the backend without terminating it.
+//
+// appProtocol, port name and port number are intentionally NOT used — they
+// are informational and do not change wire behavior, so trusting them would
+// silently strip L7 features from routes whose backends only happen to live
+// on port 443 / be named "https".
 func isTLSBackend(route *kubelbv1alpha1.Route) bool {
 	if route == nil || route.Spec.Source.Kubernetes == nil {
 		return false
@@ -624,11 +629,12 @@ func isTLSBackend(route *kubelbv1alpha1.Route) bool {
 	if getRouteKind(route) != "Ingress" {
 		return false
 	}
-	switch strings.ToUpper(route.Spec.Source.Kubernetes.Route.GetAnnotations()["nginx.ingress.kubernetes.io/backend-protocol"]) {
+	annotations := route.Spec.Source.Kubernetes.Route.GetAnnotations()
+	switch strings.ToUpper(annotations["nginx.ingress.kubernetes.io/backend-protocol"]) {
 	case "HTTPS", "GRPCS":
 		return true
 	}
-	return false
+	return strings.EqualFold(annotations["nginx.ingress.kubernetes.io/ssl-passthrough"], "true")
 }
 
 func getRouteKind(route *kubelbv1alpha1.Route) string {

--- a/internal/envoy/resource_test.go
+++ b/internal/envoy/resource_test.go
@@ -113,8 +113,33 @@ func TestIsTLSBackend(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "ingress ssl-passthrough true",
+			route: routeOfKind("Ingress", map[string]string{"nginx.ingress.kubernetes.io/ssl-passthrough": "true"}),
+			want:  true,
+		},
+		{
+			name:  "ingress ssl-passthrough True mixed case",
+			route: routeOfKind("Ingress", map[string]string{"nginx.ingress.kubernetes.io/ssl-passthrough": "True"}),
+			want:  true,
+		},
+		{
+			name:  "ingress ssl-passthrough false",
+			route: routeOfKind("Ingress", map[string]string{"nginx.ingress.kubernetes.io/ssl-passthrough": "false"}),
+			want:  false,
+		},
+		{
+			name:  "ingress ssl-passthrough true overrides missing backend-protocol",
+			route: routeOfKind("Ingress", map[string]string{"nginx.ingress.kubernetes.io/ssl-passthrough": "true", "nginx.ingress.kubernetes.io/backend-protocol": "HTTP"}),
+			want:  true,
+		},
+		{
 			name:  "httproute with backend-protocol HTTPS annotation is ignored",
 			route: routeOfKind("HTTPRoute", map[string]string{"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"}),
+			want:  false,
+		},
+		{
+			name:  "httproute with ssl-passthrough annotation is ignored",
+			route: routeOfKind("HTTPRoute", map[string]string{"nginx.ingress.kubernetes.io/ssl-passthrough": "true"}),
 			want:  false,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix 502/TLS handshake failures for Ingress resources annotated with `nginx.ingress.kubernetes.io/ssl-passthrough: "true"`. Such ingresses now get a raw TCP passthrough listener so the client TLS stream reaches the backend untouched, without requiring `backend-protocol: HTTPS` as a workaround. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where HTTP listener were being used for Ingresses annotated with `nginx.ingress.kubernetes.io/ssl-passthrough: "true"` and causing TLS handshake failures
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
