### PR TITLE
fix: prevent duplicate TOC in changelog

### DIFF
--- a/hack/release/generate-notes.sh
+++ b/hack/release/generate-notes.sh
@@ -407,7 +407,10 @@ TMPFILE=$(mktemp)
 head -1 "$CHANGELOG" > "$TMPFILE"
 echo "" >> "$TMPFILE"
 printf '%b' "$OUTPUT" >> "$TMPFILE"
-tail -n +2 "$CHANGELOG" >> "$TMPFILE"
+echo "" >> "$TMPFILE"
+# Skip everything between title and first `## v...` so the previous run's TOC
+# (or any other pre-body cruft) is dropped instead of leaking into the body.
+sed -n '/^## v/,$p' "$CHANGELOG" >> "$TMPFILE"
 mv "$TMPFILE" "$CHANGELOG"
 
 # Rebuild TOC at the top of the changelog
@@ -447,7 +450,14 @@ TOCFILE=$(mktemp)
 echo "$TITLE_LINE" > "$TOCFILE"
 echo "" >> "$TOCFILE"
 printf '%b' "$TOC" >> "$TOCFILE"
-sed -n '/^## v/,$p' "$CHANGELOG" >> "$TOCFILE"
+echo "" >> "$TOCFILE"
+# Strip any stray TOC-shaped lines that may be embedded in the body from
+# pre-fix runs (the previous prepend step let the old top TOC bleed into the
+# body between version sections). These patterns never appear in real notes.
+sed -n '/^## v/,$p' "$CHANGELOG" |
+  grep -E -v '^- \[v[0-9]+\.[0-9]+\.[0-9]+\]\(#v[0-9]+\)$' |
+  grep -E -v '^  - \[(Community|Enterprise) Edition\]\(#(community|enterprise)-edition\)$' \
+    >> "$TOCFILE"
 mv "$TOCFILE" "$CHANGELOG"
 
 printf '%b' "$OUTPUT"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix duplicate TOC blocks accumulating in `docs/changelogs/CHANGELOG-v*.md` on each release prep. The previous TOC at the top of the file was leaking into the body during prepend and surviving the rebuild.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```