### PR TITLE
release: targeted fixes from v1.4.0 docs postmortem

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -8,6 +8,9 @@ on:
 
 permissions: {}
 
+env:
+  EE_REPO: kubermatic/kubelb-ee
+
 jobs:
   auto-tag:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore/prepare-v')
@@ -68,7 +71,7 @@ jobs:
           # Need full history (not --depth 1) so we can tag an arbitrary SHA
           # that may not be branch HEAD anymore.
           git clone --branch "release/${MINOR}" \
-            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
+            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${EE_REPO}.git" /tmp/kubelb-ee
 
           cd /tmp/kubelb-ee
           if [ -n "$EE_SHA" ]; then
@@ -108,7 +111,7 @@ jobs:
         run: |
           BODY="### Release ${VERSION} — post-merge summary\n\n"
           BODY+="- **CE tag:** [\`${VERSION}\`](https://github.com/${REPO}/releases/tag/${VERSION})\n"
-          BODY+="- **EE tag:** [\`${VERSION}\`](https://github.com/kubermatic/kubelb-ee/releases/tag/${VERSION})\n"
+          BODY+="- **EE tag:** [\`${VERSION}\`](https://github.com/${EE_REPO}/releases/tag/${VERSION})\n"
 
           if [ -n "$DOCS_PR" ]; then
             BODY+="- **Docs PR:** ${DOCS_PR} ← **review and merge**\n"

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -56,12 +56,28 @@ jobs:
           KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
           MINOR: ${{ steps.version.outputs.minor }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          git clone --depth 1 --branch "release/${MINOR}" \
+          # Pin EE tag to the SHA captured by release-prep at prep time so a
+          # push to release/${MINOR} between prep PR creation and merge cannot
+          # tag a state different from what the prep PR reviewed. Falls back
+          # to branch HEAD if the marker is absent (older prep PRs predating
+          # this change).
+          EE_SHA=$(printf '%s' "$PR_BODY" | grep -oE 'EE-SHA: [a-f0-9]{7,40}' | head -1 | awk '{print $2}')
+
+          # Need full history (not --depth 1) so we can tag an arbitrary SHA
+          # that may not be branch HEAD anymore.
+          git clone --branch "release/${MINOR}" \
             "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
 
           cd /tmp/kubelb-ee
-          git tag "${VERSION}"
+          if [ -n "$EE_SHA" ]; then
+            echo "::notice::Tagging EE at prep-time SHA: ${EE_SHA}"
+            git tag "${VERSION}" "${EE_SHA}"
+          else
+            echo "::warning::No EE-SHA in prep PR body; tagging EE at release/${MINOR} HEAD"
+            git tag "${VERSION}"
+          fi
           git push origin "${VERSION}"
 
   docs-update:

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -73,6 +73,7 @@ jobs:
       is_patch: ${{ needs.auto-tag.outputs.is_patch }}
     secrets:
       KUBERMATIC_DOCS_TOKEN: ${{ secrets.KUBERMATIC_DOCS_TOKEN }}
+      KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
 
   notify:
     needs: [auto-tag, docs-update]

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -188,21 +188,39 @@ jobs:
         run: |
           DOCS_DIR="content/kubelb/${MINOR}"
 
-          PREV_VERSION=$(grep -ohE 'version=v[0-9]+\.[0-9]+\.[0-9]+' "${DOCS_DIR}/installation/management-cluster/_index.en.md" | head -1 | cut -d= -f2)
+          # Histogram all vX.Y.Z references across the docs tree and pick the
+          # most frequent (excluding the target VERSION itself). More robust
+          # than grepping a single file for `version=vX.Y.Z`: catches `:vX.Y.Z`
+          # image tags, bare prose mentions, --version=vX.Y.Z helm flags, etc.
+          PREV_VERSION=$(
+            grep -rohE 'v[0-9]+\.[0-9]+\.[0-9]+' "$DOCS_DIR" 2>/dev/null \
+              | grep -v "^${VERSION}\$" \
+              | sort | uniq -c | sort -rn \
+              | head -1 | awk '{print $2}'
+          )
 
           if [ -z "$PREV_VERSION" ]; then
-            echo "::warning::Could not detect previous version in docs, skipping version update"
+            echo "::warning::No vX.Y.Z references found in ${DOCS_DIR}; skipping version sweep"
+            exit 0
+          fi
+
+          if [ "$PREV_VERSION" = "$VERSION" ]; then
+            echo "::notice::Most-frequent version equals target ${VERSION}; nothing to update"
             exit 0
           fi
 
           echo "Updating ${PREV_VERSION} → ${VERSION} in ${DOCS_DIR}"
 
-          find "${DOCS_DIR}" -name "*.md" -type f | while read -r file; do
+          UPDATED=0
+          while IFS= read -r file; do
             if grep -q "${PREV_VERSION}" "$file"; then
               sed -i "s/${PREV_VERSION}/${VERSION}/g" "$file"
               echo "  Updated: $file"
+              UPDATED=$((UPDATED + 1))
             fi
-          done
+          done < <(find "${DOCS_DIR}" -name "*.md" -type f)
+
+          echo "::notice::Rewrote ${PREV_VERSION} → ${VERSION} in ${UPDATED} file(s)"
 
       - name: Replace helm values tables between marker comments
         env:

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -172,33 +172,57 @@ jobs:
           MARKERS["kubelb-manager-ee"]="docs/generated/helm-values-kubelb-manager-ee.md"
           MARKERS["kubelb-ccm-ee"]="docs/generated/helm-values-kubelb-ccm-ee.md"
 
+          declare -A MATCHED
+          for marker in "${!MARKERS[@]}"; do MATCHED[$marker]=0; done
+
           for marker in "${!MARKERS[@]}"; do
             REMOTE_FILE="${MARKERS[$marker]}"
-            RAW_URL="https://raw.githubusercontent.com/${KUBELB_REPO}/refs/tags/${VERSION}/${REMOTE_FILE}"
+            # Fetch from the release branch HEAD, not the immutable tag.
+            # The v1.4.0 tag was created with broken EE artifacts; the fix
+            # landed on release/v1.4 post-tag. Branch-based source means the
+            # docs always reflect the latest fixes for that minor (which is
+            # what users on that minor would actually install). Tags can be
+            # frozen with bugs; release branches are the live source of truth.
+            RAW_URL="https://raw.githubusercontent.com/${KUBELB_REPO}/refs/heads/release/${MINOR}/${REMOTE_FILE}"
             TABLE=$(curl -sfL "$RAW_URL" || echo "")
 
             if [ -z "$TABLE" ]; then
-              echo "::warning::Could not fetch ${REMOTE_FILE} for ${VERSION}, skipping ${marker}"
+              echo "::warning::Could not fetch ${REMOTE_FILE} from release/${MINOR}, skipping ${marker}"
               continue
             fi
 
             START_MARKER="<!-- helm-values-${marker} start -->"
             END_MARKER="<!-- helm-values-${marker} end -->"
 
-            find "${DOCS_DIR}" -name "*.md" -type f | while read -r file; do
+            while IFS= read -r file; do
               if grep -q "$START_MARKER" "$file"; then
-                # Replace content between markers (keep markers intact)
                 sed -i "/${START_MARKER}/,/${END_MARKER}/{
                   /${START_MARKER}/!{
                     /${END_MARKER}/!d
                   }
                 }" "$file"
