### PR TITLE
fix(release-docs): write release-notes shortcode for new minor

### DIFF
--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -93,6 +93,20 @@ jobs:
             -e "s|refs/heads/main|refs/heads/release/${MINOR}|g" \
             -e "s|/kubelb/main/|/kubelb/${MINOR}/|g"
 
+          # release-notes/_index.en.md on main is a hand-written placeholder,
+          # not a render_external_markdown shortcode, so the sed rewrite above
+          # does not produce a usable page. Overwrite it with a shortcode that
+          # renders the per-minor CHANGELOG from the release branch.
+          cat > "${DEST}/release-notes/_index.en.md" <<EOF
+          +++
+          title = "Release Notes"
+          date = $(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          weight = 60
+          +++
+
+          {{< render_external_markdown "https://raw.githubusercontent.com/${KUBELB_REPO}/refs/heads/release/${MINOR}/docs/changelogs/CHANGELOG-${MINOR}.md" >}}
+          EOF
+
           if ! grep -q "release: ${MINOR}" data/products.yaml; then
             awk -v minor="${MINOR}" '
               /^kubelb:/{found=1}


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #417. The minor-release reseed copies `content/kubelb/main` and rewrites `refs/heads/main` → `refs/heads/release/${MINOR}` via sed. That works for `references/{ce,ee}/_index.en.md` and `tutorials/observability/metrics-and-dashboards/references/{ce,ee}/_index.en.md` because `main` contains proper `render_external_markdown` shortcodes there. But `content/kubelb/main/release-notes/_index.en.md` is a hand-written placeholder ("This document is work in progress…"), not a shortcode — so the sed finds nothing to rewrite, and the new minor lands with the placeholder instead of the rendered CHANGELOG.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```