### PR TITLE
[release/v1.3] Backport release tooling fixes from v1.4.0 docs postmortem

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -8,6 +8,9 @@ on:
 
 permissions: {}
 
+env:
+  EE_REPO: kubermatic/kubelb-ee
+
 jobs:
   auto-tag:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore/prepare-v')
@@ -56,12 +59,28 @@ jobs:
           KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
           MINOR: ${{ steps.version.outputs.minor }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          git clone --depth 1 --branch "release/${MINOR}" \
-            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
+          # Pin EE tag to the SHA captured by release-prep at prep time so a
+          # push to release/${MINOR} between prep PR creation and merge cannot
+          # tag a state different from what the prep PR reviewed. Falls back
+          # to branch HEAD if the marker is absent (older prep PRs predating
+          # this change).
+          EE_SHA=$(printf '%s' "$PR_BODY" | grep -oE 'EE-SHA: [a-f0-9]{7,40}' | head -1 | awk '{print $2}')
+
+          # Need full history (not --depth 1) so we can tag an arbitrary SHA
+          # that may not be branch HEAD anymore.
+          git clone --branch "release/${MINOR}" \
+            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${EE_REPO}.git" /tmp/kubelb-ee
 
           cd /tmp/kubelb-ee
-          git tag "${VERSION}"
+          if [ -n "$EE_SHA" ]; then
+            echo "::notice::Tagging EE at prep-time SHA: ${EE_SHA}"
+            git tag "${VERSION}" "${EE_SHA}"
+          else
+            echo "::warning::No EE-SHA in prep PR body; tagging EE at release/${MINOR} HEAD"
+            git tag "${VERSION}"
+          fi
           git push origin "${VERSION}"
 
   docs-update:
@@ -73,6 +92,7 @@ jobs:
       is_patch: ${{ needs.auto-tag.outputs.is_patch }}
     secrets:
       KUBERMATIC_DOCS_TOKEN: ${{ secrets.KUBERMATIC_DOCS_TOKEN }}
+      KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
 
   notify:
     needs: [auto-tag, docs-update]
@@ -91,7 +111,7 @@ jobs:
         run: |
           BODY="### Release ${VERSION} — post-merge summary\n\n"
           BODY+="- **CE tag:** [\`${VERSION}\`](https://github.com/${REPO}/releases/tag/${VERSION})\n"
-          BODY+="- **EE tag:** [\`${VERSION}\`](https://github.com/kubermatic/kubelb-ee/releases/tag/${VERSION})\n"
+          BODY+="- **EE tag:** [\`${VERSION}\`](https://github.com/${EE_REPO}/releases/tag/${VERSION})\n"
 
           if [ -n "$DOCS_PR" ]; then
             BODY+="- **Docs PR:** ${DOCS_PR} ← **review and merge**\n"

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -189,42 +189,46 @@ jobs:
         run: |
           DOCS_DIR="content/kubelb/${MINOR}"
 
-          # Anchor-driven rewrite: only `vX.Y.Z` tokens that appear next to a
-          # kubelb-owned reference are bumped to ${VERSION}. A previous
-          # histogram-of-all-versions heuristic both corrupted unrelated
-          # references (envoy-gateway helm chart, compat-matrix rows) and
-          # silently missed kubelb-context lines whose version differed from
-          # the most-frequent token. Anchors are explicit so the failure mode
-          # for a new kubelb URL pattern is "silently not updated" (recover by
-          # adding the anchor) rather than "silently corrupted".
+          # Per-file rules: each known kubelb page lists exactly the perl
+          # expressions allowed to bump it. A previous find-sweep applied
+          # broad anchor patterns against every .md file in DOCS_DIR — that
+          # either corrupted unrelated references when anchors were too loose
+          # or silently missed legitimate ones when they were too tight.
+          # Scoping per file lets us write narrow regexes safely.
           #
-          # Each pattern keeps its kubelb anchor in a capture group and
-          # rewrites only the version segment. Patterns must not overlap each
-          # other for the same input substring.
-          PATTERNS=(
-            # quay.io image / chart tags: kubelb-manager, kubelb-ccm, EE variants,
-            # helm-charts/kubelb-*, connection-manager, etc.
-            's{(quay\.io/kubermatic/(?:helm-charts/)?kubelb[A-Za-z0-9-]*:)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
-            # helm pull/install --version= for kubelb OCI charts
-            's{(oci://quay\.io/kubermatic/helm-charts/kubelb[A-Za-z0-9-]*\s+--version=)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
-            # github release asset URLs
-            's{(github\.com/kubermatic/kubelb/releases/download/)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
-            # sbom/checksum filenames embedded in URLs or prose: kubelb_vX.Y.Z_...
-            's{\bkubelb_v\d+\.\d+\.\d+_}{kubelb_'"${VERSION}"'_}g'
-          )
+          # A missing file is treated as a warning, not a fatal error: pages
+          # may legitimately not exist on every release branch (e.g. a doc
+          # added on main after the minor was cut), and we'd rather skip
+          # than block the release on a renamed/moved entry.
+          #
+          # Rules use `perl -0777` (slurp) so multi-line patterns and ^/m
+          # anchors work. Multiple s/// statements per file are joined with `;`.
+          declare -A FILE_RULES
+          FILE_RULES["installation/management-cluster/_index.en.md"]='s{(oci://quay\.io/kubermatic/helm-charts/kubelb-manager(?:-ee)?\s+--version=)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
+          FILE_RULES["installation/tenant-cluster/_index.en.md"]='s{(oci://quay\.io/kubermatic/helm-charts/kubelb-ccm(?:-ee)?\s+--version=)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
+          FILE_RULES["ingress-to-gateway-api/kubelb-automation/_index.en.md"]='s{(oci://quay\.io/kubermatic/helm-charts/kubelb-ccm(?:-ee)?\s+--version=)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
+          # airgap: shell var, image/chart tag refs (host-agnostic so the
+          # quay.io source column and mirror.internal example column both
+          # bump together), and multi-line `--version vX.Y.Z` scoped to
+          # kubelb-manager/ccm charts only — kubelb-addons has its own
+          # version line in the same doc and must not bump with kubelb.
+          FILE_RULES["tutorials/airgap-installation/_index.en.md"]='s{^VERSION=v\d+\.\d+\.\d+$}{VERSION='"${VERSION}"'}gm; s{(kubermatic/(?:helm-charts/)?kubelb-(?:manager|ccm)(?:-ee)?:)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g; s{(oci://[^\s`]+kubelb-(?:manager|ccm)(?:-ee)?\s+\\\s*\n\s*--version[ =])v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
 
           UPDATED=0
-          while IFS= read -r file; do
+          for relpath in "${!FILE_RULES[@]}"; do
+            file="${DOCS_DIR}/${relpath}"
+            if [ ! -f "$file" ]; then
+              echo "::warning::Skipping ${relpath}: file does not exist in ${DOCS_DIR}"
+              continue
+            fi
             BEFORE=$(sha256sum "$file" | awk '{print $1}')
-            for expr in "${PATTERNS[@]}"; do
-              perl -i -pe "$expr" "$file"
-            done
+            perl -i -0777 -pe "${FILE_RULES[$relpath]}" "$file"
             AFTER=$(sha256sum "$file" | awk '{print $1}')
             if [ "$BEFORE" != "$AFTER" ]; then
               echo "  Updated: $file"
               UPDATED=$((UPDATED + 1))
             fi
-          done < <(find "${DOCS_DIR}" -name "*.md" -type f)
+          done
 
           echo "::notice::Bumped kubelb-context versions to ${VERSION} in ${UPDATED} file(s)"
 

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -36,6 +36,8 @@ on:
     secrets:
       KUBERMATIC_DOCS_TOKEN:
         required: true
+      KUBELB_EE_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       version:
@@ -57,6 +59,7 @@ permissions: {}
 env:
   DOCS_REPO: kubermatic/docs
   KUBELB_REPO: kubermatic/kubelb
+  EE_REPO: kubermatic/kubelb-ee
 
 jobs:
   update-docs:
@@ -70,6 +73,49 @@ jobs:
         with:
           repository: ${{ env.DOCS_REPO }}
           token: ${{ secrets.KUBERMATIC_DOCS_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout kubelb-ce hack/release scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ env.KUBELB_REPO }}
+          ref: release/${{ inputs.minor }}
+          path: kubelb-ce
+          sparse-checkout: |
+            hack/release
+            go.mod
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: kubelb-ce/go.mod
+
+      - name: Regenerate EE helm-values from bumped EE clone
+        env:
+          KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          MINOR: ${{ inputs.minor }}
+        run: |
+          # EE chart values stay frozen on the EE release branch (we never
+          # commit the bump back). To produce helm-values markdown that
+          # reflects ${VERSION}, clone EE fresh, bump it transiently, and
+          # regenerate. This decouples docs from any prior release-prep
+          # state — broken or stale CE release-branch artifacts no longer
+          # cause incorrect docs.
+          git clone --depth 1 --branch "release/${MINOR}" \
+            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${EE_REPO}.git" /tmp/kubelb-ee
+
+          ./kubelb-ce/hack/release/bump-versions.sh --target-dir /tmp/kubelb-ee "$VERSION"
+
+          # Generate chart README.md tables (helm-docs auto-installs via the
+          # EE Makefile). go.mod / go.sum in /tmp/kubelb-ee drives the install.
+          (cd /tmp/kubelb-ee && go mod download && make generate-helm-docs)
+
+          # Extract just the values tables to a known location.
+          mkdir -p /tmp/ee-helm-values
+          ./kubelb-ce/hack/release/extract-helm-values.sh \
+            /tmp/kubelb-ee/charts /tmp/ee-helm-values "-ee"
+
+          ls -la /tmp/ee-helm-values/
 
       - name: Setup for minor release
         if: inputs.is_patch == 'false'
@@ -107,18 +153,33 @@ jobs:
           {{< render_external_markdown "https://raw.githubusercontent.com/${KUBELB_REPO}/refs/heads/release/${MINOR}/docs/changelogs/CHANGELOG-${MINOR}.md" >}}
           EOF
 
-          if ! grep -q "release: ${MINOR}" data/products.yaml; then
+          # Add v${MINOR} to the kubelb versions list, idempotently. The check
+          # MUST be scoped to the kubelb section: a global grep matches
+          # unrelated products that share version numbers (e.g. kubeone v1.4)
+          # and silently skips the insert. v1.4.0 release shipped without a
+          # kubelb v1.4 entry in products.yaml because of exactly this.
+          HAS_MINOR=$(awk -v minor="${MINOR}" '
+            /^kubelb:[[:space:]]*$/ { in_section=1; next }
+            /^[a-zA-Z][a-zA-Z0-9_-]*:[[:space:]]*$/ { in_section=0 }
+            in_section && $0 ~ "release: " minor "$" { print "yes"; exit }
+          ' data/products.yaml)
+
+          if [ "$HAS_MINOR" != "yes" ]; then
             awk -v minor="${MINOR}" '
-              /^kubelb:/{found=1}
-              found && /name: main/{
+              /^kubelb:[[:space:]]*$/ { in_kubelb=1; print; next }
+              /^[a-zA-Z][a-zA-Z0-9_-]*:[[:space:]]*$/ { in_kubelb=0 }
+              in_kubelb && /name: main$/ && !inserted {
                 print
                 printf "    - release: %s\n      name: %s\n", minor, minor
-                found=0
+                inserted=1
                 next
               }
-              {print}
+              { print }
             ' data/products.yaml > data/products.yaml.tmp
             mv data/products.yaml.tmp data/products.yaml
+            echo "::notice::Added kubelb v${MINOR} entry to data/products.yaml"
+          else
+            echo "::notice::kubelb v${MINOR} already in data/products.yaml; skipping"
           fi
 
       - name: Update version strings in installation pages
@@ -128,21 +189,39 @@ jobs:
         run: |
           DOCS_DIR="content/kubelb/${MINOR}"
 
-          PREV_VERSION=$(grep -ohE 'version=v[0-9]+\.[0-9]+\.[0-9]+' "${DOCS_DIR}/installation/management-cluster/_index.en.md" | head -1 | cut -d= -f2)
+          # Histogram all vX.Y.Z references across the docs tree and pick the
+          # most frequent (excluding the target VERSION itself). More robust
+          # than grepping a single file for `version=vX.Y.Z`: catches `:vX.Y.Z`
+          # image tags, bare prose mentions, --version=vX.Y.Z helm flags, etc.
+          PREV_VERSION=$(
+            grep -rohE 'v[0-9]+\.[0-9]+\.[0-9]+' "$DOCS_DIR" 2>/dev/null \
+              | grep -v "^${VERSION}\$" \
+              | sort | uniq -c | sort -rn \
+              | head -1 | awk '{print $2}'
+          )
 
           if [ -z "$PREV_VERSION" ]; then
-            echo "::warning::Could not detect previous version in docs, skipping version update"
+            echo "::warning::No vX.Y.Z references found in ${DOCS_DIR}; skipping version sweep"
+            exit 0
+          fi
+
+          if [ "$PREV_VERSION" = "$VERSION" ]; then
+            echo "::notice::Most-frequent version equals target ${VERSION}; nothing to update"
             exit 0
           fi
 
           echo "Updating ${PREV_VERSION} → ${VERSION} in ${DOCS_DIR}"
 
-          find "${DOCS_DIR}" -name "*.md" -type f | while read -r file; do
+          UPDATED=0
+          while IFS= read -r file; do
             if grep -q "${PREV_VERSION}" "$file"; then
               sed -i "s/${PREV_VERSION}/${VERSION}/g" "$file"
               echo "  Updated: $file"
+              UPDATED=$((UPDATED + 1))
             fi
-          done
+          done < <(find "${DOCS_DIR}" -name "*.md" -type f)
+
+          echo "::notice::Rewrote ${PREV_VERSION} → ${VERSION} in ${UPDATED} file(s)"
 
       - name: Replace helm values tables between marker comments
         env:
@@ -151,39 +230,83 @@ jobs:
         run: |
           DOCS_DIR="content/kubelb/${MINOR}"
 
+          # Map each marker to (source_kind, source_location):
+          #   url:<path>   — fetch from refs/heads/release/${MINOR}/<path>
+          #   file:<path>  — read from local <path> (regenerated EE artifacts)
+          #
+          # CE charts are bumped on the CE release branch by release-prep, so
+          # docs/generated/helm-values-kubelb-{manager,ccm}.md on that branch
+          # is the live source of truth. Fetch via raw URL.
+          #
+          # EE chart values stay frozen on the EE release branch — release-prep
+          # bumps a transient /tmp clone and never commits back. To get
+          # ${VERSION}-correct EE helm-values we regenerated locally in the
+          # previous step; read those files directly. This decouples EE docs
+          # from any prior release-prep state.
           declare -A MARKERS
-          MARKERS["kubelb-manager"]="docs/generated/helm-values-kubelb-manager.md"
-          MARKERS["kubelb-ccm"]="docs/generated/helm-values-kubelb-ccm.md"
-          MARKERS["kubelb-manager-ee"]="docs/generated/helm-values-kubelb-manager-ee.md"
-          MARKERS["kubelb-ccm-ee"]="docs/generated/helm-values-kubelb-ccm-ee.md"
+          MARKERS["kubelb-manager"]="url:docs/generated/helm-values-kubelb-manager.md"
+          MARKERS["kubelb-ccm"]="url:docs/generated/helm-values-kubelb-ccm.md"
+          MARKERS["kubelb-manager-ee"]="file:/tmp/ee-helm-values/helm-values-kubelb-manager-ee.md"
+          MARKERS["kubelb-ccm-ee"]="file:/tmp/ee-helm-values/helm-values-kubelb-ccm-ee.md"
+
+          declare -A MATCHED
+          for marker in "${!MARKERS[@]}"; do MATCHED[$marker]=0; done
 
           for marker in "${!MARKERS[@]}"; do
-            REMOTE_FILE="${MARKERS[$marker]}"
-            RAW_URL="https://raw.githubusercontent.com/${KUBELB_REPO}/refs/tags/${VERSION}/${REMOTE_FILE}"
-            TABLE=$(curl -sfL "$RAW_URL" || echo "")
+            SPEC="${MARKERS[$marker]}"
+            KIND="${SPEC%%:*}"
+            SRC="${SPEC#*:}"
 
-            if [ -z "$TABLE" ]; then
-              echo "::warning::Could not fetch ${REMOTE_FILE} for ${VERSION}, skipping ${marker}"
-              continue
-            fi
+            case "$KIND" in
+              url)
+                RAW_URL="https://raw.githubusercontent.com/${KUBELB_REPO}/refs/heads/release/${MINOR}/${SRC}"
+                TABLE=$(curl -sfL "$RAW_URL" || echo "")
+                if [ -z "$TABLE" ]; then
+                  echo "::error::Could not fetch ${SRC} from release/${MINOR}"
+                  exit 1
+                fi
+                ;;
+              file)
+                if [ ! -f "$SRC" ]; then
+                  echo "::error::Local helm-values file not found: ${SRC}"
+                  exit 1
+                fi
+                TABLE=$(cat "$SRC")
+                ;;
+            esac
 
             START_MARKER="<!-- helm-values-${marker} start -->"
             END_MARKER="<!-- helm-values-${marker} end -->"
 
-            find "${DOCS_DIR}" -name "*.md" -type f | while read -r file; do
+            while IFS= read -r file; do
               if grep -q "$START_MARKER" "$file"; then
-                # Replace content between markers (keep markers intact)
                 sed -i "/${START_MARKER}/,/${END_MARKER}/{
                   /${START_MARKER}/!{
                     /${END_MARKER}/!d
                   }
                 }" "$file"
