### PR TITLE
fix(envoy): use STRICT_DNS for hostname endpoints in LB and Route clusters

### DIFF
--- a/api/ce/kubelb.k8c.io/v1alpha1/common_types.go
+++ b/api/ce/kubelb.k8c.io/v1alpha1/common_types.go
@@ -81,12 +81,16 @@ type EndpointPort struct {
 	Protocol corev1.Protocol `json:"protocol,omitempty" protobuf:"bytes,3,opt,name=protocol,casttype=Protocol"`
 }
 
-// EndpointAddress is a tuple that describes single IP address.
+// EndpointAddress is a tuple that describes a single endpoint address. At least
+// one of IP or Hostname must be set.
+// +kubebuilder:validation:XValidation:rule="size(self.ip) > 0 || size(self.hostname) > 0",message="at least one of ip or hostname must be set"
 type EndpointAddress struct {
 	// The IP of the endpoint. This can be an IPv4 or IPv6 address.
 	// The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses.
-	IP string `json:"ip" protobuf:"bytes,1,opt,name=ip"`
-	// The Hostname of this endpoint
+	// +optional
+	IP string `json:"ip,omitempty" protobuf:"bytes,1,opt,name=ip"`
+	// The Hostname of this endpoint. Used when the backend has no stable IP and
+	// must be resolved by DNS. If both ip and hostname are set, ip wins.
 	// +optional
 	Hostname string `json:"hostname,omitempty" protobuf:"bytes,3,opt,name=hostname"`
 }

--- a/api/ee/kubelb.k8c.io/v1alpha1/common_types.go
+++ b/api/ee/kubelb.k8c.io/v1alpha1/common_types.go
@@ -87,12 +87,16 @@ type EndpointPort struct {
 	Protocol corev1.Protocol `json:"protocol,omitempty" protobuf:"bytes,3,opt,name=protocol,casttype=Protocol"`
 }
 
-// EndpointAddress is a tuple that describes single IP address.
+// EndpointAddress is a tuple that describes a single endpoint address. At least
+// one of IP or Hostname must be set.
+// +kubebuilder:validation:XValidation:rule="size(self.ip) > 0 || size(self.hostname) > 0",message="at least one of ip or hostname must be set"
 type EndpointAddress struct {
 	// The IP of the endpoint. This can be an IPv4 or IPv6 address.
 	// The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses.
-	IP string `json:"ip" protobuf:"bytes,1,opt,name=ip"`
-	// The Hostname of this endpoint
+	// +optional
+	IP string `json:"ip,omitempty" protobuf:"bytes,1,opt,name=ip"`
+	// The Hostname of this endpoint. Used when the backend has no stable IP and
+	// must be resolved by DNS. If both ip and hostname are set, ip wins.
 	// +optional
 	Hostname string `json:"hostname,omitempty" protobuf:"bytes,3,opt,name=hostname"`
 }

--- a/charts/kubelb-manager/crds/kubelb.k8c.io_addresses.yaml
+++ b/charts/kubelb-manager/crds/kubelb.k8c.io_addresses.yaml
@@ -42,20 +42,24 @@ spec:
               addresses:
                 description: Addresses contains a list of addresses.
                 items:
-                  description: EndpointAddress is a tuple that describes single IP
-                    address.
+                  description: |-
+                    EndpointAddress is a tuple that describes a single endpoint address. At least
+                    one of IP or Hostname must be set.
                   properties:
                     hostname:
-                      description: The Hostname of this endpoint
+                      description: |-
+                        The Hostname of this endpoint. Used when the backend has no stable IP and
+                        must be resolved by DNS. If both ip and hostname are set, ip wins.
                       type: string
                     ip:
                       description: |-
                         The IP of the endpoint. This can be an IPv4 or IPv6 address.
                         The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses.
                       type: string
-                  required:
-                  - ip
                   type: object
+                  x-kubernetes-validations:
+                  - message: at least one of ip or hostname must be set
+                    rule: size(self.ip) > 0 || size(self.hostname) > 0
                 minItems: 1
                 type: array
             type: object

--- a/charts/kubelb-manager/crds/kubelb.k8c.io_loadbalancers.yaml
+++ b/charts/kubelb-manager/crds/kubelb.k8c.io_loadbalancers.yaml
@@ -69,20 +69,24 @@ spec:
                         IP addresses which offer the related ports that are marked as ready. These endpoints
                         should be considered safe for load balancers and clients to utilize.
                       items:
-                        description: EndpointAddress is a tuple that describes single
-                          IP address.
+                        description: |-
+                          EndpointAddress is a tuple that describes a single endpoint address. At least
+                          one of IP or Hostname must be set.
                         properties:
                           hostname:
-                            description: The Hostname of this endpoint
+                            description: |-
+                              The Hostname of this endpoint. Used when the backend has no stable IP and
+                              must be resolved by DNS. If both ip and hostname are set, ip wins.
                             type: string
                           ip:
                             description: |-
                               The IP of the endpoint. This can be an IPv4 or IPv6 address.
                               The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses.
                             type: string
-                        required:
-                        - ip
                         type: object
+                        x-kubernetes-validations:
+                        - message: at least one of ip or hostname must be set
+                          rule: size(self.ip) > 0 || size(self.hostname) > 0
                       minItems: 1
                       type: array
                     addressesReference:

--- a/charts/kubelb-manager/crds/kubelb.k8c.io_routes.yaml
+++ b/charts/kubelb-manager/crds/kubelb.k8c.io_routes.yaml
@@ -67,20 +67,24 @@ spec:
                         IP addresses which offer the related ports that are marked as ready. These endpoints
                         should be considered safe for load balancers and clients to utilize.
                       items:
-                        description: EndpointAddress is a tuple that describes single
-                          IP address.
+                        description: |-
+                          EndpointAddress is a tuple that describes a single endpoint address. At least
+                          one of IP or Hostname must be set.
                         properties:
                           hostname:
-                            description: The Hostname of this endpoint
+                            description: |-
+                              The Hostname of this endpoint. Used when the backend has no stable IP and
+                              must be resolved by DNS. If both ip and hostname are set, ip wins.
                             type: string
                           ip:
                             description: |-
                               The IP of the endpoint. This can be an IPv4 or IPv6 address.
                               The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses.
                             type: string
-                        required:
-                        - ip
                         type: object
+                        x-kubernetes-validations:
+                        - message: at least one of ip or hostname must be set
+                          rule: size(self.ip) > 0 || size(self.hostname) > 0
                       minItems: 1
                       type: array
                     addressesReference:

--- a/config/crd/bases/kubelb.k8c.io_addresses.yaml
+++ b/config/crd/bases/kubelb.k8c.io_addresses.yaml
@@ -42,20 +42,24 @@ spec:
               addresses:
                 description: Addresses contains a list of addresses.
                 items:
-                  description: EndpointAddress is a tuple that describes single IP
-                    address.
+                  description: |-
+                    EndpointAddress is a tuple that describes a single endpoint address. At least
+                    one of IP or Hostname must be set.
                   properties:
                     hostname:
-                      description: The Hostname of this endpoint
+                      description: |-
+                        The Hostname of this endpoint. Used when the backend has no stable IP and
+                        must be resolved by DNS. If both ip and hostname are set, ip wins.
                       type: string
                     ip:
                       description: |-
                         The IP of the endpoint. This can be an IPv4 or IPv6 address.
                         The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses.
                       type: string
-                  required:
-                  - ip
                   type: object
+                  x-kubernetes-validations:
+                  - message: at least one of ip or hostname must be set
+                    rule: size(self.ip) > 0 || size(self.hostname) > 0
                 minItems: 1
                 type: array
             type: object

--- a/config/crd/bases/kubelb.k8c.io_loadbalancers.yaml
+++ b/config/crd/bases/kubelb.k8c.io_loadbalancers.yaml
@@ -69,20 +69,24 @@ spec:
                         IP addresses which offer the related ports that are marked as ready. These endpoints
                         should be considered safe for load balancers and clients to utilize.
                       items:
-                        description: EndpointAddress is a tuple that describes single
-                          IP address.
+                        description: |-
+                          EndpointAddress is a tuple that describes a single endpoint address. At least
+                          one of IP or Hostname must be set.
                         properties:
                           hostname:
-                            description: The Hostname of this endpoint
+                            description: |-
+                              The Hostname of this endpoint. Used when the backend has no stable IP and
+                              must be resolved by DNS. If both ip and hostname are set, ip wins.
                             type: string
                           ip:
                             description: |-
                               The IP of the endpoint. This can be an IPv4 or IPv6 address.
                               The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses.
                             type: string
-                        required:
-                        - ip
                         type: object
+                        x-kubernetes-validations:
+                        - message: at least one of ip or hostname must be set
+                          rule: size(self.ip) > 0 || size(self.hostname) > 0
                       minItems: 1
                       type: array
                     addressesReference:

--- a/config/crd/bases/kubelb.k8c.io_routes.yaml
+++ b/config/crd/bases/kubelb.k8c.io_routes.yaml
@@ -67,20 +67,24 @@ spec:
                         IP addresses which offer the related ports that are marked as ready. These endpoints
                         should be considered safe for load balancers and clients to utilize.
                       items:
-                        description: EndpointAddress is a tuple that describes single
-                          IP address.
+                        description: |-
+                          EndpointAddress is a tuple that describes a single endpoint address. At least
+                          one of IP or Hostname must be set.
                         properties:
                           hostname:
-                            description: The Hostname of this endpoint
+                            description: |-
+                              The Hostname of this endpoint. Used when the backend has no stable IP and
+                              must be resolved by DNS. If both ip and hostname are set, ip wins.
                             type: string
                           ip:
                             description: |-
                               The IP of the endpoint. This can be an IPv4 or IPv6 address.
                               The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses.
                             type: string
-                        required:
-                        - ip
                         type: object
+                        x-kubernetes-validations:
+                        - message: at least one of ip or hostname must be set
+                          rule: size(self.ip) > 0 || size(self.hostname) > 0
                       minItems: 1
                       type: array
                     addressesReference:

--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net"
 	"strings"
 	"time"
 
@@ -126,8 +127,12 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 					listener = append(listener, makeUDPListener(key, key, port, lb.Spec.Persistence))
 				}
 				proxyProtocol := lbEndpointPort.Protocol == corev1.ProtocolTCP && lb.Annotations[kubelb.AnnotationProxyProtocol] == "v2"
-				endpoints = append(endpoints, makeClusterLoadAssignment(key, lbEndpoints))
-				cluster = append(cluster, makeCluster(key, lbEndpointPort.Protocol, "", proxyProtocol, lb.Spec.Persistence))
+				cla := makeClusterLoadAssignment(key, lbEndpoints)
+				discoveryType := pickClusterDiscoveryType(lbEndpoint.Addresses)
+				cluster = append(cluster, makeCluster(key, lbEndpointPort.Protocol, "", proxyProtocol, lb.Spec.Persistence, discoveryType, cla))
+				if discoveryType == envoyCluster.Cluster_EDS {
+					endpoints = append(endpoints, cla)
+				}
 			}
 		}
 	}
@@ -160,7 +165,9 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 			for _, port := range svc.Spec.Ports {
 				portLookupKey := fmt.Sprintf(kubelb.EnvoyListenerPattern, port.Port, port.Protocol)
 				var lbEndpoints []*envoyEndpoint.LbEndpoint
+				var routeAddresses []kubelbv1alpha1.EndpointAddress
 				for _, address := range route.Spec.Endpoints {
+					routeAddresses = append(routeAddresses, address.Addresses...)
 					for _, routeEndpoints := range address.Addresses {
 						lbEndpoints = append(lbEndpoints, makeEndpoint(routeEndpoints, uint32(port.NodePort)))
 					}
@@ -176,8 +183,12 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 				if l := makeRouteListener(key, listenerPort, port.Protocol, useHTTPListener); l != nil {
 					listener = append(listener, l)
 				}
-				endpoints = append(endpoints, makeClusterLoadAssignment(key, lbEndpoints))
-				cluster = append(cluster, makeCluster(key, port.Protocol, clusterRouteKind, false, nil))
+				cla := makeClusterLoadAssignment(key, lbEndpoints)
+				discoveryType := pickClusterDiscoveryType(routeAddresses)
+				cluster = append(cluster, makeCluster(key, port.Protocol, clusterRouteKind, false, nil, discoveryType, cla))
+				if discoveryType == envoyCluster.Cluster_EDS {
+					endpoints = append(endpoints, cla)
+				}
 			}
 		}
 	}
@@ -208,7 +219,7 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 	)
 }
 
