### PR TITLE
[release/v1.3] fix port allocator and LB status bugs (#409)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ test/e2e/reports/*
 .claude
 prd.md
 claude-plan.md
+docs/plans
+ai/

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -16,6 +16,7 @@ Metrics exposed by the KubeLB Manager component (kubelb-manager).
 
 | Metric | Type | Description | Labels |
 |--------|------|-------------|--------|
+| `kubelb_manager_envoy_duplicate_listeners_dropped_total` | Counter | Total number of listeners dropped from the Envoy snapshot due to duplicate bind addresses | `snapshot_name` |
 | `kubelb_manager_envoy_proxies` | Gauge | Current number of Envoy proxy deployments | `namespace`, `topology` |
 | `kubelb_manager_envoycp_clusters` | Gauge | Current number of clusters in the Envoy snapshot | `snapshot_name` |
 | `kubelb_manager_envoycp_endpoints` | Gauge | Current number of endpoints in the Envoy snapshot | `snapshot_name` |
@@ -27,6 +28,7 @@ Metrics exposed by the KubeLB Manager component (kubelb-manager).
 | `kubelb_manager_loadbalancer_reconcile_total` | Counter | Total number of LoadBalancer reconciliation attempts | `namespace`, `result` |
 | `kubelb_manager_loadbalancers` | Gauge | Current number of LoadBalancer resources | `namespace`, `tenant`, `topology` |
 | `kubelb_manager_port_allocator_allocated_ports` | Gauge | Current number of allocated ports in the port allocator | - |
+| `kubelb_manager_port_allocator_collisions_healed_total` | Counter | Total number of duplicate port assignments detected and cleared by the port allocator on load | - |
 | `kubelb_manager_port_allocator_endpoints` | Gauge | Current number of endpoints tracked by the port allocator | - |
 | `kubelb_manager_route_reconcile_duration_seconds` | Histogram | Duration of Route reconciliations in seconds | `namespace` |
 | `kubelb_manager_route_reconcile_total` | Counter | Total number of Route reconciliation attempts | `namespace`, `route_type`, `result` |

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/gomega v1.39.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	go.uber.org/zap v1.27.1
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
@@ -73,7 +74,6 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -142,7 +142,7 @@ func (r *EnvoyCPReconciler) reconcile(ctx context.Context, req ctrl.Request) err
 func (r *EnvoyCPReconciler) updateCache(ctx context.Context, snapshotName string, lbs []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route) error {
 	log := ctrl.LoggerFrom(ctx)
 	snapshotStart := time.Now()
-	desiredSnapshot, err := envoycp.MapSnapshot(ctx, r.Client, lbs, routes, r.PortAllocator)
+	desiredSnapshot, err := envoycp.MapSnapshot(ctx, r.Client, lbs, routes, r.PortAllocator, snapshotName)
 	envoycpmetrics.SnapshotGenerationDuration.WithLabelValues(snapshotName).Observe(time.Since(snapshotStart).Seconds())
 	if err != nil {
 		return err

--- a/internal/controllers/kubelb/loadbalancer_controller.go
+++ b/internal/controllers/kubelb/loadbalancer_controller.go
@@ -25,6 +25,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 	utils "k8c.io/kubelb/internal/controllers"
 	"k8c.io/kubelb/internal/kubelb"
@@ -426,15 +428,7 @@ func (r *LoadBalancerReconciler) updateLoadBalancerStatus(ctx context.Context, l
 		return nil
 	}
 
-	updatedPorts := []kubelbv1alpha1.ServicePort{}
-	for i, port := range service.Spec.Ports {
-		targetPort := loadBalancer.Spec.Endpoints[0].Ports[i].Port
-		updatedPorts = append(updatedPorts, kubelbv1alpha1.ServicePort{
-			ServicePort: port,
-			// In case of global topology, this will be different from the targetPort. Otherwise it will be the same.
-			UpstreamTargetPort: targetPort,
-		})
-	}
+	updatedPorts := buildServicePortStatus(log, service.Spec.Ports, loadBalancer.Spec.Endpoints[0].Ports)
 
 	// Create the updated status
 	updatedLoadBalancerStatus := kubelbv1alpha1.LoadBalancerStatus{
@@ -498,6 +492,36 @@ func (r *LoadBalancerReconciler) updateLoadBalancerStatus(ctx context.Context, l
 		// update the status
 		return r.Status().Patch(ctx, lb, ctrlruntimeclient.MergeFrom(original))
 	})
+}
+
+// buildServicePortStatus pairs the generated Service's ports with the LoadBalancer's
+// endpoint ports by Name+Protocol. CreateServicePorts sorts service.Spec.Ports
+// alphabetically by Name while Spec.Endpoints[0].Ports retain user-provided order;
+// a parallel index-based pairing would scramble UpstreamTargetPort against Name for
+// multi-port LBs and prevent PortAllocator.LoadState from matching on restart.
+func buildServicePortStatus(log logr.Logger, svcPorts []corev1.ServicePort, endpointPorts []kubelbv1alpha1.EndpointPort) []kubelbv1alpha1.ServicePort {
+	updated := make([]kubelbv1alpha1.ServicePort, 0, len(svcPorts))
+	for _, svcPort := range svcPorts {
+		var targetPort int32
+		matched := false
+		for _, epPort := range endpointPorts {
+			if epPort.Name == svcPort.Name && epPort.Protocol == svcPort.Protocol {
+				targetPort = epPort.Port
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			log.Info("no endpoint port matches service port; UpstreamTargetPort will be zero",
+				"portName", svcPort.Name, "port", svcPort.Port, "protocol", svcPort.Protocol,
+				"svcPortCount", len(svcPorts), "endpointPortCount", len(endpointPorts))
+		}
+		updated = append(updated, kubelbv1alpha1.ServicePort{
+			ServicePort:        svcPort,
+			UpstreamTargetPort: targetPort,
+		})
+	}
+	return updated
 }
 
 func (r *LoadBalancerReconciler) cleanup(ctx context.Context, lb kubelbv1alpha1.LoadBalancer, resourceNamespace string) error {

--- a/internal/controllers/kubelb/loadbalancer_controller_test.go
+++ b/internal/controllers/kubelb/loadbalancer_controller_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Lb deployment and service creation", func() {
 				snapshot, err := envoyServer.Cache.GetSnapshot(snapshotName)
 				Expect(err).ToNot(HaveOccurred())
 
-				testSnapshot, err := envoycp.MapSnapshot(ctx, k8sClient, getLoadBalancerList(*lb), nil, ecpr.PortAllocator)
+				testSnapshot, err := envoycp.MapSnapshot(ctx, k8sClient, getLoadBalancerList(*lb), nil, ecpr.PortAllocator, "test-snapshot")
 				Expect(err).ToNot(HaveOccurred())
 				diff := deep.Equal(snapshot, testSnapshot)
 				if len(diff) > 0 {
@@ -187,7 +187,7 @@ var _ = Describe("Lb deployment and service creation", func() {
 				snapshot, err := envoyServer.Cache.GetSnapshot(snapshotName)
 				Expect(err).ToNot(HaveOccurred())
 
-				testSnapshot, err := envoycp.MapSnapshot(ctx, k8sClient, getLoadBalancerList(*existingLb), nil, ecpr.PortAllocator)
+				testSnapshot, err := envoycp.MapSnapshot(ctx, k8sClient, getLoadBalancerList(*existingLb), nil, ecpr.PortAllocator, "test-snapshot")
 				Expect(err).ToNot(HaveOccurred())
 				diff := deep.Equal(snapshot, testSnapshot)
 				if len(diff) > 0 {

--- a/internal/controllers/kubelb/loadbalancer_status_test.go
+++ b/internal/controllers/kubelb/loadbalancer_status_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelb
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// TestBuildServicePortStatus_SortedVsUnsortedNames is the regression test for
+// the multi-port index-mismatch bug. Service ports are sorted alphabetically
+// by Name (CreateServicePorts), but LoadBalancer endpoint ports are not.
+// Pairing by index scrambled UpstreamTargetPort against Name, breaking
+// LoadState match on manager restart.
+func TestBuildServicePortStatus_SortedVsUnsortedNames(t *testing.T) {
+	svcPorts := []corev1.ServicePort{
+		{Name: "a", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(10001)},
+		{Name: "b", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(10002)},
+		{Name: "c", Port: 8080, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(10003)},
+	}
+	endpointPorts := []kubelbv1alpha1.EndpointPort{
+		{Name: "c", Port: 30003, Protocol: corev1.ProtocolTCP},
+		{Name: "a", Port: 30001, Protocol: corev1.ProtocolTCP},
+		{Name: "b", Port: 30002, Protocol: corev1.ProtocolTCP},
+	}
+
+	out := buildServicePortStatus(logr.Discard(), svcPorts, endpointPorts)
+
+	if got, want := len(out), len(svcPorts); got != want {
+		t.Fatalf("got %d entries, want %d", got, want)
+	}
+	wantUpstream := map[string]int32{"a": 30001, "b": 30002, "c": 30003}
+	for _, p := range out {
+		if p.UpstreamTargetPort != wantUpstream[p.Name] {
+			t.Errorf("port %q: UpstreamTargetPort=%d, want %d", p.Name, p.UpstreamTargetPort, wantUpstream[p.Name])
+		}
+	}
+}
+
+func TestBuildServicePortStatus_AlreadySorted(t *testing.T) {
+	svcPorts := []corev1.ServicePort{
+		{Name: "a", Port: 80, Protocol: corev1.ProtocolTCP},
+		{Name: "b", Port: 443, Protocol: corev1.ProtocolTCP},
+	}
+	endpointPorts := []kubelbv1alpha1.EndpointPort{
+		{Name: "a", Port: 30001, Protocol: corev1.ProtocolTCP},
+		{Name: "b", Port: 30002, Protocol: corev1.ProtocolTCP},
+	}
+
+	out := buildServicePortStatus(logr.Discard(), svcPorts, endpointPorts)
+	if out[0].UpstreamTargetPort != 30001 || out[1].UpstreamTargetPort != 30002 {
+		t.Fatalf("unexpected upstream ports: %+v", out)
+	}
+}
+
+func TestBuildServicePortStatus_UnnamedMatches(t *testing.T) {
+	svcPorts := []corev1.ServicePort{
+		{Port: 80, Protocol: corev1.ProtocolTCP},
+	}
+	endpointPorts := []kubelbv1alpha1.EndpointPort{
+		{Port: 30001, Protocol: corev1.ProtocolTCP},
+	}
+
+	out := buildServicePortStatus(logr.Discard(), svcPorts, endpointPorts)
+	if len(out) != 1 || out[0].UpstreamTargetPort != 30001 {
+		t.Fatalf("single-port case: %+v", out)
+	}
+}
+
+// TestBuildServicePortStatus_MismatchedNamesYieldZero verifies the safety
+// property: when names don't align, UpstreamTargetPort stays zero rather than
+// silently pairing with a random endpoint port.
+func TestBuildServicePortStatus_MismatchedNamesYieldZero(t *testing.T) {
+	svcPorts := []corev1.ServicePort{
+		{Name: "only-in-service", Port: 80, Protocol: corev1.ProtocolTCP},
+	}
+	endpointPorts := []kubelbv1alpha1.EndpointPort{
+		{Name: "only-in-endpoint", Port: 30001, Protocol: corev1.ProtocolTCP},
+	}
+
+	out := buildServicePortStatus(logr.Discard(), svcPorts, endpointPorts)
+	if len(out) != 1 || out[0].UpstreamTargetPort != 0 {
+		t.Fatalf("expected UpstreamTargetPort=0 on name mismatch, got %+v", out)
+	}
+}
+
+// TestBuildServicePortStatus_DistinctProtocolsSameName covers the case where
+// TCP and UDP ports share a Name. Match must include Protocol.
+func TestBuildServicePortStatus_DistinctProtocolsSameName(t *testing.T) {
+	svcPorts := []corev1.ServicePort{
+		{Name: "dns", Port: 53, Protocol: corev1.ProtocolTCP},
+		{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP},
+	}
+	endpointPorts := []kubelbv1alpha1.EndpointPort{
+		{Name: "dns", Port: 30053, Protocol: corev1.ProtocolUDP},
+		{Name: "dns", Port: 31053, Protocol: corev1.ProtocolTCP},
+	}
+
+	out := buildServicePortStatus(logr.Discard(), svcPorts, endpointPorts)
+	sort.Slice(out, func(i, j int) bool { return out[i].Protocol < out[j].Protocol })
+	if out[0].Protocol != corev1.ProtocolTCP || out[0].UpstreamTargetPort != 31053 {
+		t.Errorf("TCP dns: got %+v", out[0])
+	}
+	if out[1].Protocol != corev1.ProtocolUDP || out[1].UpstreamTargetPort != 30053 {
+		t.Errorf("UDP dns: got %+v", out[1])
+	}
+}

--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -49,9 +49,11 @@ import (
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 	"k8c.io/kubelb/internal/kubelb"
+	managermetrics "k8c.io/kubelb/internal/metrics/manager"
 	portlookup "k8c.io/kubelb/internal/port-lookup"
 
 	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -73,7 +75,7 @@ const (
 	accessLogFormat = "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%DOWNSTREAM_REMOTE_ADDRESS%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
 )
 
-func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route, portAllocator *portlookup.PortAllocator) (*envoycache.Snapshot, error) {
+func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route, portAllocator *portlookup.PortAllocator, snapshotName string) (*envoycache.Snapshot, error) {
 	var listener []types.Resource
 	var cluster []types.Resource
 
@@ -176,6 +178,8 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 			}
 		}
 	}
+
+	listener = dedupListenersByAddress(listener, snapshotName)
 
 	var content []byte
 	var resources []types.Resource
@@ -520,6 +524,41 @@ func makeHTTPListener(listenerName string, clusterName string, listenerPort uint
 			}},
 		}},
 	}
+}
+
+// dedupListenersByAddress drops listeners with duplicate bind addresses before
+// building the xDS snapshot. Envoy NACKs snapshots containing two listeners on
+// the same address. This should never happen if the port allocator is consistent,
+// but defend here so a bug upstream can't cascade into unbounded log volume.
+// snapshotName is used only for metric labeling.
+func dedupListenersByAddress(listeners []types.Resource, snapshotName string) []types.Resource {
+	if len(listeners) < 2 {
+		return listeners
+	}
+	seen := make(map[string]string, len(listeners))
+	deduped := make([]types.Resource, 0, len(listeners))
+	for _, r := range listeners {
+		l, ok := r.(*envoyListener.Listener)
+		if !ok {
+			deduped = append(deduped, r)
+			continue
+		}
+		sa := l.GetAddress().GetSocketAddress()
+		if sa == nil {
+			deduped = append(deduped, r)
+			continue
+		}
+		key := fmt.Sprintf("%s:%d/%s", sa.GetAddress(), sa.GetPortValue(), sa.GetProtocol())
+		if prev, exists := seen[key]; exists {
+			ctrl.Log.WithName("envoy").Info("dropping duplicate listener from snapshot",
+				"snapshot", snapshotName, "address", key, "kept", prev, "dropped", l.GetName())
+			managermetrics.EnvoyDuplicateListenersDropped.WithLabelValues(snapshotName).Inc()
+			continue
+		}
+		seen[key] = l.GetName()
+		deduped = append(deduped, r)
+	}
+	return deduped
 }
 
 func MustMarshalAny(pb proto.Message) *anypb.Any {

--- a/internal/envoy/resource_test.go
+++ b/internal/envoy/resource_test.go
@@ -20,12 +20,26 @@ import (
 	"testing"
 
 	envoyEndpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	dto "github.com/prometheus/client_model/go"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	managermetrics "k8c.io/kubelb/internal/metrics/manager"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func counterValue(t *testing.T, c interface {
+	Write(*dto.Metric) error
+}) float64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := c.Write(m); err != nil {
+		t.Fatalf("counter Write failed: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
 
 func TestMakeCluster_ProxyProtocol(t *testing.T) {
 	endpoints := []*envoyEndpoint.LbEndpoint{
@@ -161,5 +175,79 @@ func TestIsTLSBackend(t *testing.T) {
 				t.Errorf("isTLSBackend() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func dedupListenersByAddressTestHelper(listeners []types.Resource) []types.Resource {
+	return dedupListenersByAddress(listeners, "test-ns")
+}
+
+func TestDedupListenersByAddress(t *testing.T) {
+	l1 := makeTCPListener("cluster-a", "listener-a", 10001)
+	l2 := makeTCPListener("cluster-b", "listener-b", 10001)
+	l3 := makeTCPListener("cluster-c", "listener-c", 10002)
+
+	out := dedupListenersByAddressTestHelper([]types.Resource{l1, l2, l3})
+
+	if got, want := len(out), 2; got != want {
+		t.Fatalf("expected %d listeners after dedup, got %d", want, got)
+	}
+	if out[0] != l1 {
+		t.Errorf("expected first listener to be kept")
+	}
+	if out[1] != l3 {
+		t.Errorf("expected non-colliding listener to be preserved")
+	}
+}
+
+func TestDedupListenersByAddress_DistinctProtocols(t *testing.T) {
+	tcp := makeTCPListener("cluster-tcp", "listener-tcp", 10001)
+	udp := makeUDPListener("cluster-udp", "listener-udp", 10001)
+
+	out := dedupListenersByAddressTestHelper([]types.Resource{tcp, udp})
+	if len(out) != 2 {
+		t.Fatalf("TCP and UDP on same port must not be deduped; got %d", len(out))
+	}
+}
+
+func TestDedupListenersByAddress_ShortCircuits(t *testing.T) {
+	if out := dedupListenersByAddressTestHelper(nil); out != nil {
+		t.Fatalf("nil input should pass through, got %v", out)
+	}
+	single := []types.Resource{makeTCPListener("c", "l", 10001)}
+	if out := dedupListenersByAddressTestHelper(single); len(out) != 1 {
+		t.Fatalf("single listener should pass through, got %d", len(out))
+	}
+}
+
+// TestDedupListenersByAddress_NoMetricIncrementWithoutDuplicates asserts the
+// dedup counter stays flat when the input has no collisions.
+func TestDedupListenersByAddress_NoMetricIncrementWithoutDuplicates(t *testing.T) {
+	m := managermetrics.EnvoyDuplicateListenersDropped.WithLabelValues("ns-clean")
+	before := counterValue(t, m)
+
+	listeners := []types.Resource{
+		makeTCPListener("c1", "l1", 10001),
+		makeTCPListener("c2", "l2", 10002),
+		makeUDPListener("c3", "l3", 10003),
+	}
+	dedupListenersByAddress(listeners, "ns-clean")
+
+	if after := counterValue(t, m); after != before {
+		t.Fatalf("dedup counter incremented without duplicates: before=%v after=%v", before, after)
+	}
+}
+
+func TestDedupListenersByAddress_LabelCardinalityMatches(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("WithLabelValues panicked: %v (label cardinality drift)", r)
+		}
+	}()
+	l1 := makeTCPListener("cluster-a", "listener-a", 10010)
+	l2 := makeTCPListener("cluster-b", "listener-b", 10010)
+	out := dedupListenersByAddress([]types.Resource{l1, l2}, "tenant-bb8")
+	if len(out) != 1 {
+		t.Fatalf("expected 1 listener kept, got %d", len(out))
 	}
 }

--- a/internal/metrics/factory.go
+++ b/internal/metrics/factory.go
@@ -73,6 +73,18 @@ func (f *MetricFactory) NewGauge(name, help string) prometheus.Gauge {
 	return NewGauge(f.subsystem, name, help)
 }
 
+// NewCounter creates a Counter and captures its description.
+func (f *MetricFactory) NewCounter(name, help string) prometheus.Counter {
+	f.descriptions = append(f.descriptions, MetricDescription{
+		Name:      f.subsystem + "_" + name,
+		Help:      help,
+		Type:      MetricTypeCounter,
+		Labels:    []string{},
+		Component: f.component,
+	})
+	return NewCounter(f.subsystem, name, help)
+}
+
 // NewHistogramVec creates a HistogramVec and captures its description.
 // If buckets is nil, DefaultBuckets will be used.
 func (f *MetricFactory) NewHistogramVec(name, help string, labels []string, buckets []float64) *prometheus.HistogramVec {

--- a/internal/metrics/manager/metrics.go
+++ b/internal/metrics/manager/metrics.go
@@ -150,6 +150,15 @@ var (
 		"port_allocator_endpoints",
 		"Current number of endpoints tracked by the port allocator",
 	)
+
+	// PortAllocatorCollisionsHealed counts duplicate port assignments detected
+	// and cleared by LoadState. Non-zero on manager start typically indicates
+	// an upgrade path that seeded colliding ports into the allocator;
+	// subsequent reconciles allocate fresh ports for the cleared endpointKeys.
+	PortAllocatorCollisionsHealed = factory.NewCounter(
+		"port_allocator_collisions_healed_total",
+		"Total number of duplicate port assignments detected and cleared by the port allocator on load",
+	)
 )
 
 // EnvoyCP snapshot metrics.
@@ -181,6 +190,16 @@ var (
 		"Current number of endpoints in the Envoy snapshot",
 		[]string{"snapshot_name"},
 	)
+
+	// EnvoyDuplicateListenersDropped counts listeners dropped from the xDS snapshot
+	// because their bind address collided with another listener. Non-zero means
+	// something upstream produced two listeners with the same 0.0.0.0:<port>/<protocol>.
+	// The snapshot sent to Envoy keeps only the first one.
+	EnvoyDuplicateListenersDropped = factory.NewCounterVec(
+		"envoy_duplicate_listeners_dropped_total",
+		"Total number of listeners dropped from the Envoy snapshot due to duplicate bind addresses",
+		[]string{"snapshot_name"},
+	)
 )
 
 // allCollectors returns all metrics collectors for registration.
@@ -206,11 +225,13 @@ func allCollectors() []prometheus.Collector {
 		// Port allocator
 		PortAllocatorAllocatedPorts,
 		PortAllocatorEndpoints,
+		PortAllocatorCollisionsHealed,
 		// EnvoyCP snapshot
 		EnvoyCPSnapshotUpdatesTotal,
 		EnvoyCPClusters,
 		EnvoyCPListeners,
 		EnvoyCPEndpoints,
+		EnvoyDuplicateListenersDropped,
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -91,6 +91,15 @@ func NewGauge(subsystem, name, help string) prometheus.Gauge {
 	})
 }
 
+// NewCounter creates a new Counter with the KubeLB namespace.
+func NewCounter(subsystem, name, help string) prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: subsystem,
+		Name:      name,
+		Help:      help,
+	})
+}
+
 // NewHistogramVec creates a new HistogramVec with the KubeLB namespace.
 // If buckets is nil, DefaultBuckets will be used.
 func NewHistogramVec(subsystem, name, help string, labels []string, buckets []float64) *prometheus.HistogramVec {

--- a/internal/port-lookup/allocator.go
+++ b/internal/port-lookup/allocator.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
+	"sort"
 	"sync"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 	"k8c.io/kubelb/internal/kubelb"
 	managermetrics "k8c.io/kubelb/internal/metrics/manager"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -131,6 +133,11 @@ func (pa *PortAllocator) allocatePort() int {
 	for {
 		port := rand.Intn(endPort-startPort) + startPort
 		if _, exists := pa.portLookupReverse[port]; !exists {
+			// Mark the port as used immediately so subsequent allocations within
+			// the same AllocatePorts batch can't pick it too. recomputeAvailablePorts
+			// runs only at the end of AllocatePorts; without this write, two keys
+			// in the same call can collide on the same random value.
+			pa.portLookupReverse[port] = true
 			return port
 		}
 	}
@@ -170,9 +177,24 @@ func (pa *PortAllocator) LoadState(ctx context.Context, apiReader client.Reader)
 
 			for _, lbEndpointPort := range lbEndpoint.Ports {
 				portKey := fmt.Sprintf(kubelb.EnvoyListenerPattern, lbEndpointPort.Port, lbEndpointPort.Protocol)
+				// Match by Name+Protocol when Name is set on either side; otherwise by
+				// UpstreamTargetPort+Protocol. The previous predicate required all three of
+				// (Name, Protocol, UpstreamTargetPort) to match, which silently failed for
+				// multi-port LBs whose status was written by the pre-fix updateLoadBalancerStatus
+				// (Name and UpstreamTargetPort were indexed against parallel arrays sorted
+				// differently). Falling back to Name-only lets historically corrupt statuses
+				// heal instead of triggering a fresh random allocation.
 				for _, port := range lb.Status.Service.Ports {
-					// Name is not guaranteed to be set, so we need to check for port and protocol as well.
-					if port.UpstreamTargetPort == lbEndpointPort.Port && port.Protocol == lbEndpointPort.Protocol && port.Name == lbEndpointPort.Name {
+					if port.Protocol != lbEndpointPort.Protocol {
+						continue
+					}
+					var match bool
+					if lbEndpointPort.Name != "" || port.Name != "" {
+						match = port.Name == lbEndpointPort.Name
+					} else {
+						match = port.UpstreamTargetPort == lbEndpointPort.Port
+					}
+					if match {
 						lookupTable[endpointKey][portKey] = port.TargetPort.IntValue()
 						break
 					}
@@ -216,7 +238,43 @@ func (pa *PortAllocator) LoadState(ctx context.Context, apiReader client.Reader)
 			}
 		}
 	}
+	// Heal duplicate port assignments across endpointKeys. Two different
+	// endpointKeys owning the same port value cause duplicate Envoy listeners
+	// (and NACK spam). This happens on upgrade where Routes that shared a
+	// backend Service seed the same port into each of their distinct
+	// per-route endpointKeys. Keep the first owner in sorted key order and
+	// clear duplicates so the next reconcile allocates fresh ports for them.
+	healLoadStateCollisions(lookupTable)
+
 	pa.portLookup = lookupTable
 	pa.recomputeAvailablePorts()
 	return nil
+}
+
+func healLoadStateCollisions(lookupTable LookupTable) {
+	log := ctrl.Log.WithName("port-allocator")
+	owners := make(map[int]string)
+	endpointKeys := make([]string, 0, len(lookupTable))
+	for k := range lookupTable {
+		endpointKeys = append(endpointKeys, k)
+	}
+	sort.Strings(endpointKeys)
+	for _, endpointKey := range endpointKeys {
+		portKeys := make([]string, 0, len(lookupTable[endpointKey]))
+		for k := range lookupTable[endpointKey] {
+			portKeys = append(portKeys, k)
+		}
+		sort.Strings(portKeys)
+		for _, portKey := range portKeys {
+			port := lookupTable[endpointKey][portKey]
+			if owner, exists := owners[port]; exists && owner != endpointKey {
+				log.Info("detected duplicate port allocation; clearing to force reallocation",
+					"port", port, "keeping", owner, "clearing", endpointKey, "portKey", portKey)
+				delete(lookupTable[endpointKey], portKey)
+				managermetrics.PortAllocatorCollisionsHealed.Inc()
+				continue
+			}
+			owners[port] = endpointKey
+		}
+	}
 }

--- a/internal/port-lookup/allocator_test.go
+++ b/internal/port-lookup/allocator_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portlookup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// stubReader serves canned LoadBalancerList and RouteList responses for LoadState tests.
+type stubReader struct {
+	lbs    []kubelbv1alpha1.LoadBalancer
+	routes []kubelbv1alpha1.Route
+}
+
+func (s *stubReader) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return nil
+}
+func (s *stubReader) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	switch l := list.(type) {
+	case *kubelbv1alpha1.LoadBalancerList:
+		l.Items = s.lbs
+	case *kubelbv1alpha1.RouteList:
+		l.Items = s.routes
+	}
+	return nil
+}
+
+// TestAllocatePorts_NoIntraBatchCollision guards against the regression where
+// allocatePort reads portLookupReverse but doesn't write, allowing two keys in
+// the same AllocatePorts call to receive the same random port.
+func TestAllocatePorts_NoIntraBatchCollision(t *testing.T) {
+	pa := NewPortAllocator()
+
+	const n = 500
+	keys := make([]string, n)
+	for i := 0; i < n; i++ {
+		keys[i] = fmt.Sprintf("port-%d", i)
+	}
+	pa.AllocatePorts("endpointA", keys)
+
+	seen := make(map[int]string)
+	for _, k := range keys {
+		port, ok := pa.Lookup("endpointA", k)
+		if !ok {
+			t.Fatalf("port not allocated for key %s", k)
+		}
+		if owner, dup := seen[port]; dup {
+			t.Fatalf("port %d allocated twice in one batch: owners %s and %s", port, owner, k)
+		}
+		seen[port] = k
+	}
+}
+
+// TestLoadState_HealsUpgradeCollision simulates the upgrade state where two
+// routes sharing a backend service have the same port recorded in both routes'
+// statuses. After LoadState, at most one endpointKey must own that port.
+func TestLoadState_HealsUpgradeCollision(t *testing.T) {
+	lookupTable := LookupTable{
+		"endpointKey_A": map[string]int{"tcp/80": 12345},
+		"endpointKey_B": map[string]int{"tcp/80": 12345}, // collision
+		"endpointKey_C": map[string]int{"tcp/443": 23456},
+	}
+
+	healLoadStateCollisions(lookupTable)
+
+	aHas := len(lookupTable["endpointKey_A"]) > 0
+	bHas := len(lookupTable["endpointKey_B"]) > 0
+	if aHas == bHas {
+		t.Fatalf("expected exactly one of endpointKey_A/B to retain the port; got A=%v B=%v", aHas, bHas)
+	}
+	if lookupTable["endpointKey_C"]["tcp/443"] != 23456 {
+		t.Fatalf("non-colliding entry was disturbed: %+v", lookupTable["endpointKey_C"])
+	}
+}
+
+// TestLoadState_HealsUpgradeCollision_Deterministic asserts the healing picks
+// the same owner across runs (sorted key order).
+func TestLoadState_HealsUpgradeCollision_Deterministic(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		lookupTable := LookupTable{
+			"endpointKey_B": map[string]int{"tcp/80": 12345},
+			"endpointKey_A": map[string]int{"tcp/80": 12345},
+		}
+		healLoadStateCollisions(lookupTable)
+		if len(lookupTable["endpointKey_A"]) != 1 {
+			t.Fatalf("iteration %d: endpointKey_A should have kept its port", i)
+		}
+		if len(lookupTable["endpointKey_B"]) != 0 {
+			t.Fatalf("iteration %d: endpointKey_B should have been cleared", i)
+		}
+	}
+}
+
+// TestAllocateAfterHeal confirms the cleared endpointKey gets a fresh port on
+// the next allocation pass.
+func TestAllocateAfterHeal(t *testing.T) {
+	pa := NewPortAllocator()
+	pa.portLookup = LookupTable{
+		"endpointKey_A": map[string]int{"tcp/80": 12345},
+		"endpointKey_B": map[string]int{},
+	}
+	pa.recomputeAvailablePorts()
+
+	pa.AllocatePorts("endpointKey_B", []string{"tcp/80"})
+
+	portB, ok := pa.Lookup("endpointKey_B", "tcp/80")
+	if !ok {
+		t.Fatalf("expected endpointKey_B to receive a port")
+	}
+	if portB == 12345 {
+		t.Fatalf("expected endpointKey_B to get a port different from endpointKey_A's %d, got %d", 12345, portB)
+	}
+}
+
+// TestHealLoadStateCollisions_NoopOnCleanState asserts healing does not mutate a
+// lookup table that has no duplicates.
+func TestHealLoadStateCollisions_NoopOnCleanState(t *testing.T) {
+	original := LookupTable{
+		"endpointKey_A": map[string]int{"tcp/80": 10001, "tcp/443": 10002},
+		"endpointKey_B": map[string]int{"tcp/80": 20001, "udp/53": 20002},
+	}
+	snapshot := LookupTable{}
+	for k, v := range original {
+		inner := map[string]int{}
+		for pk, pv := range v {
+			inner[pk] = pv
+		}
+		snapshot[k] = inner
+	}
+
+	healLoadStateCollisions(original)
+
+	for epKey, ports := range snapshot {
+		for portKey, port := range ports {
+			if original[epKey][portKey] != port {
+				t.Fatalf("non-colliding entry mutated: %s/%s had %d, now %d",
+					epKey, portKey, port, original[epKey][portKey])
+			}
+		}
+	}
+	if len(original["endpointKey_A"]) != 2 || len(original["endpointKey_B"]) != 2 {
+		t.Fatalf("entry count changed: %+v", original)
+	}
+}
+
+// TestLoadState_RecoversFromScrambledStatus drives LoadState end-to-end with a
+// LoadBalancer whose status was written by the pre-fix updateLoadBalancerStatus
+// (Name and UpstreamTargetPort indexed against differently-sorted parallel
+// arrays). The relaxed match predicate must still recover the correct port
+// mapping by matching on Name+Protocol alone.
+func TestLoadState_RecoversFromScrambledStatus(t *testing.T) {
+	lb := kubelbv1alpha1.LoadBalancer{}
+	lb.Name = "test-lb"
+	lb.Namespace = "tenant-test"
+	lb.Spec.Endpoints = []kubelbv1alpha1.LoadBalancerEndpoints{
+		{
+			Ports: []kubelbv1alpha1.EndpointPort{
+				{Name: "c", Port: 30003, Protocol: corev1.ProtocolTCP},
+				{Name: "a", Port: 30001, Protocol: corev1.ProtocolTCP},
+				{Name: "b", Port: 30002, Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+	lb.Status.Service.Ports = []kubelbv1alpha1.ServicePort{
+		// Pre-fix code paired Name="a" (post-sort first) with Endpoints[0].Port = 30003.
+		{ServicePort: corev1.ServicePort{Name: "a", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(10001)}, UpstreamTargetPort: 30003},
+		{ServicePort: corev1.ServicePort{Name: "b", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(10002)}, UpstreamTargetPort: 30001},
+		{ServicePort: corev1.ServicePort{Name: "c", Port: 8080, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(10003)}, UpstreamTargetPort: 30002},
+	}
+
+	pa := NewPortAllocator()
+	if err := pa.LoadState(context.Background(), &stubReader{lbs: []kubelbv1alpha1.LoadBalancer{lb}}); err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	endpointKey := fmt.Sprintf(kubelb.EnvoyEndpointPattern, lb.Namespace, lb.Name, 0)
+	wantTargetForName := map[string]int{"c": 10003, "a": 10001, "b": 10002}
+	for _, ep := range lb.Spec.Endpoints[0].Ports {
+		portKey := fmt.Sprintf(kubelb.EnvoyListenerPattern, ep.Port, ep.Protocol)
+		got, ok := pa.Lookup(endpointKey, portKey)
+		if !ok {
+			t.Errorf("endpoint %q (port=%d): no entry in allocator; LoadState failed to match scrambled status", ep.Name, ep.Port)
+			continue
+		}
+		if got != wantTargetForName[ep.Name] {
+			t.Errorf("endpoint %q: got allocated port %d, want %d", ep.Name, got, wantTargetForName[ep.Name])
+		}
+	}
+}
+
+// TestLoadState_HealsDuplicateRoutePort drives LoadState for the upgrade
+// scenario: two Routes share a backend service and each Route's status
+// carries the same TargetPort. LoadState must heal the duplicate.
+func TestLoadState_HealsDuplicateRoutePort(t *testing.T) {
+	mkRoute := func(name string) kubelbv1alpha1.Route {
+		r := kubelbv1alpha1.Route{}
+		r.Name = name
+		r.Namespace = "tenant-test"
+		r.Spec.Source.Kubernetes = &kubelbv1alpha1.KubernetesSource{}
+		r.Spec.Source.Kubernetes.Services = []kubelbv1alpha1.UpstreamService{{
+			Service: corev1.Service{},
+		}}
+		r.Spec.Source.Kubernetes.Services[0].Name = "foo"
+		r.Spec.Source.Kubernetes.Services[0].Namespace = "app-ns"
+		r.Spec.Source.Kubernetes.Route.SetName(name)
+		r.Status.Resources.Services = map[string]kubelbv1alpha1.RouteServiceStatus{
+			"app-ns/foo": {
+				Ports: []corev1.ServicePort{
+					{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(42000)},
+				},
+			},
+		}
+		return r
+	}
+
+	pa := NewPortAllocator()
+	routes := []kubelbv1alpha1.Route{mkRoute("route-a"), mkRoute("route-b")}
+	if err := pa.LoadState(context.Background(), &stubReader{routes: routes}); err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	keyA := fmt.Sprintf(kubelb.EnvoyEndpointRoutePattern, "tenant-test", "app-ns", "foo", "route-a")
+	keyB := fmt.Sprintf(kubelb.EnvoyEndpointRoutePattern, "tenant-test", "app-ns", "foo", "route-b")
+	portKey := fmt.Sprintf(kubelb.EnvoyListenerPattern, int32(80), corev1.ProtocolTCP)
+
+	_, aHas := pa.Lookup(keyA, portKey)
+	_, bHas := pa.Lookup(keyB, portKey)
+	if aHas == bHas {
+		t.Fatalf("expected exactly one route to retain the port after heal; got A=%v B=%v", aHas, bHas)
+	}
+}
+
+// TestHealLoadStateCollisions_EndpointPatternKeys uses realistic kubelb pattern
+// keys to catch accidental coupling to key format.
+func TestHealLoadStateCollisions_EndpointPatternKeys(t *testing.T) {
+	routeAKey := fmt.Sprintf(kubelb.EnvoyEndpointRoutePattern, "ns", "ns", "foo", "routeA")
+	routeBKey := fmt.Sprintf(kubelb.EnvoyEndpointRoutePattern, "ns", "ns", "foo", "routeB")
+	lookupTable := LookupTable{
+		routeAKey: map[string]int{"tcp/80": 42000},
+		routeBKey: map[string]int{"tcp/80": 42000},
+	}
+	healLoadStateCollisions(lookupTable)
+	total := len(lookupTable[routeAKey]) + len(lookupTable[routeBKey])
+	if total != 1 {
+		t.Fatalf("expected exactly one endpointKey to keep the port, got total=%d (%+v)", total, lookupTable)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of https://github.com/kubermatic/kubelb/pull/409

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix duplicate port allocations for Routes that shared a backend Service before upgrade, and fix multi-port LoadBalancer target-port corruption that could cause traffic drop after a manager restart while the API server was write-unavailable.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