-                # Insert new table after start marker
                 sed -i "/${START_MARKER}/r /dev/stdin" "$file" <<< "$TABLE"
                 echo "  Updated ${marker} in ${file}"
+                MATCHED[$marker]=$((MATCHED[$marker] + 1))
               fi
-            done
+            done < <(find "${DOCS_DIR}" -name "*.md" -type f)
           done
+
+          # Fail loudly if any of the expected markers were never matched.
+          # The original `find | while` pipeline scoped the increment to a
+          # subshell, so the count was lost across iterations; switching to
+          # process substitution preserves it.
+          MISSING=()
+          for marker in "${!MARKERS[@]}"; do
+            if [ "${MATCHED[$marker]}" -eq 0 ]; then
+              MISSING+=("$marker")
+            fi
+          done
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "::error::No docs page contains markers for: ${MISSING[*]}"
+            echo "::error::Expected <!-- helm-values-<marker> start --> / end --> in ${DOCS_DIR}"
+            exit 1
+          fi
 
       - name: Create PR
         id: create-pr
@@ -196,9 +319,28 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           BRANCH="chore/kubelb-${VERSION}-docs"
+
+          # If a prior run already pushed this branch, close any associated
+          # open PR and delete the remote branch so we can recreate cleanly.
+          # Without this, a re-run hits non-fast-forward push failure with no
+          # recovery path short of manual cleanup.
+          if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
+            echo "::notice::Branch ${BRANCH} already exists on origin; cleaning up prior run"
+            EXISTING_PR=$(gh pr list --repo "${{ env.DOCS_REPO }}" --head "$BRANCH" --state open --json number --jq '.[0].number')
+            if [ -n "$EXISTING_PR" ]; then
+              echo "::notice::Closing existing PR #${EXISTING_PR}"
+              gh pr close "$EXISTING_PR" --repo "${{ env.DOCS_REPO }}" --delete-branch
+            else
+              git push origin --delete "$BRANCH"
+            fi
+          fi
+
           git checkout -b "${BRANCH}"
           git add -A
