### PR TITLE
feat(annotations): add deny list and glob pattern support

### DIFF
--- a/api/ce/kubelb.k8c.io/v1alpha1/common_types.go
+++ b/api/ce/kubelb.k8c.io/v1alpha1/common_types.go
@@ -113,15 +113,24 @@ const (
 )
 
 type AnnotationSettings struct {
-	// PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.
+	// PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.
+	// Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;
+	// otherwise the value is a comma-separated list of permitted values for exact match.
 	// Tenant configuration has higher precedence than the annotations specified at the Config level.
 	// +optional
 	PropagatedAnnotations *map[string]string `json:"propagatedAnnotations,omitempty"`
 
-	// PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.
+	// PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.
+	// If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.
 	// Tenant configuration has higher precedence than the value specified at the Config level.
 	// +optional
 	PropagateAllAnnotations *bool `json:"propagateAllAnnotations,omitempty"`
+
+	// DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of
+	// PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").
+	// Tenant configuration has higher precedence than the value specified at the Config level.
+	// +optional
+	DeniedAnnotations []string `json:"deniedAnnotations,omitempty"`
 
 	// DefaultAnnotations defines the list of annotations(key-value pairs) that will be set on the load balancing resources if not already present. A special key `all` can be used to apply the same
 	// set of annotations to all resources.

--- a/api/ce/kubelb.k8c.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/ce/kubelb.k8c.io/v1alpha1/zz_generated.deepcopy.go
@@ -139,6 +139,11 @@ func (in *AnnotationSettings) DeepCopyInto(out *AnnotationSettings) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeniedAnnotations != nil {
+		in, out := &in.DeniedAnnotations, &out.DeniedAnnotations
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DefaultAnnotations != nil {
 		in, out := &in.DefaultAnnotations, &out.DefaultAnnotations
 		*out = make(map[AnnotatedResource]Annotations, len(*in))

--- a/api/ee/kubelb.k8c.io/v1alpha1/common_types.go
+++ b/api/ee/kubelb.k8c.io/v1alpha1/common_types.go
@@ -119,15 +119,24 @@ const (
 )
 
 type AnnotationSettings struct {
-	// PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.
+	// PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.
+	// Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;
+	// otherwise the value is a comma-separated list of permitted values for exact match.
 	// Tenant configuration has higher precedence than the annotations specified at the Config level.
 	// +optional
 	PropagatedAnnotations *map[string]string `json:"propagatedAnnotations,omitempty"`
 
-	// PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.
+	// PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.
+	// If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.
 	// Tenant configuration has higher precedence than the value specified at the Config level.
 	// +optional
 	PropagateAllAnnotations *bool `json:"propagateAllAnnotations,omitempty"`
+
+	// DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of
+	// PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").
+	// Tenant configuration has higher precedence than the value specified at the Config level.
+	// +optional
+	DeniedAnnotations []string `json:"deniedAnnotations,omitempty"`
 
 	// DefaultAnnotations defines the list of annotations(key-value pairs) that will be set on the load balancing resources if not already present. A special key `all` can be used to apply the same
 	// set of annotations to all resources.

--- a/api/ee/kubelb.k8c.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/ee/kubelb.k8c.io/v1alpha1/zz_generated.deepcopy.go
@@ -139,6 +139,11 @@ func (in *AnnotationSettings) DeepCopyInto(out *AnnotationSettings) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeniedAnnotations != nil {
+		in, out := &in.DeniedAnnotations, &out.DeniedAnnotations
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DefaultAnnotations != nil {
 		in, out := &in.DefaultAnnotations, &out.DefaultAnnotations
 		*out = make(map[AnnotatedResource]Annotations, len(*in))

--- a/charts/kubelb-manager/README.md
+++ b/charts/kubelb-manager/README.md
@@ -71,6 +71,7 @@ cosign verify quay.io/kubermatic/kubelb-manager:v1.3.5 \
 | kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
 | kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
 | kubelb.debug | bool | `true` |  |
+| kubelb.deniedAnnotations | list | `[]` | Annotation key patterns to exclude from propagation. Patterns support shell-style globbing. Deny rules always take precedence over PropagatedAnnotations and PropagateAllAnnotations. |
 | kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
 | kubelb.enableLeaderElection | bool | `true` |  |
 | kubelb.envoyProxy.affinity | object | `{}` |  |
@@ -84,8 +85,8 @@ cosign verify quay.io/kubermatic/kubelb-manager:v1.3.5 \
 | kubelb.envoyProxy.topology | string | `"shared"` | Topology defines the deployment topology for Envoy Proxy. Only "shared" is supported. "dedicated" and "global" are deprecated and will default to shared. |
 | kubelb.envoyProxy.useDaemonset | bool | `false` | Use DaemonSet for Envoy Proxy deployment instead of Deployment. |
 | kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
-| kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the LB resource to the LB service. |
-| kubelb.propagatedAnnotations | object | `{}` | Allowed annotations that will be propagated from the LB resource to the LB service. |
+| kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the source resource to load balancing resources. DeniedAnnotations still applies. |
+| kubelb.propagatedAnnotations | object | `{}` | Allowed annotation key patterns to propagate from the source resource to load balancing resources. Keys support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*"). Empty value means any value. |
 | kubelb.skipConfigGeneration | bool | `true` | Set to false to enable the generation of the Config CR. Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually. |
 | metrics.port | int | `9443` | Port where the manager exposes metrics (includes both manager and envoycp metrics) |
 | nameOverride | string | `""` |  |

--- a/charts/kubelb-manager/crds/kubelb.k8c.io_configs.yaml
+++ b/charts/kubelb-manager/crds/kubelb.k8c.io_configs.yaml
@@ -65,6 +65,14 @@ spec:
                   set of annotations to all resources.
                   Tenant configuration has higher precedence than the annotations specified at the Config level.
                 type: object
+              deniedAnnotations:
+                description: |-
+                  DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of
+                  PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").
+                  Tenant configuration has higher precedence than the value specified at the Config level.
+                items:
+                  type: string
+                type: array
               dns:
                 description: ConfigDNSSettings defines the global settings for DNS
                   management and automation.
@@ -1299,14 +1307,17 @@ spec:
                 type: object
               propagateAllAnnotations:
                 description: |-
-                  PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.
+                  PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.
+                  If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.
                   Tenant configuration has higher precedence than the value specified at the Config level.
                 type: boolean
               propagatedAnnotations:
                 additionalProperties:
                   type: string
                 description: |-
-                  PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.
+                  PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.
+                  Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;
+                  otherwise the value is a comma-separated list of permitted values for exact match.
                   Tenant configuration has higher precedence than the annotations specified at the Config level.
                 type: object
             type: object

--- a/charts/kubelb-manager/crds/kubelb.k8c.io_tenants.yaml
+++ b/charts/kubelb-manager/crds/kubelb.k8c.io_tenants.yaml
@@ -64,6 +64,14 @@ spec:
                   set of annotations to all resources.
                   Tenant configuration has higher precedence than the annotations specified at the Config level.
                 type: object
+              deniedAnnotations:
+                description: |-
+                  DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of
+                  PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").
+                  Tenant configuration has higher precedence than the value specified at the Config level.
+                items:
+                  type: string
+                type: array
               dns:
                 description: DNSSettings defines the settings for DNS management and
                   automation.
@@ -249,14 +257,17 @@ spec:
                 type: object
               propagateAllAnnotations:
                 description: |-
-                  PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.
+                  PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.
+                  If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.
                   Tenant configuration has higher precedence than the value specified at the Config level.
                 type: boolean
               propagatedAnnotations:
                 additionalProperties:
                   type: string
                 description: |-
-                  PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.
+                  PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.
+                  Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;
+                  otherwise the value is a comma-separated list of permitted values for exact match.
                   Tenant configuration has higher precedence than the annotations specified at the Config level.
                 type: object
             type: object

--- a/charts/kubelb-manager/templates/config.yaml
+++ b/charts/kubelb-manager/templates/config.yaml
@@ -39,4 +39,8 @@ spec:
   {{- toYaml . | nindent 4 }}
   {{- end }}
   propagateAllAnnotations: {{ .Values.kubelb.propagateAllAnnotations }}
+  {{- with .Values.kubelb.deniedAnnotations }}
+  deniedAnnotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/kubelb-manager/values.yaml
+++ b/charts/kubelb-manager/values.yaml
@@ -41,10 +41,14 @@ kubelb:
     podMonitor:
       # -- Create PodMonitor resources for Envoy Proxy pods to enable Prometheus Operator scraping.
       enabled: false
-  # -- Allowed annotations that will be propagated from the LB resource to the LB service.
+  # -- Allowed annotation key patterns to propagate from the source resource to load balancing resources.
+  # Keys support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*"). Empty value means any value.
   propagatedAnnotations: {}
-  # -- Propagate all annotations from the LB resource to the LB service.
+  # -- Propagate all annotations from the source resource to load balancing resources. DeniedAnnotations still applies.
   propagateAllAnnotations: false
+  # -- Annotation key patterns to exclude from propagation. Patterns support shell-style globbing.
+  # Deny rules always take precedence over PropagatedAnnotations and PropagateAllAnnotations.
+  deniedAnnotations: []
 
 # Create required resources for KKP integration.
 kkpintegration:

--- a/config/crd/bases/kubelb.k8c.io_configs.yaml
+++ b/config/crd/bases/kubelb.k8c.io_configs.yaml
@@ -65,6 +65,14 @@ spec:
                   set of annotations to all resources.
                   Tenant configuration has higher precedence than the annotations specified at the Config level.
                 type: object
+              deniedAnnotations:
+                description: |-
+                  DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of
+                  PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").
+                  Tenant configuration has higher precedence than the value specified at the Config level.
+                items:
+                  type: string
+                type: array
               dns:
                 description: ConfigDNSSettings defines the global settings for DNS
                   management and automation.
@@ -1299,14 +1307,17 @@ spec:
                 type: object
               propagateAllAnnotations:
                 description: |-
-                  PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.
+                  PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.
+                  If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.
                   Tenant configuration has higher precedence than the value specified at the Config level.
                 type: boolean
               propagatedAnnotations:
                 additionalProperties:
                   type: string
                 description: |-
-                  PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.
+                  PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.
+                  Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;
+                  otherwise the value is a comma-separated list of permitted values for exact match.
                   Tenant configuration has higher precedence than the annotations specified at the Config level.
                 type: object
             type: object

--- a/config/crd/bases/kubelb.k8c.io_tenants.yaml
+++ b/config/crd/bases/kubelb.k8c.io_tenants.yaml
@@ -64,6 +64,14 @@ spec:
                   set of annotations to all resources.
                   Tenant configuration has higher precedence than the annotations specified at the Config level.
                 type: object
+              deniedAnnotations:
+                description: |-
+                  DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of
+                  PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").
+                  Tenant configuration has higher precedence than the value specified at the Config level.
+                items:
+                  type: string
+                type: array
               dns:
                 description: DNSSettings defines the settings for DNS management and
                   automation.
@@ -249,14 +257,17 @@ spec:
                 type: object
               propagateAllAnnotations:
                 description: |-
-                  PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.
+                  PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.
+                  If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.
                   Tenant configuration has higher precedence than the value specified at the Config level.
                 type: boolean
               propagatedAnnotations:
                 additionalProperties:
                   type: string
                 description: |-
-                  PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.
+                  PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.
+                  Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;
+                  otherwise the value is a comma-separated list of permitted values for exact match.
                   Tenant configuration has higher precedence than the annotations specified at the Config level.
                 type: object
             type: object

--- a/internal/controllers/kubelb/shared.go
+++ b/internal/controllers/kubelb/shared.go
@@ -64,19 +64,27 @@ func GetConfig(ctx context.Context, client ctrlclient.Client, configNamespace st
 	return config, nil
 }
 
+// GetAnnotations resolves the effective AnnotationSettings for a tenant.
+// Tenant fully owns the propagation policy (PropagateAllAnnotations + PropagatedAnnotations)
+// if it sets either field; otherwise the policy falls back to config. This lets a tenant
+// explicitly set PropagateAllAnnotations=false to opt out of a config-wide propagate-all,
+// or replace propagate-all with a specific allow-list. DefaultAnnotations are resolved
+// independently with the same tenant-overrides-config rule.
 func GetAnnotations(tenant *kubelbv1alpha1.Tenant, config *kubelbv1alpha1.Config) kubelbv1alpha1.AnnotationSettings {
 	var annotations kubelbv1alpha1.AnnotationSettings
-	if config.Spec.PropagateAllAnnotations != nil && *config.Spec.PropagateAllAnnotations {
+
+	if tenant.Spec.PropagateAllAnnotations != nil || tenant.Spec.PropagatedAnnotations != nil {
+		annotations.PropagateAllAnnotations = tenant.Spec.PropagateAllAnnotations
+		annotations.PropagatedAnnotations = tenant.Spec.PropagatedAnnotations
+	} else {
 		annotations.PropagateAllAnnotations = config.Spec.PropagateAllAnnotations
-	} else if config.Spec.PropagatedAnnotations != nil {
 		annotations.PropagatedAnnotations = config.Spec.PropagatedAnnotations
 	}
 
-	// Tenant configuration has higher precedence than the annotations specified at the Config level.
-	if tenant.Spec.PropagateAllAnnotations != nil && *tenant.Spec.PropagateAllAnnotations {
-		annotations.PropagateAllAnnotations = tenant.Spec.PropagateAllAnnotations
-	} else if tenant.Spec.PropagatedAnnotations != nil {
-		annotations.PropagatedAnnotations = tenant.Spec.PropagatedAnnotations
+	if tenant.Spec.DeniedAnnotations != nil {
+		annotations.DeniedAnnotations = tenant.Spec.DeniedAnnotations
+	} else if config.Spec.DeniedAnnotations != nil {
+		annotations.DeniedAnnotations = config.Spec.DeniedAnnotations
 	}
 
 	if tenant.Spec.DefaultAnnotations != nil {

--- a/internal/controllers/kubelb/shared_test.go
+++ b/internal/controllers/kubelb/shared_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelb
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+)
+
+func ptrBool(b bool) *bool { return &b }
+
+func ptrMap(m map[string]string) *map[string]string { return &m }
+
+func TestGetAnnotations(t *testing.T) {
+	tests := []struct {
+		name   string
+		tenant kubelbv1alpha1.TenantSpec
+		config kubelbv1alpha1.ConfigSpec
+		want   kubelbv1alpha1.AnnotationSettings
+	}{
+		{
+			name:   "both empty",
+			tenant: kubelbv1alpha1.TenantSpec{},
+			config: kubelbv1alpha1.ConfigSpec{},
+			want:   kubelbv1alpha1.AnnotationSettings{},
+		},
+		{
+			name: "only config propagated annotations",
+			config: kubelbv1alpha1.ConfigSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagatedAnnotations: ptrMap(map[string]string{"k": ""}),
+				},
+			},
+			want: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"k": ""}),
+			},
+		},
+		{
+			name: "tenant propagated annotations override config",
+			config: kubelbv1alpha1.ConfigSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagatedAnnotations: ptrMap(map[string]string{"config": ""}),
+				},
+			},
+			tenant: kubelbv1alpha1.TenantSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagatedAnnotations: ptrMap(map[string]string{"tenant": ""}),
+				},
+			},
+			want: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"tenant": ""}),
+			},
+		},
+		{
+			name: "tenant propagate-all overrides config propagated list",
+			config: kubelbv1alpha1.ConfigSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagatedAnnotations: ptrMap(map[string]string{"k": ""}),
+				},
+			},
+			tenant: kubelbv1alpha1.TenantSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagateAllAnnotations: ptrBool(true),
+				},
+			},
+			want: kubelbv1alpha1.AnnotationSettings{
+				PropagateAllAnnotations: ptrBool(true),
+			},
+		},
+		{
+			name: "default annotations: tenant fully replaces config",
+			config: kubelbv1alpha1.ConfigSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+						kubelbv1alpha1.AnnotatedResourceService: {"c": "1"},
+					},
+				},
+			},
+			tenant: kubelbv1alpha1.TenantSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+						kubelbv1alpha1.AnnotatedResourceService: {"t": "1"},
+					},
+				},
+			},
+			want: kubelbv1alpha1.AnnotationSettings{
+				DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+					kubelbv1alpha1.AnnotatedResourceService: {"t": "1"},
+				},
+			},
+		},
+		{
+			name: "tenant explicit false disables config propagate-all",
+			config: kubelbv1alpha1.ConfigSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagateAllAnnotations: ptrBool(true),
+				},
+			},
+			tenant: kubelbv1alpha1.TenantSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagateAllAnnotations: ptrBool(false),
+				},
+			},
+			want: kubelbv1alpha1.AnnotationSettings{
+				PropagateAllAnnotations: ptrBool(false),
+			},
+		},
+		{
+			name: "tenant PropagatedAnnotations replaces config propagate-all",
+			config: kubelbv1alpha1.ConfigSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagateAllAnnotations: ptrBool(true),
+				},
+			},
+			tenant: kubelbv1alpha1.TenantSpec{
+				AnnotationSettings: kubelbv1alpha1.AnnotationSettings{
+					PropagatedAnnotations: ptrMap(map[string]string{"k": ""}),
+				},
+			},
+			want: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"k": ""}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tenant := &kubelbv1alpha1.Tenant{Spec: tt.tenant}
+			config := &kubelbv1alpha1.Config{Spec: tt.config}
+			got := GetAnnotations(tenant, config)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("GetAnnotations mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"path"
 	"strings"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
@@ -114,77 +115,115 @@ func GetNamespace(obj client.Object) string {
 	return namespace
 }
 
-func PropagateAnnotations(loadbalancer map[string]string, annotations kubelbv1alpha1.AnnotationSettings, resource kubelbv1alpha1.AnnotatedResource) map[string]string {
-	if loadbalancer == nil {
-		loadbalancer = make(map[string]string)
-	}
+// PropagateAnnotations returns the set of annotations to apply to a downstream
+// resource (Service/Ingress/Route/Gateway) based on the source resource's annotations
+// and the tenant/config AnnotationSettings. The returned map is always a fresh
+// allocation; the source map is never mutated. Precedence:
+//  1. DeniedAnnotations (glob) — always wins.
+//  2. PropagateAllAnnotations=true — keep everything not denied.
+//  3. PropagatedAnnotations — allow-list with glob keys and exact value match.
+//  4. DefaultAnnotations — merged in last; never overrides existing keys.
+func PropagateAnnotations(source map[string]string, settings kubelbv1alpha1.AnnotationSettings, resource kubelbv1alpha1.AnnotatedResource) map[string]string {
+	out := make(map[string]string, len(source))
+	denied := compileDenyMatcher(settings.DeniedAnnotations)
+	propagateAll := settings.PropagateAllAnnotations != nil && *settings.PropagateAllAnnotations
+	allowed := compileAllowMatcher(settings.PropagatedAnnotations)
 
-	if annotations.PropagateAllAnnotations != nil && *annotations.PropagateAllAnnotations {
-		return applyDefaultAnnotations(loadbalancer, annotations, resource)
-	}
-	permitted := make(map[string]string)
-
-	if annotations.PropagatedAnnotations != nil {
-		permitted = *annotations.PropagatedAnnotations
-	}
-
-	a := make(map[string]string)
-	permittedMap := make(map[string][]string)
-	for k, v := range permitted {
-		if _, found := permittedMap[k]; !found {
-			if v == "" {
-				permittedMap[k] = []string{}
-			} else {
-				filterValues := strings.Split(v, ",")
-				for i, v := range filterValues {
-					filterValues[i] = strings.TrimSpace(v)
-				}
-				permittedMap[k] = filterValues
-			}
+	for k, v := range source {
+		if denied(k) {
+			continue
+		}
+		if propagateAll || allowed(k, v) {
+			out[k] = v
 		}
 	}
-
-	for k, v := range loadbalancer {
-		if valuesFilter, ok := permittedMap[k]; ok {
-			if len(valuesFilter) == 0 {
-				a[k] = v
-			} else {
-				for _, vf := range valuesFilter {
-					if v == vf {
-						a[k] = v
-						break
-					}
-				}
-			}
-		}
-	}
-	return applyDefaultAnnotations(a, annotations, resource)
+	return mergeDefaultAnnotations(out, settings, resource)
 }
 
-func applyDefaultAnnotations(loadbalancer map[string]string, annotations kubelbv1alpha1.AnnotationSettings, resource kubelbv1alpha1.AnnotatedResource) map[string]string {
-	if annotations.DefaultAnnotations != nil {
-		if _, ok := annotations.DefaultAnnotations[resource]; ok {
-			// Merge the default annotations with the loadbalancer annotations while giving precedence to the loadbalancer annotations. If an annotation
-			// already exists in the loadbalancer, it will not be overridden by the default annotations.
-			for k, v := range annotations.DefaultAnnotations[resource] {
-				if _, ok := loadbalancer[k]; !ok {
-					loadbalancer[k] = v
+// compileDenyMatcher returns a function reporting whether key matches any deny pattern.
+// Patterns support shell-style globbing via path.Match. Invalid patterns are treated as
+// literal exact matches so that bad config can't silently bypass a denial.
+func compileDenyMatcher(patterns []string) func(key string) bool {
+	if len(patterns) == 0 {
+		return func(string) bool { return false }
+	}
+	return func(key string) bool {
+		for _, p := range patterns {
+			if matchPattern(p, key) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// compileAllowMatcher compiles the allow-list (key pattern -> comma-separated values, empty value means any)
+// into a closure that reports whether (key, value) is permitted. Keys support globbing.
+func compileAllowMatcher(allow *map[string]string) func(key, value string) bool {
+	if allow == nil || len(*allow) == 0 {
+		return func(string, string) bool { return false }
+	}
+	type rule struct {
+		pattern string
+		values  []string // nil means any value
+	}
+	rules := make([]rule, 0, len(*allow))
+	for k, v := range *allow {
+		r := rule{pattern: k}
+		if v != "" {
+			parts := strings.Split(v, ",")
+			for i := range parts {
+				parts[i] = strings.TrimSpace(parts[i])
+			}
+			r.values = parts
+		}
+		rules = append(rules, r)
+	}
+	return func(key, value string) bool {
+		for _, r := range rules {
+			if !matchPattern(r.pattern, key) {
+				continue
+			}
+			if r.values == nil {
+				return true
+			}
+			for _, allowed := range r.values {
+				if allowed == value {
+					return true
 				}
 			}
 		}
+		return false
+	}
+}
 
-		// Apply the default annotations for all resources if they are set.
-		if _, ok := annotations.DefaultAnnotations[kubelbv1alpha1.AnnotatedResourceAll]; ok {
-			// Merge the default annotations with the loadbalancer annotations while giving precedence to the loadbalancer annotations. If an annotation
-			// already exists in the loadbalancer, it will not be overridden by the default annotations.
-			for k, v := range annotations.DefaultAnnotations[kubelbv1alpha1.AnnotatedResourceAll] {
-				if _, ok := loadbalancer[k]; !ok {
-					loadbalancer[k] = v
-				}
-			}
+// matchPattern reports whether key matches the (possibly glob) pattern. If the pattern is
+// malformed for path.Match, it falls back to an exact-string comparison.
+func matchPattern(pattern, key string) bool {
+	matched, err := path.Match(pattern, key)
+	if err != nil {
+		return pattern == key
+	}
+	return matched
+}
+
+// mergeDefaultAnnotations writes resource-specific defaults (then "all" defaults)
+// into out, without overwriting existing keys. out is mutated and returned.
+func mergeDefaultAnnotations(out map[string]string, settings kubelbv1alpha1.AnnotationSettings, resource kubelbv1alpha1.AnnotatedResource) map[string]string {
+	if settings.DefaultAnnotations == nil {
+		return out
+	}
+	for k, v := range settings.DefaultAnnotations[resource] {
+		if _, exists := out[k]; !exists {
+			out[k] = v
 		}
 	}
-	return loadbalancer
+	for k, v := range settings.DefaultAnnotations[kubelbv1alpha1.AnnotatedResourceAll] {
+		if _, exists := out[k]; !exists {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 func AddKubeLBLabels(labels map[string]string, name, namespace, gvk string) map[string]string {

--- a/internal/kubelb/utils_test.go
+++ b/internal/kubelb/utils_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelb
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+)
+
+func ptrBool(b bool) *bool { return &b }
+
+func ptrMap(m map[string]string) *map[string]string { return &m }
+
+func TestPropagateAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   map[string]string
+		settings kubelbv1alpha1.AnnotationSettings
+		resource kubelbv1alpha1.AnnotatedResource
+		want     map[string]string
+	}{
+		{
+			name:     "nil source, empty settings, returns empty map",
+			source:   nil,
+			settings: kubelbv1alpha1.AnnotationSettings{},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{},
+		},
+		{
+			name:   "no allow list, source dropped",
+			source: map[string]string{"foo": "bar"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{}),
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{},
+		},
+		{
+			name:   "propagate-all keeps source unchanged",
+			source: map[string]string{"foo": "bar", "baz": "qux"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagateAllAnnotations: ptrBool(true),
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"foo": "bar", "baz": "qux"},
+		},
+		{
+			name:   "exact key match, empty value means any value",
+			source: map[string]string{"foo": "bar", "baz": "qux"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"foo": ""}),
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"foo": "bar"},
+		},
+		{
+			name:   "key match with comma-separated value list, value matches",
+			source: map[string]string{"k": "b"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"k": "a,b,c"}),
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"k": "b"},
+		},
+		{
+			name:   "key match, value list trims whitespace",
+			source: map[string]string{"k": "b"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"k": " a , b , c "}),
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"k": "b"},
+		},
+		{
+			name:   "key match but value not in list, dropped",
+			source: map[string]string{"k": "z"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"k": "a,b,c"}),
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{},
+		},
+		{
+			name:   "default annotations applied when key absent",
+			source: map[string]string{},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{}),
+				DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+					kubelbv1alpha1.AnnotatedResourceService: {"d": "1"},
+				},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"d": "1"},
+		},
+		{
+			name:   "source value wins over default",
+			source: map[string]string{"d": "src"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"d": ""}),
+				DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+					kubelbv1alpha1.AnnotatedResourceService: {"d": "default"},
+				},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"d": "src"},
+		},
+		{
+			name:   "all-resource defaults applied",
+			source: map[string]string{},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{}),
+				DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+					kubelbv1alpha1.AnnotatedResourceAll: {"a": "1"},
+				},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceIngress,
+			want:     map[string]string{"a": "1"},
+		},
+		{
+			name:   "resource-specific default wins over all",
+			source: map[string]string{},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{}),
+				DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+					kubelbv1alpha1.AnnotatedResourceAll:     {"k": "all"},
+					kubelbv1alpha1.AnnotatedResourceIngress: {"k": "ingress"},
+				},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceIngress,
+			want:     map[string]string{"k": "ingress"},
+		},
+		{
+			name:   "propagate-all also applies defaults",
+			source: map[string]string{"x": "1"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagateAllAnnotations: ptrBool(true),
+				DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+					kubelbv1alpha1.AnnotatedResourceService: {"d": "1"},
+				},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"x": "1", "d": "1"},
+		},
+		{
+			name:   "glob in allow key matches whole nginx ingress prefix",
+			source: map[string]string{"nginx.ingress.kubernetes.io/rewrite-target": "/", "nginx.ingress.kubernetes.io/ssl-redirect": "true", "other": "x"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"nginx.ingress.kubernetes.io/*": ""}),
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceIngress,
+			want: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+				"nginx.ingress.kubernetes.io/ssl-redirect":   "true",
+			},
+		},
+		{
+			name:   "deny list drops key under propagate-all",
+			source: map[string]string{"keep": "1", "drop.me/foo": "x", "drop.me/bar": "y"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagateAllAnnotations: ptrBool(true),
+				DeniedAnnotations:       []string{"drop.me/*"},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"keep": "1"},
+		},
+		{
+			name:   "deny overrides allow",
+			source: map[string]string{"a/x": "1", "a/y": "2"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"a/*": ""}),
+				DeniedAnnotations:     []string{"a/x"},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"a/y": "2"},
+		},
+		{
+			name:   "deny is exact when no glob",
+			source: map[string]string{"a/x": "1", "a/xx": "2"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagateAllAnnotations: ptrBool(true),
+				DeniedAnnotations:       []string{"a/x"},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"a/xx": "2"},
+		},
+		{
+			name:   "glob allow with value list still enforces exact value match",
+			source: map[string]string{"x.io/a": "ok", "x.io/b": "bad"},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				PropagatedAnnotations: ptrMap(map[string]string{"x.io/*": "ok"}),
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"x.io/a": "ok"},
+		},
+		{
+			name:   "deny does not block default annotations",
+			source: map[string]string{},
+			settings: kubelbv1alpha1.AnnotationSettings{
+				DeniedAnnotations: []string{"d"},
+				DefaultAnnotations: map[kubelbv1alpha1.AnnotatedResource]kubelbv1alpha1.Annotations{
+					kubelbv1alpha1.AnnotatedResourceService: {"d": "1"},
+				},
+			},
+			resource: kubelbv1alpha1.AnnotatedResourceService,
+			want:     map[string]string{"d": "1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var srcCopy map[string]string
+			if tt.source != nil {
+				srcCopy = map[string]string{}
+				for k, v := range tt.source {
+					srcCopy[k] = v
+				}
+			}
+			got := PropagateAnnotations(tt.source, tt.settings, tt.resource)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("PropagateAnnotations result mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(srcCopy, tt.source); diff != "" {
+				t.Errorf("PropagateAnnotations mutated input map (-before +after):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements the two annotation-handling improvements requested in #452:

1. **Deny list**: new `deniedAnnotations` field on `Config` and `Tenant`. Listed key patterns are excluded from propagation regardless of `propagateAllAnnotations` or `propagatedAnnotations`.
2. **Wildcard support**: `propagatedAnnotations` keys and `deniedAnnotations` entries support shell-style globs via `path.Match` (e.g. `nginx.ingress.kubernetes.io/*`).

Precedence: deny > propagate-all > allow-list > defaults. Defaults bypass deny since they represent explicit admin intent.

Example, propagate the whole nginx ingress prefix while excluding sensitive keys:
```yaml
apiVersion: kubelb.k8c.io/v1alpha1
kind: Config
metadata:
  name: default
  namespace: kubelb
spec:
  propagatedAnnotations:
    nginx.ingress.kubernetes.io/*: ""
  deniedAnnotations:
    - "kubernetes.io/last-applied-configuration"
    - "internal.company.io/*"
```

**Which issue(s) this PR fixes**:

Fixes #452

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

While auditing the existing code I found and fixed two precedence bugs in `GetAnnotations`:
- Explicit `tenant.propagateAllAnnotations: false` could not disable a config-level `true`.
- `tenant.propagatedAnnotations` was silently dropped when config had `propagateAllAnnotations: true`.

Also dropped a side-effecting mutation of the caller's annotation map in the propagate-all branch. Added unit tests covering existing behavior, the bug fixes, glob matching, and deny semantics — `PropagateAnnotations` and `GetAnnotations` had zero coverage before.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `deniedAnnotations` to Config and Tenant for excluding annotation keys from propagation. Keys in `propagatedAnnotations` and `deniedAnnotations` now support shell-style glob patterns (e.g. `nginx.ingress.kubernetes.io/*`).
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/2178
```