### PR TITLE
envoy: streaming-friendly HTTP timeout defaults

### DIFF
--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -473,6 +473,11 @@ func makeHTTPListener(listenerName string, clusterName string, listenerPort uint
 				Action: &envoyRoute.Route_Route{
 					Route: &envoyRoute.RouteAction{
 						ClusterSpecifier: &envoyRoute.RouteAction_Cluster{Cluster: clusterName},
+						// Disable per-request timeout. Envoy's 15s default cuts off
+						// streaming/large-file workloads (object-storage downloads,
+						// model artifacts). Edge proxies enforce request bounds in
+						// front of KubeLB.
+						Timeout: durationpb.New(0),
 					},
 				},
 			}},
@@ -511,10 +516,15 @@ func makeHTTPListener(listenerName string, clusterName string, listenerPort uint
 			InitialStreamWindowSize:     wrapperspb.UInt32(math.MaxInt32),
 			InitialConnectionWindowSize: wrapperspb.UInt32(math.MaxInt32),
 		},
-		// Common HTTP protocol options
+		// Common HTTP protocol options. Idle timeout raised from 60s to 1h
+		// so long-lived HTTP connections (websockets, SSE, gRPC streams)
+		// aren't cycled mid-flight.
 		CommonHttpProtocolOptions: &envoyCore.HttpProtocolOptions{
-			IdleTimeout: durationpb.New(60 * time.Second),
+			IdleTimeout: durationpb.New(time.Hour),
 		},
+		// Stream idle timeout raised from Envoy's 5m default to 1h to
+		// match streaming-friendly idle handling.
+		StreamIdleTimeout: durationpb.New(time.Hour),
 		UpgradeConfigs: []*envoyHttpManager.HttpConnectionManager_UpgradeConfig{
 			{UpgradeType: "websocket"},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjusts three HTTP timeout defaults in the KubeLB-managed Envoy proxy so streaming and large-file workloads (object-storage downloads, model artifacts, websockets, SSE, long-running gRPC streams) aren't cut off mid-flight by stock Envoy defaults.

| Field | Was | Now |
|---|---|---|
| `RouteAction.Timeout` | unset → Envoy default **15s** | **`0`** (disabled) |
| HCM `StreamIdleTimeout` | unset → Envoy default **5m** | **`1h`** |
| HCM `CommonHttpProtocolOptions.IdleTimeout` | hardcoded **60s** | **`1h`** |

Edge proxies (Ingress controller, Envoy Gateway) enforce per-request bounds in front of KubeLB, so the KubeLB Envoy layer's per-request timeout was double-bounding legitimate streaming traffic.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HTTP idle-connection timeout default raised from 60s to 1h, and per-request timeout default changed from 15s (Envoy default) to disabled (streaming-friendly)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
