### PR TITLE
fix(addons): swap deleted kubebuilder rbac-proxy + harden build script

### DIFF
--- a/hack/build-addons-chart-deps.sh
+++ b/hack/build-addons-chart-deps.sh
@@ -30,6 +30,12 @@ CHART_DIR="${1:-charts/kubelb-addons}"
 CHARTS_SUBDIR="${CHART_DIR}/charts"
 PATCH_DIR="hack/patches"
 
+# Wipe the whole subchart directory so removed deps (e.g. a swapped addon)
+# don't linger. Per-chart cleanup below only covers deps helm still produces
+# a tgz for; a dep dropped from Chart.yaml would otherwise leak its templates
+# — and its images — into every helm template invocation.
+rm -rf "${CHARTS_SUBDIR}"
+
 # GitHub release asset 500s are a recurring flake when pulling ingress-nginx
 # over the https://kubernetes.github.io/ingress-nginx → github.com redirect.
 retry 5 helm dependency build "${CHART_DIR}"
@@ -39,18 +45,12 @@ for tgz in "${CHARTS_SUBDIR}"/*.tgz; do
   chart_name=$(tar -tzf "$tgz" | head -1 | cut -d/ -f1 || true)
   patch_file="${PATCH_DIR}/${chart_name}.patch"
 
-  # If a patch exists, always re-extract so it applies fresh against the
-  # pristine upstream chart. Without this, a stale dir from a prior run could
-  # silently remain unpatched.
-  if [ -d "${CHARTS_SUBDIR}/${chart_name}" ]; then
-    if [ -f "$patch_file" ]; then
-      rm -rf "${CHARTS_SUBDIR}/${chart_name}"
-    else
-      rm -f "$tgz"
-      continue
-    fi
-  fi
-
+  # Always blow away a prior extraction. A new tgz here means helm dependency
+  # build produced one, so the pristine upstream must overwrite whatever a
+  # previous run left behind — otherwise a version bump silently keeps the
+  # old chart (patch applies to stale sources, non-patched charts ship their
+  # old defaults to the image lists).
+  rm -rf "${CHARTS_SUBDIR}/${chart_name}"
   tar -xzf "$tgz" -C "${CHARTS_SUBDIR}"
   rm -f "$tgz"
 

--- a/hack/patches/metallb.patch
+++ b/hack/patches/metallb.patch
@@ -293,3 +293,31 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
          imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
          securityContext:
            readOnlyRootFilesystem: true
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8s/values.yaml b/metallb/charts/frr-k8s/values.yaml
+--- a/metallb/charts/frr-k8s/values.yaml	2025-12-04 20:20:55
++++ b/metallb/charts/frr-k8s/values.yaml	2026-04-22 12:35:00
+@@ -48,8 +48,8 @@
+ 
+   # the image to be used for the kuberbacproxy container
+   rbacProxy:
+-    repository: gcr.io/kubebuilder/kube-rbac-proxy
+-    tag: v0.12.0
++    repository: quay.io/brancz/kube-rbac-proxy
++    tag: v0.20.1
+     pullPolicy:
+ 
+   # Prometheus Operator ServiceMonitors.
+diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/values.yaml b/metallb/values.yaml
+--- a/metallb/values.yaml	2025-12-04 20:20:55
++++ b/metallb/values.yaml	2026-04-22 12:35:00
+@@ -55,8 +55,8 @@
+ 
+   # the image to be used for the kuberbacproxy container
+   rbacProxy:
+-    repository: gcr.io/kubebuilder/kube-rbac-proxy
+-    tag: v0.12.0
++    repository: quay.io/brancz/kube-rbac-proxy
++    tag: v0.20.1
+     pullPolicy:
+ 
+   # Prometheus Operator PodMonitors


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the issue with kubebuilder's missing image for metallb.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```