### PR TITLE
[release/v1.3] Fix tag creation for CE (#401)

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.KUBELB_EE_TOKEN }}
 
       - name: Tag CE repo
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #401 to `release/v1.3`.

The `release-auto-tag.yml` workflow on `release/v1.3` pushes the CE tag using the default `GITHUB_TOKEN`. GitHub Actions deliberately does not trigger workflows from events caused by `GITHUB_TOKEN`, so the tag push silently fails to start `release.yml`.

This caused both v1.3.10 and v1.3.11 to require manual `workflow_dispatch` after the prep PR merged. v1.3.11 currently has a tag in place but no release artifacts  confirming the symptom.


**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```