-                # Insert new table after start marker
                 sed -i "/${START_MARKER}/r /dev/stdin" "$file" <<< "$TABLE"
                 echo "  Updated ${marker} in ${file}"
+                MATCHED[$marker]=$((MATCHED[$marker] + 1))
               fi
-            done
+            done < <(find "${DOCS_DIR}" -name "*.md" -type f)
           done
+
+          # Fail loudly if any of the expected markers were never matched.
+          # The original `find | while` pipeline scoped the increment to a
+          # subshell, so the count was lost across iterations; switching to
+          # process substitution preserves it.
+          MISSING=()
+          for marker in "${!MARKERS[@]}"; do
+            if [ "${MATCHED[$marker]}" -eq 0 ]; then
+              MISSING+=("$marker")
+            fi
+          done
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "::error::No docs page contains markers for: ${MISSING[*]}"
+            echo "::error::Expected <!-- helm-values-<marker> start --> / end --> in ${DOCS_DIR}"
+            exit 1
+          fi
 
       - name: Create PR
         id: create-pr

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -318,9 +318,28 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           BRANCH="chore/kubelb-${VERSION}-docs"
+
+          # If a prior run already pushed this branch, close any associated
+          # open PR and delete the remote branch so we can recreate cleanly.
+          # Without this, a re-run hits non-fast-forward push failure with no
+          # recovery path short of manual cleanup.
+          if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
+            echo "::notice::Branch ${BRANCH} already exists on origin; cleaning up prior run"
+            EXISTING_PR=$(gh pr list --repo "${{ env.DOCS_REPO }}" --head "$BRANCH" --state open --json number --jq '.[0].number')
+            if [ -n "$EXISTING_PR" ]; then
+              echo "::notice::Closing existing PR #${EXISTING_PR}"
+              gh pr close "$EXISTING_PR" --repo "${{ env.DOCS_REPO }}" --delete-branch
+            else
+              git push origin --delete "$BRANCH"
+            fi
+          fi
+
           git checkout -b "${BRANCH}"
           git add -A