-func makeCluster(clusterName string, protocol corev1.Protocol, routeKind string, proxyProtocol bool, persistence *kubelbv1alpha1.LoadBalancerPersistence) *envoyCluster.Cluster {
+func makeCluster(clusterName string, protocol corev1.Protocol, routeKind string, proxyProtocol bool, persistence *kubelbv1alpha1.LoadBalancerPersistence, discoveryType envoyCluster.Cluster_DiscoveryType, loadAssignment *envoyEndpoint.ClusterLoadAssignment) *envoyCluster.Cluster {
 	defaultHealthCheck := []*envoyCore.HealthCheck{
 		{
 			Timeout:            &durationpb.Duration{Seconds: defaultHealthCheckTimeoutSeconds},
@@ -234,9 +245,26 @@ func makeCluster(clusterName string, protocol corev1.Protocol, routeKind string,
 	cluster := &envoyCluster.Cluster{
 		Name:                 clusterName,
 		ConnectTimeout:       durationpb.New(5 * time.Second),
-		ClusterDiscoveryType: &envoyCluster.Cluster_Type{Type: envoyCluster.Cluster_EDS},
+		ClusterDiscoveryType: &envoyCluster.Cluster_Type{Type: discoveryType},
 		LbPolicy:             envoyCluster.Cluster_ROUND_ROBIN,
-		EdsClusterConfig: &envoyCluster.Cluster_EdsClusterConfig{
+		DnsLookupFamily:      envoyCluster.Cluster_AUTO,
+		HealthChecks:         defaultHealthCheck,
+		CommonLbConfig: &envoyCluster.Cluster_CommonLbConfig{
+			HealthyPanicThreshold: &envoyType.Percent{Value: 0},
+		},
+	}
+
+	switch discoveryType {
+	case envoyCluster.Cluster_STRICT_DNS, envoyCluster.Cluster_LOGICAL_DNS:
+		cluster.LoadAssignment = loadAssignment
+		// DnsRefreshRate / RespectDnsTtl are marked deprecated in the proto in
+		// favour of TypedDnsResolverConfig but remain the supported way to tune
+		// DNS behaviour for STRICT_DNS clusters; envoy-gateway uses the same
+		// fields. Migrate when upstream removes them.
+		cluster.DnsRefreshRate = durationpb.New(30 * time.Second) //nolint:staticcheck // SA1019
+		cluster.RespectDnsTtl = true                              //nolint:staticcheck // SA1019
+	default:
+		cluster.EdsClusterConfig = &envoyCluster.Cluster_EdsClusterConfig{
 			ServiceName: clusterName,
 			EdsConfig: &envoyCore.ConfigSource{
 				ResourceApiVersion: envoyCore.ApiVersion_V3,
@@ -254,12 +282,7 @@ func makeCluster(clusterName string, protocol corev1.Protocol, routeKind string,
 					},
 				},
 			},
-		},
-		DnsLookupFamily: envoyCluster.Cluster_AUTO,
-		HealthChecks:    defaultHealthCheck,
-		CommonLbConfig: &envoyCluster.Cluster_CommonLbConfig{
-			HealthyPanicThreshold: &envoyType.Percent{Value: 0},
-		},
+		}
 	}
 
 	if persistenceType(persistence) == kubelbv1alpha1.LoadBalancerPersistenceTypeSourceIP && (protocol == corev1.ProtocolTCP || protocol == corev1.ProtocolUDP) {
@@ -330,11 +353,36 @@ func makeClusterLoadAssignment(clusterName string, lbEndpoints []*envoyEndpoint.
 	}
 }
 
-func makeEndpoint(addr kubelbv1alpha1.EndpointAddress, port uint32) *envoyEndpoint.LbEndpoint {
-	address := addr.IP
-	if address == "" {
-		address = addr.Hostname
+// resolveEndpointLiteral returns the address string for an EndpointAddress and
+// whether it is an IP literal. It classifies by content, not by which field
+// the value lives in: directly-authored LoadBalancer manifests sometimes place
+// FQDNs in the IP field, while CCM hostname mode uses the Hostname field.
+// Both must produce a hostname-flagged literal so the cluster can be built
+// with the correct discovery type.
+func resolveEndpointLiteral(addr kubelbv1alpha1.EndpointAddress) (string, bool) {
+	if addr.IP != "" {
+		return addr.IP, net.ParseIP(addr.IP) != nil
 	}
+	if addr.Hostname != "" {
+		return addr.Hostname, net.ParseIP(addr.Hostname) != nil
+	}
+	return "", false
+}
+
+// pickClusterDiscoveryType returns STRICT_DNS if any address is a hostname,
+// otherwise EDS. EDS does no name resolution and rejects non-IP endpoints, so
+// any hostname in the set forces a DNS-aware cluster type.
+func pickClusterDiscoveryType(addrs []kubelbv1alpha1.EndpointAddress) envoyCluster.Cluster_DiscoveryType {
+	for _, a := range addrs {
+		if _, isIP := resolveEndpointLiteral(a); !isIP {
+			return envoyCluster.Cluster_STRICT_DNS
+		}
+	}
+	return envoyCluster.Cluster_EDS
+}
+
+func makeEndpoint(addr kubelbv1alpha1.EndpointAddress, port uint32) *envoyEndpoint.LbEndpoint {
+	literal, _ := resolveEndpointLiteral(addr)
 	return &envoyEndpoint.LbEndpoint{
 		HostIdentifier: &envoyEndpoint.LbEndpoint_Endpoint{
 			Endpoint: &envoyEndpoint.Endpoint{
@@ -342,7 +390,7 @@ func makeEndpoint(addr kubelbv1alpha1.EndpointAddress, port uint32) *envoyEndpoi
 					Address: &envoyCore.Address_SocketAddress{
 						SocketAddress: &envoyCore.SocketAddress{
 							Protocol: envoyCore.SocketAddress_TCP,
-							Address:  address,
+							Address:  literal,
 							PortSpecifier: &envoyCore.SocketAddress_PortValue{
 								PortValue: port,
 							},

--- a/internal/envoy/resource_test.go
+++ b/internal/envoy/resource_test.go
@@ -18,6 +18,7 @@ package envoy
 
 import (
 	"testing"
+	"time"
 
 	envoyCluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoyListener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -102,7 +103,7 @@ func TestMakeCluster_ProxyProtocol(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cluster := makeCluster("test-cluster", corev1.ProtocolTCP, "", tt.proxyProtocol, nil)
+			cluster := makeCluster("test-cluster", corev1.ProtocolTCP, "", tt.proxyProtocol, nil, envoyCluster.Cluster_EDS, nil)
 
 			if tt.wantTransport && cluster.TransportSocket == nil {
 				t.Error("expected TransportSocket to be set for proxy protocol v2")
@@ -146,7 +147,7 @@ func TestMakeCluster_Persistence(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cluster := makeCluster("test-cluster", tt.protocol, "", false, tt.persistence)
+			cluster := makeCluster("test-cluster", tt.protocol, "", false, tt.persistence, envoyCluster.Cluster_EDS, nil)
 			if cluster.GetLbPolicy() != tt.wantPolicy {
 				t.Fatalf("LbPolicy = %v, want %v", cluster.GetLbPolicy(), tt.wantPolicy)
 			}
@@ -390,4 +391,109 @@ func TestDedupListenersByAddress_LabelCardinalityMatches(t *testing.T) {
 	if len(out) != 1 {
 		t.Fatalf("expected 1 listener kept, got %d", len(out))
 	}
+}
+
+func TestResolveEndpointLiteral(t *testing.T) {
+	const (
+		testIP   = "10.0.0.1"
+		testFQDN = "node.example.com"
+	)
+	tests := []struct {
+		name        string
+		addr        kubelbv1alpha1.EndpointAddress
+		wantLiteral string
+		wantIsIP    bool
+	}{
+		{name: "ipv4 in IP field", addr: kubelbv1alpha1.EndpointAddress{IP: testIP}, wantLiteral: testIP, wantIsIP: true},
+		{name: "ipv6 in IP field", addr: kubelbv1alpha1.EndpointAddress{IP: "::1"}, wantLiteral: "::1", wantIsIP: true},
+		{name: "fqdn in IP field", addr: kubelbv1alpha1.EndpointAddress{IP: testFQDN}, wantLiteral: testFQDN, wantIsIP: false},
+		{name: "hostname only", addr: kubelbv1alpha1.EndpointAddress{Hostname: testFQDN}, wantLiteral: testFQDN, wantIsIP: false},
+		{name: "ip in hostname field", addr: kubelbv1alpha1.EndpointAddress{Hostname: testIP}, wantLiteral: testIP, wantIsIP: true},
+		{name: "both set, IP wins", addr: kubelbv1alpha1.EndpointAddress{IP: testIP, Hostname: testFQDN}, wantLiteral: testIP, wantIsIP: true},
+		{name: "empty", addr: kubelbv1alpha1.EndpointAddress{}, wantLiteral: "", wantIsIP: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLiteral, gotIsIP := resolveEndpointLiteral(tt.addr)
+			if gotLiteral != tt.wantLiteral || gotIsIP != tt.wantIsIP {
+				t.Errorf("resolveEndpointLiteral(%+v) = (%q, %v), want (%q, %v)", tt.addr, gotLiteral, gotIsIP, tt.wantLiteral, tt.wantIsIP)
+			}
+		})
+	}
+}
+
+func TestPickClusterDiscoveryType(t *testing.T) {
+	const (
+		testIP   = "10.0.0.1"
+		testFQDN = "node.example.com"
+	)
+	tests := []struct {
+		name  string
+		addrs []kubelbv1alpha1.EndpointAddress
+		want  envoyCluster.Cluster_DiscoveryType
+	}{
+		{
+			name:  "all IPs in IP field",
+			addrs: []kubelbv1alpha1.EndpointAddress{{IP: testIP}, {IP: "10.0.0.2"}},
+			want:  envoyCluster.Cluster_EDS,
+		},
+		{
+			name:  "any FQDN in IP field forces STRICT_DNS",
+			addrs: []kubelbv1alpha1.EndpointAddress{{IP: testIP}, {IP: testFQDN}},
+			want:  envoyCluster.Cluster_STRICT_DNS,
+		},
+		{
+			name:  "hostname only",
+			addrs: []kubelbv1alpha1.EndpointAddress{{Hostname: testFQDN}},
+			want:  envoyCluster.Cluster_STRICT_DNS,
+		},
+		{
+			name:  "mixed IP and hostname",
+			addrs: []kubelbv1alpha1.EndpointAddress{{IP: testIP}, {Hostname: testFQDN}},
+			want:  envoyCluster.Cluster_STRICT_DNS,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pickClusterDiscoveryType(tt.addrs); got != tt.want {
+				t.Errorf("pickClusterDiscoveryType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMakeCluster_DiscoveryType(t *testing.T) {
+	cla := makeClusterLoadAssignment("test-cluster", nil)
+
+	t.Run("EDS keeps EdsClusterConfig and no inline LoadAssignment", func(t *testing.T) {
+		c := makeCluster("test-cluster", corev1.ProtocolTCP, "", false, nil, envoyCluster.Cluster_EDS, cla)
+		if c.GetType() != envoyCluster.Cluster_EDS {
+			t.Errorf("type = %v, want EDS", c.GetType())
+		}
+		if c.EdsClusterConfig == nil {
+			t.Error("EdsClusterConfig should be set for EDS")
+		}
+		if c.LoadAssignment != nil {
+			t.Error("LoadAssignment should be nil for EDS (delivered via separate xDS resource)")
+		}
+	})
+
+	t.Run("STRICT_DNS sets inline LoadAssignment and drops EdsClusterConfig", func(t *testing.T) {
+		c := makeCluster("test-cluster", corev1.ProtocolTCP, "", false, nil, envoyCluster.Cluster_STRICT_DNS, cla)
+		if c.GetType() != envoyCluster.Cluster_STRICT_DNS {
+			t.Errorf("type = %v, want STRICT_DNS", c.GetType())
+		}
+		if c.EdsClusterConfig != nil {
+			t.Error("EdsClusterConfig must be nil for STRICT_DNS")
+		}
+		if c.LoadAssignment == nil {
+			t.Error("LoadAssignment must be set inline for STRICT_DNS")
+		}
+		if c.DnsRefreshRate == nil || c.DnsRefreshRate.AsDuration() != 30*time.Second { //nolint:staticcheck // SA1019
+			t.Errorf("DnsRefreshRate = %v, want 30s", c.DnsRefreshRate) //nolint:staticcheck // SA1019
+		}
+		if !c.RespectDnsTtl { //nolint:staticcheck // SA1019
+			t.Error("RespectDnsTtl must be true for STRICT_DNS")
+		}
+	})
 }

--- a/test/e2e/tests/layer4/service/hostname-endpoints/chainsaw-test.yaml
+++ b/test/e2e/tests/layer4/service/hostname-endpoints/chainsaw-test.yaml
@@ -1,0 +1,222 @@
+# Copyright 2026 The KubeLB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Hostname-endpoint LoadBalancer Test
+# Verifies the manager correctly translates hostname-bearing endpoints into
+# Envoy clusters with discovery type STRICT_DNS (not EDS, which only accepts
+# IPs and would reject the entire ClusterLoadAssignment).
+#
+# Two scenarios, both authored directly in the manager cluster (no CCM):
+#   1. hostname-only — uses the Hostname field.
+#   2. fqdn-in-ip    — places an FQDN in the IP field, mirroring a customer
+#                      manifest that slipped past the (now-relaxed) schema.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: hostname-endpoints-loadbalancer
+  labels:
+    all:
+    test: hostname-endpoints
+    resource: service
+    layer: layer4
+spec:
+  description: |
+    Apply LoadBalancer CRDs directly in the kubelb cluster with hostname-bearing
+    endpoints and verify Envoy xDS produces STRICT_DNS clusters (not EDS).
+  bindings:
+    - name: kubelb_namespace
+      value: tenant-primary
+  steps:
+    - name: create-lb-hostname-only
+      description: Hostname-only endpoint via the Hostname field
+      cluster: kubelb
+      try:
+        - apply:
+            resource:
+              apiVersion: kubelb.k8c.io/v1alpha1
+              kind: LoadBalancer
+              metadata:
+                name: lb-hostname-only
+                namespace: tenant-primary
+              spec:
+                type: ClusterIP
+                endpoints:
+                  - name: backend
+                    addresses:
+                      - hostname: nginx.example.com
+                    ports:
+                      - name: http
+                        port: 8181
+                        protocol: TCP
+                ports:
+                  - name: http
+                    port: 8181
+                    protocol: TCP
+        - assert:
+            timeout: 60s
+            resource:
+              apiVersion: kubelb.k8c.io/v1alpha1
+              kind: LoadBalancer
+              metadata:
+                name: lb-hostname-only
+                namespace: tenant-primary
+
+    - name: create-lb-fqdn-in-ip
+      description: Customer scenario — FQDN placed in the IP field
+      cluster: kubelb
+      try:
+        - apply:
+            resource:
+              apiVersion: kubelb.k8c.io/v1alpha1
+              kind: LoadBalancer
+              metadata:
+                name: lb-fqdn-in-ip
+                namespace: tenant-primary
+              spec:
+                type: ClusterIP
+                endpoints:
+                  - name: backend
+                    addresses:
+                      - ip: backend.example.com
+                    ports:
+                      - name: http
+                        port: 8182
+                        protocol: TCP
+                ports:
+                  - name: http
+                    port: 8182
+                    protocol: TCP
+        - assert:
+            timeout: 60s
+            resource:
+              apiVersion: kubelb.k8c.io/v1alpha1
+              kind: LoadBalancer
+              metadata:
+                name: lb-fqdn-in-ip
+                namespace: tenant-primary
+
+    - name: verify-strict-dns-in-xds
+      description: Both clusters must be STRICT_DNS in Envoy config_dump
+      cluster: kubelb
+      try:
+        - script:
+            timeout: 180s
+            content: |
+              set -e
+              NAMESPACE="tenant-primary"
+
+              POD=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name="$NAMESPACE" -o name 2>/dev/null | head -1)
+              [ -z "$POD" ] && { echo "No Envoy pod found in $NAMESPACE"; exit 1; }
+
+              kubectl port-forward -n "$NAMESPACE" $POD 29032:9001 >/dev/null 2>&1 &
+              PF_PID=$!
+              trap "kill $PF_PID 2>/dev/null || true" EXIT
+              sleep 3
+
+              for i in $(seq 1 30); do
+                DUMP=$(curl -s --max-time 5 http://127.0.0.1:29032/config_dump 2>/dev/null || true)
+
+                HOSTNAME_ONLY_TYPE=$(printf '%s' "$DUMP" | jq -r '
+                  [.configs[]
+                    | select(.["@type"] | contains("ClustersConfigDump"))
+                    | .dynamic_active_clusters[].cluster
+                    | select(.name | contains("lb-hostname-only"))
+                  ] | .[0].type // empty
+                ' 2>/dev/null || true)
+
+                FQDN_IN_IP_TYPE=$(printf '%s' "$DUMP" | jq -r '
+                  [.configs[]
+                    | select(.["@type"] | contains("ClustersConfigDump"))
+                    | .dynamic_active_clusters[].cluster
+                    | select(.name | contains("lb-fqdn-in-ip"))
+                  ] | .[0].type // empty
+                ' 2>/dev/null || true)
+
+                if [ "$HOSTNAME_ONLY_TYPE" = "STRICT_DNS" ] && [ "$FQDN_IN_IP_TYPE" = "STRICT_DNS" ]; then
+                  echo "Both clusters reported STRICT_DNS in xDS"
+                  exit 0
+                fi
+                sleep 3
+              done
+              echo "expected STRICT_DNS for both clusters; got hostname-only=$HOSTNAME_ONLY_TYPE fqdn-in-ip=$FQDN_IN_IP_TYPE"
+              echo "--- config_dump excerpt ---"
+              printf '%s' "$DUMP" | jq '[.configs[]
+                | select(.["@type"] | contains("ClustersConfigDump"))
+                | .dynamic_active_clusters[].cluster
+                | select(.name | test("lb-(hostname-only|fqdn-in-ip)"))
+                | {name: .name, type: .type, load_assignment: .load_assignment}
+              ]'
+              exit 1
+            check:
+              ($error == null): true
+
+    - name: verify-load-assignment-inline
+      description: STRICT_DNS clusters must carry an inline LoadAssignment (no EDS resource)
+      cluster: kubelb
+      try:
+        - script:
+            timeout: 60s
+            content: |
+              set -e
+              NAMESPACE="tenant-primary"
+
+              POD=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name="$NAMESPACE" -o name 2>/dev/null | head -1)
+              [ -z "$POD" ] && { echo "No Envoy pod found"; exit 1; }
+
+              kubectl port-forward -n "$NAMESPACE" $POD 29033:9001 >/dev/null 2>&1 &
+              PF_PID=$!
+              trap "kill $PF_PID 2>/dev/null || true" EXIT
+              sleep 3
+
+              DUMP=$(curl -s --max-time 5 http://127.0.0.1:29033/config_dump 2>/dev/null || true)
+
+              MISSING=$(printf '%s' "$DUMP" | jq -r '
+                [.configs[]
+                  | select(.["@type"] | contains("ClustersConfigDump"))
+                  | .dynamic_active_clusters[].cluster
+                  | select(.name | test("lb-(hostname-only|fqdn-in-ip)"))
+                  | select(.load_assignment == null or (.load_assignment.endpoints | length) == 0)
+                  | .name
+                ] | length
+              ' 2>/dev/null || echo "0")
+
+              if [ "$MISSING" != "0" ]; then
+                echo "$MISSING STRICT_DNS cluster(s) missing inline load_assignment"
+                exit 1
+              fi
+              echo "STRICT_DNS clusters have inline LoadAssignment"
+            check:
+              ($error == null): true
+
+    - name: cleanup
+      cluster: kubelb
+      try:
+        - delete:
+            ref:
+              apiVersion: kubelb.k8c.io/v1alpha1
+              kind: LoadBalancer
+              name: lb-hostname-only
+              namespace: tenant-primary
+        - delete:
+            ref:
+              apiVersion: kubelb.k8c.io/v1alpha1
+              kind: LoadBalancer
+              name: lb-fqdn-in-ip
+              namespace: tenant-primary
+      finally:
+        - script:
+            cluster: kubelb
+            content: |
+              kubectl delete loadbalancer.kubelb.k8c.io lb-hostname-only -n tenant-primary --ignore-not-found
+              kubectl delete loadbalancer.kubelb.k8c.io lb-fqdn-in-ip   -n tenant-primary --ignore-not-found


### PR DESCRIPTION
**What this PR does / why we need it**:

The manager builds every LoadBalancer/Route cluster as `Cluster_EDS` and ships endpoints via an EDS `ClusterLoadAssignment`. EDS performs no DNS resolution so endpoints must be IP literals. As soon as a hostname reaches an endpoint (either via `EndpointAddress.Hostname`, the CCM running with `--node-address-type=Hostname`, or a tenant placing an FQDN in `EndpointAddress.IP`), Envoy rejects the entire CLA with:

```
gRPC config for type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment rejected:
malformed IP address: <fqdn>. Consider setting resolver_name or setting cluster
type to 'STRICT_DNS' or 'LOGICAL_DNS'
```

The cluster goes dark for that LB/Route. Tunnels and bootstrap clusters were already on `STRICT_DNS`; only the data-plane path was wrong. This PR fixes this corner case.

The CRD also previously required `EndpointAddress.IP`, which made hostname-only addresses impossible to author. `ip` is now optional and a struct-level CEL rule enforces "at least one of `ip` or `hostname` must be set". The validation only fires when an `EndpointAddress` is present, so `AddressesReference`-only endpoints continue to work.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
- LoadBalancer and Route endpoints with hostnames (FQDNs) are now translated into Envoy STRICT_DNS clusters instead of EDS clusters, fixing "malformed IP address" rejections for tenants that use hostname-based
endpoints. 
- The `ip` field on EndpointAddress is now optional; at least one of `ip` or `hostname` must be set.
```

**Documentation**:

```documentation
NONE
```