-          git commit -s -m "docs: update KubeLB docs for ${VERSION}" || exit 0
+          if ! git commit -s -m "docs: update KubeLB docs for ${VERSION}"; then
+            echo "::notice::No changes to commit; skipping PR creation"
+            exit 0
+          fi
           git push -u origin "${BRANCH}"
 
           BODY="Update KubeLB documentation for release ${VERSION}."

--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -189,39 +189,44 @@ jobs:
         run: |
           DOCS_DIR="content/kubelb/${MINOR}"
 
-          # Histogram all vX.Y.Z references across the docs tree and pick the
-          # most frequent (excluding the target VERSION itself). More robust
-          # than grepping a single file for `version=vX.Y.Z`: catches `:vX.Y.Z`
-          # image tags, bare prose mentions, --version=vX.Y.Z helm flags, etc.
-          PREV_VERSION=$(
-            grep -rohE 'v[0-9]+\.[0-9]+\.[0-9]+' "$DOCS_DIR" 2>/dev/null \
-              | grep -v "^${VERSION}\$" \
-              | sort | uniq -c | sort -rn \
-              | head -1 | awk '{print $2}'
+          # Anchor-driven rewrite: only `vX.Y.Z` tokens that appear next to a
+          # kubelb-owned reference are bumped to ${VERSION}. A previous
+          # histogram-of-all-versions heuristic both corrupted unrelated
+          # references (envoy-gateway helm chart, compat-matrix rows) and
+          # silently missed kubelb-context lines whose version differed from
+          # the most-frequent token. Anchors are explicit so the failure mode
+          # for a new kubelb URL pattern is "silently not updated" (recover by
+          # adding the anchor) rather than "silently corrupted".
+          #
+          # Each pattern keeps its kubelb anchor in a capture group and
+          # rewrites only the version segment. Patterns must not overlap each
+          # other for the same input substring.
+          PATTERNS=(
+            # quay.io image / chart tags: kubelb-manager, kubelb-ccm, EE variants,
+            # helm-charts/kubelb-*, connection-manager, etc.
+            's{(quay\.io/kubermatic/(?:helm-charts/)?kubelb[A-Za-z0-9-]*:)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
+            # helm pull/install --version= for kubelb OCI charts
+            's{(oci://quay\.io/kubermatic/helm-charts/kubelb[A-Za-z0-9-]*\s+--version=)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
+            # github release asset URLs
+            's{(github\.com/kubermatic/kubelb/releases/download/)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
+            # sbom/checksum filenames embedded in URLs or prose: kubelb_vX.Y.Z_...
+            's{\bkubelb_v\d+\.\d+\.\d+_}{kubelb_'"${VERSION}"'_}g'
           )
-
-          if [ -z "$PREV_VERSION" ]; then
-            echo "::warning::No vX.Y.Z references found in ${DOCS_DIR}; skipping version sweep"
-            exit 0
-          fi
-
-          if [ "$PREV_VERSION" = "$VERSION" ]; then
-            echo "::notice::Most-frequent version equals target ${VERSION}; nothing to update"
-            exit 0
-          fi
-
-          echo "Updating ${PREV_VERSION} → ${VERSION} in ${DOCS_DIR}"
 
           UPDATED=0
           while IFS= read -r file; do
-            if grep -q "${PREV_VERSION}" "$file"; then
-              sed -i "s/${PREV_VERSION}/${VERSION}/g" "$file"
+            BEFORE=$(sha256sum "$file" | awk '{print $1}')
+            for expr in "${PATTERNS[@]}"; do
+              perl -i -pe "$expr" "$file"
+            done
+            AFTER=$(sha256sum "$file" | awk '{print $1}')
+            if [ "$BEFORE" != "$AFTER" ]; then
               echo "  Updated: $file"
               UPDATED=$((UPDATED + 1))
             fi
           done < <(find "${DOCS_DIR}" -name "*.md" -type f)
 
-          echo "::notice::Rewrote ${PREV_VERSION} → ${VERSION} in ${UPDATED} file(s)"
+          echo "::notice::Bumped kubelb-context versions to ${VERSION} in ${UPDATED} file(s)"
 
       - name: Replace helm values tables between marker comments
         env:
@@ -336,7 +341,14 @@ jobs:
           fi
 
           git checkout -b "${BRANCH}"
-          git add -A
+          # Stage only paths this workflow owns. `git add -A` previously
+          # picked up the kubelb-ce sparse-checkout dir as a submodule
+          # gitlink, polluting the PR. data/products.yaml is only modified
+          # on minor releases.
+          git add "content/kubelb/${MINOR}"
+          if [ "${IS_PATCH}" = "false" ]; then
+            git add data/products.yaml
+          fi
           if ! git commit -s -m "docs: update KubeLB docs for ${VERSION}"; then
             echo "::notice::No changes to commit; skipping PR creation"
             exit 0

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -30,8 +30,16 @@ on:
         required: false
         type: string
         default: ""
+      dry_run:
+        description: "Dry run: bump charts and generate artifacts but skip all writes (no branch creation, no commits pushed, no PR opened)."
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
+
+env:
+  EE_REPO: kubermatic/kubelb-ee
 
 jobs:
   prep:
@@ -68,12 +76,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
           VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           MINOR=$(echo "$VERSION" | grep -oE 'v[0-9]+\.[0-9]+')
-          EE_REPO="kubermatic/kubelb-ee"
           if gh api "repos/${EE_REPO}/branches/release/${MINOR}" --jq '.name' >/dev/null 2>&1; then
             echo "::notice::EE release branch release/${MINOR} already exists"
           else
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::error::[dry-run] EE release branch release/${MINOR} does not exist; cannot proceed (subsequent clone would fail). Re-run with dry_run=false or pre-create the branch."
+              exit 1
+            fi
             echo "Creating EE release branch release/${MINOR} from main..."
             MAIN_SHA=$(gh api "repos/${EE_REPO}/git/ref/heads/main" --jq '.object.sha')
             gh api "repos/${EE_REPO}/git/refs" \
@@ -85,8 +97,13 @@ jobs:
       - name: Ensure CE release branch exists
         env:
           BRANCH: ${{ inputs.branch }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::error::[dry-run] CE release branch $BRANCH does not exist; cannot proceed without creating it. Re-run with dry_run=false or pre-create the branch."
+              exit 1
+            fi
             echo "Creating CE release branch $BRANCH from main..."
             git checkout main
             git checkout -b "$BRANCH"
@@ -126,21 +143,28 @@ jobs:
         run: ./hack/release/bump-versions.sh "$VERSION"
 
       - name: Clone and bump EE
+        id: ee-clone
         env:
           KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
           VERSION: ${{ inputs.version }}
         run: |
           MINOR=$(echo "$VERSION" | grep -oE 'v[0-9]+\.[0-9]+')
           git clone --branch "release/${MINOR}" \
-            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/kubermatic/kubelb-ee.git" /tmp/kubelb-ee
+            "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${EE_REPO}.git" /tmp/kubelb-ee
           cd /tmp/kubelb-ee
           git fetch --tags
-          for chart in kubelb-manager kubelb-ccm; do
-            [ -f "charts/${chart}/Chart.yaml" ] || continue
-            sed -i "s/^version:.*/version: ${VERSION}/" "charts/${chart}/Chart.yaml"
-            sed -i "s/^appVersion:.*/appVersion: ${VERSION}/" "charts/${chart}/Chart.yaml"
-            sed -i "0,/^  tag:/{s/^  tag:.*/  tag: ${VERSION}/}" "charts/${chart}/values.yaml"
-          done
+          # Capture EE HEAD SHA at prep time. release-auto-tag pins the EE
+          # tag to this exact SHA so that an EE push between prep PR creation
+          # and merge cannot cause CE/EE tags to diverge from what was
+          # reviewed in the prep PR.
+          EE_HEAD_SHA=$(git rev-parse HEAD)
+          echo "ee_head_sha=${EE_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "::notice::EE prep SHA: ${EE_HEAD_SHA}"
+          # Bump EE chart values in /tmp clone only — never committed back.
+          # EE keeps its release branch values frozen at the last shipped
+          # version; the bump happens transiently in CI per release.
+          cd "${GITHUB_WORKSPACE}"
+          ./hack/release/bump-versions.sh --target-dir /tmp/kubelb-ee "$VERSION"
 
       - name: Generate artifacts (CE codegen + EE docs)
         env:
@@ -190,7 +214,7 @@ jobs:
           if [ -n "$PREV_TAG" ]; then
             ./hack/release/generate-notes.sh "$VERSION" "$PREV_TAG" \
               --branch "$BRANCH" \
-              --ee-repo kubermatic/kubelb-ee --ee-path /tmp/kubelb-ee --ee-branch "release/${MINOR}" \
+              --ee-repo "${EE_REPO}" --ee-path /tmp/kubelb-ee --ee-branch "release/${MINOR}" \
               kubermatic/kubelb
           else
             echo "::notice::No reachable previous tag found, skipping release notes generation"
@@ -205,6 +229,7 @@ jobs:
           KUBELB_EE_TOKEN: ${{ secrets.KUBELB_EE_TOKEN }}
           VERSION: ${{ inputs.version }}
           BASE_BRANCH: ${{ inputs.branch }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           BRANCH="chore/prepare-${VERSION}"
 
@@ -218,8 +243,6 @@ jobs:
           echo "::endgroup::"
           git add -A
           git commit -s -m "chore: prepare ${VERSION}"
-          git remote set-url origin "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${{ github.repository }}.git"
-          git push origin "${BRANCH}"
 
           MINOR=$(echo "${VERSION}" | grep -oE 'v[0-9]+\.[0-9]+')
           CHANGELOG_FILE="docs/changelogs/CHANGELOG-${MINOR}.md"
@@ -228,11 +251,7 @@ jobs:
             NOTES_PREVIEW=$(head -100 "$CHANGELOG_FILE")
           fi
 
-          gh pr create \
-            --base "${BASE_BRANCH}" \
-            --head "${BRANCH}" \
-            --title "chore: prepare ${VERSION}" \
-            --body-file - <<PREOF
+          PR_BODY=$(cat <<PREOF
           **What this PR does / why we need it**:
           Prepare release ${VERSION}. Bumps chart versions, regenerates docs, and generates release notes.
 
@@ -252,6 +271,8 @@ jobs:
           - [ ] CI green
           - [ ] Cherry-picks complete
 
+          <!-- EE-SHA: ${{ steps.ee-clone.outputs.ee_head_sha }} -->
+
           <details>
           <summary><b>Release Notes Preview</b></summary>
 
@@ -267,6 +288,29 @@ jobs:
           NONE
           \`\`\`
           PREOF
+          )
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::group::[dry-run] would push branch ${BRANCH}"
+            git log -1 --stat
+            echo "::endgroup::"
+            echo "::group::[dry-run] would open PR — title: chore: prepare ${VERSION}"
+            printf '%s\n' "$PR_BODY"
+            echo "::endgroup::"
+            echo "::group::[dry-run] would add labels: release-note-none, kind/chore"
+            echo "::endgroup::"
+            echo "::notice::dry-run complete — no remote writes performed"
+            exit 0
+          fi
+
+          git remote set-url origin "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "${BRANCH}"
+
+          printf '%s\n' "$PR_BODY" | gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${BRANCH}" \
+            --title "chore: prepare ${VERSION}" \
+            --body-file -
 
           gh pr edit "${BRANCH}" --add-label "release-note-none" 2>/dev/null || true
           gh pr edit "${BRANCH}" --add-label "kind/chore" 2>/dev/null || true

--- a/hack/release/bump-versions.sh
+++ b/hack/release/bump-versions.sh
@@ -15,27 +15,60 @@
 
 #!/usr/bin/env bash
 # Bump Chart.yaml version/appVersion and values.yaml image tag for kubelb-manager and kubelb-ccm.
-# Usage: bump-versions.sh [--dry-run] <VERSION>
+# Usage: bump-versions.sh [--dry-run] [--target-dir <dir>] <VERSION>
 # VERSION must be semver with v prefix: v1.4.0, v1.4.0-rc.1
+#
+# --target-dir <dir>: bump charts under <dir>/charts/ instead of the CE workspace.
+#   Used by release workflows to bump a freshly-cloned kubelb-ee in /tmp without
+#   committing the bump back. Defaults to the CE workspace root.
+#
+# When --target-dir is given:
+#   - The local-tag-exists check is skipped (the target may be a transient clone).
+#   - The git-tag check still runs against the CE workspace if invoked from there.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 DRY_RUN=false
-if [[ "${1:-}" == "--dry-run" ]]; then
-  DRY_RUN=true
-  shift
-fi
+TARGET_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --dry-run)
+    DRY_RUN=true
+    shift
+    ;;
+  --target-dir)
+    TARGET_DIR="${2:?--target-dir requires a value}"
+    shift 2
+    ;;
+  -*)
+    echo "ERROR: unknown flag: $1" >&2
+    echo "Usage: bump-versions.sh [--dry-run] [--target-dir <dir>] <VERSION>" >&2
+    exit 1
+    ;;
+  *)
+    break
+    ;;
+  esac
+done
 
-VERSION="${1:?Usage: bump-versions.sh [--dry-run] <VERSION>}"
+VERSION="${1:?Usage: bump-versions.sh [--dry-run] [--target-dir <dir>] <VERSION>}"
+TARGET_DIR="${TARGET_DIR:-$REPO_ROOT}"
+
+if [[ ! -d "$TARGET_DIR/charts" ]]; then
+  echo "ERROR: charts directory not found: $TARGET_DIR/charts" >&2
+  exit 1
+fi
 
 if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
   echo "ERROR: Invalid version format: $VERSION (expected vX.Y.Z or vX.Y.Z-rc.N)" >&2
   exit 1
 fi
 
-if git tag -l "$VERSION" | grep -q .; then
+# The local tag check only makes sense for the CE workspace. External clones
+# (e.g. /tmp/kubelb-ee in CI) are throw-away — re-bumping them is fine.
+if [[ "$TARGET_DIR" == "$REPO_ROOT" ]] && git tag -l "$VERSION" | grep -q .; then
   echo "ERROR: Tag $VERSION already exists" >&2
   exit 1
 fi
@@ -51,8 +84,13 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 for chart in "${CHARTS[@]}"; do
-  CHART_YAML="${REPO_ROOT}/charts/${chart}/Chart.yaml"
-  VALUES_YAML="${REPO_ROOT}/charts/${chart}/values.yaml"
+  CHART_YAML="${TARGET_DIR}/charts/${chart}/Chart.yaml"
+  VALUES_YAML="${TARGET_DIR}/charts/${chart}/values.yaml"
+
+  if [[ ! -f "$CHART_YAML" ]]; then
+    echo "  skip ${chart}: ${CHART_YAML} not found"
+    continue
+  fi
 
   if [[ "$DRY_RUN" == "true" ]]; then
     echo "=== ${chart}/Chart.yaml ==="
@@ -66,4 +104,4 @@ for chart in "${CHARTS[@]}"; do
   fi
 done
 
-echo "Bumped charts to ${VERSION}"
+echo "Bumped charts in ${TARGET_DIR} to ${VERSION}"

--- a/hack/release/generate-docs.sh
+++ b/hack/release/generate-docs.sh
@@ -86,11 +86,15 @@ if [[ ! -d "$EE_PATH" ]]; then
 fi
 
 echo "==> Generating EE docs from ${EE_PATH}"
+# Do NOT swallow these failures with `|| echo`. A failed make produces
+# stale chart README.md / metrics.md, which extract-helm-values.sh then
+# happily reads — silently shipping wrong docs/generated/*-ee.md. This
+# is exactly the cascade that produced the broken v1.4.0 EE artifacts.
 (
   cd "$EE_PATH"
   go mod download
-  make generate-metricsdocs || echo "::warning::EE generate-metricsdocs failed"
-  make generate-helm-docs || echo "::warning::EE generate-helm-docs failed"
+  make generate-metricsdocs
+  make generate-helm-docs
 )
 
 # EE Makefile vintage may emit metrics to either docs/generated/metrics.md or docs/metrics.md.


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports release-tooling fixes from `main` to `release/v1.3` to unblock the v1.3.12 prep run. The current `release-prep` workflow on `release/v1.3` invokes `bump-versions.sh --target-dir /tmp/kubelb-ee` (line 167) but the script on this branch predates the `--target-dir` flag, so it parses `--target-dir` as the version and aborts with `Invalid version format: --target-dir`. See https://github.com/kubermatic/kubelb/actions/runs/25480551913/job/74763476176.

Cherry-picks (in order):
- #423 `release: targeted fixes from v1.4.0 docs postmortem` — adds `--target-dir` to `bump-versions.sh`, dry-run mode in `release-prep`, EE-SHA pinning in `release-auto-tag`, EE helm-values regen in `release-docs-update`, scoped `data/products.yaml` insert, marker validation, and stops `generate-docs.sh` from swallowing make failures with `|| echo`.
- #426 `release-docs-update: anchor-driven version sweep` — replaces the broken find-sweep that previously corrupted unrelated version refs (or silently missed legitimate ones) with per-file perl rules.
- #428 `Improve version substitution to make it idempotent` — re-running release-docs-update on the same version is now a no-op instead of producing churn.

All three cherry-picked cleanly. Post-backport diff vs `main` for the touched files is limited to dependabot action-SHA pin differences (setup-go, setup-helm, golangci-lint-action) — not in scope here.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:
- Three commits, each preserves the `(cherry picked from commit ...)` trailer (`-x`).
- Smoke-test before merge: re-run `Release Prep` workflow_dispatch with `version=v1.3.12 branch=release/v1.3 dry_run=true` — should now pass past the EE clone step.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```