-          git commit -s -m "docs: update KubeLB docs for ${VERSION}" || exit 0
+          if ! git commit -s -m "docs: update KubeLB docs for ${VERSION}"; then
+            echo "::notice::No changes to commit; skipping PR creation"
+            exit 0
+          fi
           git push -u origin "${BRANCH}"
 
           BODY="Update KubeLB documentation for release ${VERSION}."

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -59,6 +59,7 @@ permissions: {}
 env:
   DOCS_REPO: kubermatic/docs
   KUBELB_REPO: kubermatic/kubelb
+  EE_REPO: kubermatic/kubelb-ee
 
 jobs:
   update-docs:
@@ -101,7 +102,7 @@ jobs:
           # state — broken or stale CE release-branch artifacts no longer
           # cause incorrect docs.
           git clone --depth 1 --branch "release/${MINOR}" \
-            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
+            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${EE_REPO}.git" /tmp/kubelb-ee
 
           ./kubelb-ce/hack/release/bump-versions.sh --target-dir /tmp/kubelb-ee "$VERSION"
 

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -107,18 +107,33 @@ jobs:
           {{< render_external_markdown "https://raw.githubusercontent.com/${KUBELB_REPO}/refs/heads/release/${MINOR}/docs/changelogs/CHANGELOG-${MINOR}.md" >}}
           EOF
 
