### PR TITLE
tenant: tolerate missing PodMonitor CRD

### DIFF
--- a/internal/controllers/kubelb/tenant_controller.go
+++ b/internal/controllers/kubelb/tenant_controller.go
@@ -469,6 +469,9 @@ func (r *TenantReconciler) reconcilePodMonitor(ctx context.Context, namespace st
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(desired.GroupVersionKind())
 	err = r.Get(ctx, types.NamespacedName{Name: podMonitorName, Namespace: namespace}, existing)
+	if apimeta.IsNoMatchError(err) {
+		return nil
+	}
 	if kerrors.IsNotFound(err) {
 		return r.Create(ctx, desired)
 	}
@@ -486,7 +489,7 @@ func (r *TenantReconciler) deletePodMonitor(ctx context.Context, namespace strin
 	obj.SetGroupVersionKind(podMonitorGVK())
 	obj.SetName(podMonitorName)
 	obj.SetNamespace(namespace)
-	if err := r.Delete(ctx, obj); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.Delete(ctx, obj); err != nil && !kerrors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

The tenant controller reconciles a PodMonitor (`monitoring.coreos.com/v1`) on every pass — creating one when `EnvoyProxy.PodMonitor.Enabled=true`, deleting any leftover otherwise. On clusters without the Prometheus Operator CRDs installed, the API server doesn't recognize the kind and the call fails with `no matches for kind "PodMonitor" in version "monitoring.coreos.com/v1"`. That's `meta.NoKindMatchError`, not `IsNotFound`, so the existing guard didn't catch it and the tenant Ready condition flipped to `Failed` even though the desired state (no PodMonitor) was already true.

This treats `apimeta.IsNoMatchError` the same as `IsNotFound` on both the cleanup Delete and the Get before create/update.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

Repro: deploy on a cluster without `prometheus-operator` CRDs and leave `EnvoyProxy.PodMonitor` unset (or `Enabled: false`). Tenant status:

```
- type: Ready
  status: "False"
  reason: ReconciliationFailed
  message: 'failed to reconcile PodMonitor: no matches for kind "PodMonitor" in version "monitoring.coreos.com/v1"'
```

After the fix the tenant reconciles cleanly. If a user enables `PodMonitor` without installing the CRD we no-op rather than erroring — they'll notice nothing got created, but at least we don't wedge the tenant.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix tenant reconciler failing with `no matches for kind "PodMonitor"` on clusters without the Prometheus Operator CRDs installed.
```

**Documentation**:
```documentation
NONE
```