-          if ! grep -q "release: ${MINOR}" data/products.yaml; then
+          # Add v${MINOR} to the kubelb versions list, idempotently. The check
+          # MUST be scoped to the kubelb section: a global grep matches
+          # unrelated products that share version numbers (e.g. kubeone v1.4)
+          # and silently skips the insert. v1.4.0 release shipped without a
+          # kubelb v1.4 entry in products.yaml because of exactly this.
+          HAS_MINOR=$(awk -v minor="${MINOR}" '
+            /^kubelb:[[:space:]]*$/ { in_section=1; next }
+            /^[a-zA-Z][a-zA-Z0-9_-]*:[[:space:]]*$/ { in_section=0 }
+            in_section && $0 ~ "release: " minor "$" { print "yes"; exit }
+          ' data/products.yaml)
+
+          if [ "$HAS_MINOR" != "yes" ]; then
             awk -v minor="${MINOR}" '
-              /^kubelb:/{found=1}
-              found && /name: main/{
+              /^kubelb:[[:space:]]*$/ { in_kubelb=1; print; next }
+              /^[a-zA-Z][a-zA-Z0-9_-]*:[[:space:]]*$/ { in_kubelb=0 }
+              in_kubelb && /name: main$/ && !inserted {
                 print
                 printf "    - release: %s\n      name: %s\n", minor, minor
-                found=0
+                inserted=1
                 next
               }
-              {print}
+              { print }
             ' data/products.yaml > data/products.yaml.tmp
             mv data/products.yaml.tmp data/products.yaml
+            echo "::notice::Added kubelb v${MINOR} entry to data/products.yaml"
+          else
+            echo "::notice::kubelb v${MINOR} already in data/products.yaml; skipping"
           fi
 
       - name: Update version strings in installation pages

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -36,6 +36,8 @@ on:
     secrets:
       KUBERMATIC_DOCS_TOKEN:
         required: true
+      KUBELB_EE_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       version:
@@ -70,6 +72,49 @@ jobs:
         with:
           repository: ${{ env.DOCS_REPO }}
           token: ${{ secrets.KUBERMATIC_DOCS_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout kubelb-ce hack/release scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ env.KUBELB_REPO }}
+          ref: release/${{ inputs.minor }}
+          path: kubelb-ce
+          sparse-checkout: |
+            hack/release
+            go.mod
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: kubelb-ce/go.mod
+
+      - name: Regenerate EE helm-values from bumped EE clone
+        env:
+          KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          MINOR: ${{ inputs.minor }}
+        run: |
+          # EE chart values stay frozen on the EE release branch (we never
+          # commit the bump back). To produce helm-values markdown that
+          # reflects ${VERSION}, clone EE fresh, bump it transiently, and
+          # regenerate. This decouples docs from any prior release-prep
+          # state — broken or stale CE release-branch artifacts no longer
+          # cause incorrect docs.
+          git clone --depth 1 --branch "release/${MINOR}" \
+            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
+
+          ./kubelb-ce/hack/release/bump-versions.sh --target-dir /tmp/kubelb-ee "$VERSION"
+
+          # Generate chart README.md tables (helm-docs auto-installs via the
+          # EE Makefile). go.mod / go.sum in /tmp/kubelb-ee drives the install.
+          (cd /tmp/kubelb-ee && go mod download && make generate-helm-docs)
+
+          # Extract just the values tables to a known location.
+          mkdir -p /tmp/ee-helm-values
+          ./kubelb-ce/hack/release/extract-helm-values.sh \
+            /tmp/kubelb-ee/charts /tmp/ee-helm-values "-ee"
+
+          ls -la /tmp/ee-helm-values/
 
       - name: Setup for minor release
         if: inputs.is_patch == 'false'
@@ -166,30 +211,50 @@ jobs:
         run: |
           DOCS_DIR="content/kubelb/${MINOR}"
 
+          # Map each marker to (source_kind, source_location):
+          #   url:<path>   — fetch from refs/heads/release/${MINOR}/<path>
+          #   file:<path>  — read from local <path> (regenerated EE artifacts)
+          #
+          # CE charts are bumped on the CE release branch by release-prep, so
+          # docs/generated/helm-values-kubelb-{manager,ccm}.md on that branch
+          # is the live source of truth. Fetch via raw URL.
+          #
+          # EE chart values stay frozen on the EE release branch — release-prep
+          # bumps a transient /tmp clone and never commits back. To get
+          # ${VERSION}-correct EE helm-values we regenerated locally in the
+          # previous step; read those files directly. This decouples EE docs
+          # from any prior release-prep state.
           declare -A MARKERS
-          MARKERS["kubelb-manager"]="docs/generated/helm-values-kubelb-manager.md"
-          MARKERS["kubelb-ccm"]="docs/generated/helm-values-kubelb-ccm.md"
-          MARKERS["kubelb-manager-ee"]="docs/generated/helm-values-kubelb-manager-ee.md"
-          MARKERS["kubelb-ccm-ee"]="docs/generated/helm-values-kubelb-ccm-ee.md"
+          MARKERS["kubelb-manager"]="url:docs/generated/helm-values-kubelb-manager.md"
+          MARKERS["kubelb-ccm"]="url:docs/generated/helm-values-kubelb-ccm.md"
+          MARKERS["kubelb-manager-ee"]="file:/tmp/ee-helm-values/helm-values-kubelb-manager-ee.md"
+          MARKERS["kubelb-ccm-ee"]="file:/tmp/ee-helm-values/helm-values-kubelb-ccm-ee.md"
 
           declare -A MATCHED
           for marker in "${!MARKERS[@]}"; do MATCHED[$marker]=0; done
 
           for marker in "${!MARKERS[@]}"; do
-            REMOTE_FILE="${MARKERS[$marker]}"
-            # Fetch from the release branch HEAD, not the immutable tag.
-            # The v1.4.0 tag was created with broken EE artifacts; the fix
-            # landed on release/v1.4 post-tag. Branch-based source means the
-            # docs always reflect the latest fixes for that minor (which is
-            # what users on that minor would actually install). Tags can be
-            # frozen with bugs; release branches are the live source of truth.
-            RAW_URL="https://raw.githubusercontent.com/${KUBELB_REPO}/refs/heads/release/${MINOR}/${REMOTE_FILE}"
-            TABLE=$(curl -sfL "$RAW_URL" || echo "")
+            SPEC="${MARKERS[$marker]}"
+            KIND="${SPEC%%:*}"
+            SRC="${SPEC#*:}"
 
-            if [ -z "$TABLE" ]; then
-              echo "::warning::Could not fetch ${REMOTE_FILE} from release/${MINOR}, skipping ${marker}"
-              continue
-            fi
+            case "$KIND" in
+              url)
+                RAW_URL="https://raw.githubusercontent.com/${KUBELB_REPO}/refs/heads/release/${MINOR}/${SRC}"
+                TABLE=$(curl -sfL "$RAW_URL" || echo "")
+                if [ -z "$TABLE" ]; then
+                  echo "::error::Could not fetch ${SRC} from release/${MINOR}"
+                  exit 1
+                fi
+                ;;
+              file)
+                if [ ! -f "$SRC" ]; then
+                  echo "::error::Local helm-values file not found: ${SRC}"
+                  exit 1
+                fi
+                TABLE=$(cat "$SRC")
+                ;;
+            esac
 
             START_MARKER="<!-- helm-values-${marker} start -->"
             END_MARKER="<!-- helm-values-${marker} end -->"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -135,12 +135,11 @@ jobs:
             "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
           cd /tmp/kubelb-ee
           git fetch --tags
-          for chart in kubelb-manager kubelb-ccm; do
-            [ -f "charts/${chart}/Chart.yaml" ] || continue
-            sed -i "s/^version:.*/version: ${VERSION}/" "charts/${chart}/Chart.yaml"
-            sed -i "s/^appVersion:.*/appVersion: ${VERSION}/" "charts/${chart}/Chart.yaml"
-            sed -i "0,/^  tag:/{s/^  tag:.*/  tag: ${VERSION}/}" "charts/${chart}/values.yaml"
-          done
+          # Bump EE chart values in /tmp clone only — never committed back.
+          # EE keeps its release branch values frozen at the last shipped
+          # version; the bump happens transiently in CI per release.
+          cd "${GITHUB_WORKSPACE}"
+          ./hack/release/bump-versions.sh --target-dir /tmp/kubelb-ee "$VERSION"
 
       - name: Generate artifacts (CE codegen + EE docs)
         env:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -126,6 +126,7 @@ jobs:
         run: ./hack/release/bump-versions.sh "$VERSION"
 
       - name: Clone and bump EE
+        id: ee-clone
         env:
           KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
           VERSION: ${{ inputs.version }}
@@ -135,6 +136,13 @@ jobs:
             "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
           cd /tmp/kubelb-ee
           git fetch --tags
+          # Capture EE HEAD SHA at prep time. release-auto-tag pins the EE
+          # tag to this exact SHA so that an EE push between prep PR creation
+          # and merge cannot cause CE/EE tags to diverge from what was
+          # reviewed in the prep PR.
+          EE_HEAD_SHA=$(git rev-parse HEAD)
+          echo "ee_head_sha=${EE_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "::notice::EE prep SHA: ${EE_HEAD_SHA}"
           # Bump EE chart values in /tmp clone only — never committed back.
           # EE keeps its release branch values frozen at the last shipped
           # version; the bump happens transiently in CI per release.
@@ -250,6 +258,8 @@ jobs:
           - [ ] Vulnerability scan passed
           - [ ] CI green
           - [ ] Cherry-picks complete
+
+          <!-- EE-SHA: ${{ steps.ee-clone.outputs.ee_head_sha }} -->
 
           <details>
           <summary><b>Release Notes Preview</b></summary>

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -76,11 +76,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
           VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           MINOR=$(echo "$VERSION" | grep -oE 'v[0-9]+\.[0-9]+')
           if gh api "repos/${EE_REPO}/branches/release/${MINOR}" --jq '.name' >/dev/null 2>&1; then
             echo "::notice::EE release branch release/${MINOR} already exists"
           else
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::error::[dry-run] EE release branch release/${MINOR} does not exist; cannot proceed (subsequent clone would fail). Re-run with dry_run=false or pre-create the branch."
+              exit 1
+            fi
             echo "Creating EE release branch release/${MINOR} from main..."
             MAIN_SHA=$(gh api "repos/${EE_REPO}/git/ref/heads/main" --jq '.object.sha')
             gh api "repos/${EE_REPO}/git/refs" \
@@ -92,8 +97,13 @@ jobs:
       - name: Ensure CE release branch exists
         env:
           BRANCH: ${{ inputs.branch }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::error::[dry-run] CE release branch $BRANCH does not exist; cannot proceed without creating it. Re-run with dry_run=false or pre-create the branch."
+              exit 1
+            fi
             echo "Creating CE release branch $BRANCH from main..."
             git checkout main
             git checkout -b "$BRANCH"
@@ -219,6 +229,7 @@ jobs:
           KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
           VERSION: ${{ inputs.version }}
           BASE_BRANCH: ${{ inputs.branch }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           BRANCH="chore/prepare-${VERSION}"
 
@@ -232,8 +243,6 @@ jobs:
           echo "::endgroup::"
           git add -A
           git commit -s -m "chore: prepare ${VERSION}"
-          git remote set-url origin "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${{ github.repository }}.git"
-          git push origin "${BRANCH}"
 
           MINOR=$(echo "${VERSION}" | grep -oE 'v[0-9]+\.[0-9]+')
           CHANGELOG_FILE="docs/changelogs/CHANGELOG-${MINOR}.md"
@@ -242,11 +251,7 @@ jobs:
             NOTES_PREVIEW=$(head -100 "$CHANGELOG_FILE")
           fi
 
-          gh pr create \
-            --base "${BASE_BRANCH}" \
-            --head "${BRANCH}" \
-            --title "chore: prepare ${VERSION}" \
-            --body-file - <<PREOF
+          PR_BODY=$(cat <<PREOF
           **What this PR does / why we need it**:
           Prepare release ${VERSION}. Bumps chart versions, regenerates docs, and generates release notes.
 
@@ -283,6 +288,29 @@ jobs:
           NONE
           \`\`\`
           PREOF
+          )
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::group::[dry-run] would push branch ${BRANCH}"
+            git log -1 --stat
+            echo "::endgroup::"
+            echo "::group::[dry-run] would open PR — title: chore: prepare ${VERSION}"
+            printf '%s\n' "$PR_BODY"
+            echo "::endgroup::"
+            echo "::group::[dry-run] would add labels: release-note-none, kind/chore"
+            echo "::endgroup::"
+            echo "::notice::dry-run complete — no remote writes performed"
+            exit 0
+          fi
+
+          git remote set-url origin "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "${BRANCH}"
+
+          printf '%s\n' "$PR_BODY" | gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${BRANCH}" \
+            --title "chore: prepare ${VERSION}" \
+            --body-file -
 
           gh pr edit "${BRANCH}" --add-label "release-note-none" 2>/dev/null || true
           gh pr edit "${BRANCH}" --add-label "kind/chore" 2>/dev/null || true

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -30,8 +30,16 @@ on:
         required: false
         type: string
         default: ""
+      dry_run:
+        description: "Dry run: bump charts and generate artifacts but skip all writes (no branch creation, no commits pushed, no PR opened)."
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
+
+env:
+  EE_REPO: kubermatic/kubelb-ee
 
 jobs:
   prep:
@@ -70,7 +78,6 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           MINOR=$(echo "$VERSION" | grep -oE 'v[0-9]+\.[0-9]+')
-          EE_REPO="kubermatic/kubelb-ee"
           if gh api "repos/${EE_REPO}/branches/release/${MINOR}" --jq '.name' >/dev/null 2>&1; then
             echo "::notice::EE release branch release/${MINOR} already exists"
           else
@@ -133,7 +140,7 @@ jobs:
         run: |
           MINOR=$(echo "$VERSION" | grep -oE 'v[0-9]+\.[0-9]+')
           git clone --branch "release/${MINOR}" \
-            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
+            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${EE_REPO}.git" /tmp/kubelb-ee
           cd /tmp/kubelb-ee
           git fetch --tags
           # Capture EE HEAD SHA at prep time. release-auto-tag pins the EE
@@ -197,7 +204,7 @@ jobs:
           if [ -n "$PREV_TAG" ]; then
             ./hack/release/generate-notes.sh "$VERSION" "$PREV_TAG" \
               --branch "$BRANCH" \
-              --ee-repo kubermatic/kubelb-ee --ee-path /tmp/kubelb-ee --ee-branch "release/${MINOR}" \
+              --ee-repo "${EE_REPO}" --ee-path /tmp/kubelb-ee --ee-branch "release/${MINOR}" \
               kubermatic/kubelb
           else
             echo "::notice::No reachable previous tag found, skipping release notes generation"

--- a/hack/release/bump-versions.sh
+++ b/hack/release/bump-versions.sh
@@ -15,27 +15,60 @@
 
 #!/usr/bin/env bash
 # Bump Chart.yaml version/appVersion and values.yaml image tag for kubelb-manager and kubelb-ccm.
-# Usage: bump-versions.sh [--dry-run] <VERSION>
+# Usage: bump-versions.sh [--dry-run] [--target-dir <dir>] <VERSION>
 # VERSION must be semver with v prefix: v1.4.0, v1.4.0-rc.1
+#
+# --target-dir <dir>: bump charts under <dir>/charts/ instead of the CE workspace.
+#   Used by release workflows to bump a freshly-cloned kubelb-ee in /tmp without
+#   committing the bump back. Defaults to the CE workspace root.
+#
+# When --target-dir is given:
+#   - The local-tag-exists check is skipped (the target may be a transient clone).
+#   - The git-tag check still runs against the CE workspace if invoked from there.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 DRY_RUN=false
-if [[ "${1:-}" == "--dry-run" ]]; then
-  DRY_RUN=true
-  shift
-fi
+TARGET_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --target-dir)
+      TARGET_DIR="${2:?--target-dir requires a value}"
+      shift 2
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $1" >&2
+      echo "Usage: bump-versions.sh [--dry-run] [--target-dir <dir>] <VERSION>" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
-VERSION="${1:?Usage: bump-versions.sh [--dry-run] <VERSION>}"
+VERSION="${1:?Usage: bump-versions.sh [--dry-run] [--target-dir <dir>] <VERSION>}"
+TARGET_DIR="${TARGET_DIR:-$REPO_ROOT}"
+
+if [[ ! -d "$TARGET_DIR/charts" ]]; then
+  echo "ERROR: charts directory not found: $TARGET_DIR/charts" >&2
+  exit 1
+fi
 
 if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
   echo "ERROR: Invalid version format: $VERSION (expected vX.Y.Z or vX.Y.Z-rc.N)" >&2
   exit 1
 fi
 
-if git tag -l "$VERSION" | grep -q .; then
+# The local tag check only makes sense for the CE workspace. External clones
+# (e.g. /tmp/kubelb-ee in CI) are throw-away — re-bumping them is fine.
+if [[ "$TARGET_DIR" == "$REPO_ROOT" ]] && git tag -l "$VERSION" | grep -q .; then
   echo "ERROR: Tag $VERSION already exists" >&2
   exit 1
 fi
@@ -51,8 +84,13 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 for chart in "${CHARTS[@]}"; do
-  CHART_YAML="${REPO_ROOT}/charts/${chart}/Chart.yaml"
-  VALUES_YAML="${REPO_ROOT}/charts/${chart}/values.yaml"
+  CHART_YAML="${TARGET_DIR}/charts/${chart}/Chart.yaml"
+  VALUES_YAML="${TARGET_DIR}/charts/${chart}/values.yaml"
+
+  if [[ ! -f "$CHART_YAML" ]]; then
+    echo "  skip ${chart}: ${CHART_YAML} not found"
+    continue
+  fi
 
   if [[ "$DRY_RUN" == "true" ]]; then
     echo "=== ${chart}/Chart.yaml ==="
@@ -66,4 +104,4 @@ for chart in "${CHARTS[@]}"; do
   fi
 done
 
-echo "Bumped charts to ${VERSION}"
+echo "Bumped charts in ${TARGET_DIR} to ${VERSION}"

--- a/hack/release/bump-versions.sh
+++ b/hack/release/bump-versions.sh
@@ -34,22 +34,22 @@ DRY_RUN=false
 TARGET_DIR=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run)
-      DRY_RUN=true
-      shift
-      ;;
-    --target-dir)
-      TARGET_DIR="${2:?--target-dir requires a value}"
-      shift 2
-      ;;
-    -*)
-      echo "ERROR: unknown flag: $1" >&2
-      echo "Usage: bump-versions.sh [--dry-run] [--target-dir <dir>] <VERSION>" >&2
-      exit 1
-      ;;
-    *)
-      break
-      ;;
+  --dry-run)
+    DRY_RUN=true
+    shift
+    ;;
+  --target-dir)
+    TARGET_DIR="${2:?--target-dir requires a value}"
+    shift 2
+    ;;
+  -*)
+    echo "ERROR: unknown flag: $1" >&2
+    echo "Usage: bump-versions.sh [--dry-run] [--target-dir <dir>] <VERSION>" >&2
+    exit 1
+    ;;
+  *)
+    break
+    ;;
   esac
 done
 

--- a/hack/release/generate-docs.sh
+++ b/hack/release/generate-docs.sh
@@ -86,11 +86,15 @@ if [[ ! -d "$EE_PATH" ]]; then
 fi
 
 echo "==> Generating EE docs from ${EE_PATH}"
+# Do NOT swallow these failures with `|| echo`. A failed make produces
+# stale chart README.md / metrics.md, which extract-helm-values.sh then
+# happily reads — silently shipping wrong docs/generated/*-ee.md. This
+# is exactly the cascade that produced the broken v1.4.0 EE artifacts.
 (
   cd "$EE_PATH"
   go mod download
-  make generate-metricsdocs || echo "::warning::EE generate-metricsdocs failed"
-  make generate-helm-docs || echo "::warning::EE generate-helm-docs failed"
+  make generate-metricsdocs
+  make generate-helm-docs
 )
 
 # EE Makefile vintage may emit metrics to either docs/generated/metrics.md or docs/metrics.md.


### PR DESCRIPTION
**What this PR does / why we need it**:

Five targeted fixes for issues uncovered by the v1.4.0 release docs flow. Each commit addresses one specific failure mode; no blanket changes.

**1. `release-docs-update.yml`: scope products.yaml check to the `kubelb:` section** (`75e0093`)

`grep -q "release: ${MINOR}" data/products.yaml` matches *any* product. KubeOne is also at v1.4 — so the check returned true, the awk insert was skipped, and the v1.4.0 docs PR shipped without a `kubelb v1.4` entry in products.yaml. Replaced with section-scoped awk that only checks inside the `kubelb:` block.

**2. `release-docs-update.yml`: fetch CE helm-values from release branch, not tag** (`ec1ce73`)

Tags are immutable; the v1.4.0 tag was created with broken EE helm-values, then PR #418 fixed them on `release/v1.4` HEAD post-tag. The docs site rendered the stale tag content. Switched the source to `refs/heads/release/${MINOR}` for CE markers.

Same commit also: tracks per-marker hit count, fails the step at end if any of the 4 expected markers (`kubelb-{manager,ccm}{,-ee}`) was never matched, and switches `find | while read` to process substitution so the increment is not scoped to a subshell.

**3. `hack/release/generate-docs.sh`: fail hard on EE codegen errors** (`9d0fa42`)

`make generate-metricsdocs || echo "::warning::..."` swallowed non-zero exits. A failed make produced stale chart READMEs / `metrics.md`, which `extract-helm-values.sh` then read — silently shipping wrong `docs/generated/*-ee.md`. Removed the `|| echo` so `set -euo pipefail` propagates.

**4. `bump-versions.sh`: add `--target-dir` flag for external clones** (`95dd046`)

EE chart values stay frozen on the EE release branch — release-prep bumps a transient `/tmp/kubelb-ee` per release without ever committing the bump back. The inline 5-line sed in `release-prep.yml`'s `Clone and bump EE` step duplicated `bump-versions.sh`'s logic. Added a `--target-dir` flag so the same script works against any chart layout, then refactored release-prep to use it. The "tag already exists" guard only runs for the CE workspace path (transient external clones legitimately need re-bumping).

**5. `release-docs-update.yml`: regenerate EE helm-values from a bumped EE clone** (`9e77b47`)

Fix 2 made CE markers safe by sourcing from the CE release branch (where CE charts ARE bumped). EE markers were left fetching from the same branch — but that only works if release-prep correctly bumped EE in `/tmp` and committed the resulting EE markdown to CE's release branch. If release-prep regresses, broken EE artifacts get baked into docs again.

Defense in depth: in `release-docs-update` itself, clone `kubelb-ee@release/${MINOR}`, bump via `bump-versions.sh --target-dir`, regenerate EE helm-values markdowns locally, then have the marker substitution read EE markers from the local files. CE markers still use the URL fetch (asymmetric on purpose — CE charts ARE bumped on the CE branch).

Wires `KUBELB_EE_TOKEN` through `release-auto-tag.yml` so the `workflow_call` chain has access.

**What is NOT in this PR (intentionally)**:
- The version-string sweep stays as-is. Per discussion, blanket `v1.3.X → v1.4.0` rewrites would clobber intentional historical references (compatibility matrix, cosign verify examples, airgap docs example versions). The narrow heuristic is the right scope.
- No worktree/plan-driven refactor; these are surgical fixes to specific failure modes from the v1.4.0 postmortem.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind bug
/kind chore

**Special notes for your reviewer**:
- 5 self-contained commits, each with a long-form message documenting the failure mode it addresses.
- Backports to `release/v1.3` and `release/v1.4` will be straightforward (no conflicts expected).
- All five fixes were validated locally: products.yaml awk against the live `kubermatic/docs` data; release-branch curl returns the corrected EE helm-values content; `bump-versions.sh --target-dir` against `/Users/waleedmalik/go/src/k8c.io/kubelb-ee`; helm-docs flow against bumped EE clone produces v1.4.0 EE helm-values markdown.

```release-note
NONE
```

```documentation
NONE
```