### PR TITLE
refactor(ccm): extract SourceAdapter and shared Source-to-Route reconciler

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ linters:
     rules:
       - linters:
           - revive
+          - goconst
         path: _test\.go
       - path: (.+)\.go$
         text: cyclomatic complexity 33 of func `CreateOrUpdateGRPCRoute` is high

--- a/docs/generated/api-reference-ee.md
+++ b/docs/generated/api-reference-ee.md
@@ -139,8 +139,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
-| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.<br />Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;<br />otherwise the value is a comma-separated list of permitted values for exact match.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
+| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.<br />If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `deniedAnnotations` _string array_ | DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of<br />PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
 | `defaultAnnotations` _object (keys:[AnnotatedResource](#annotatedresource), values:[Annotations](#annotations))_ | DefaultAnnotations defines the list of annotations(key-value pairs) that will be set on the load balancing resources if not already present. A special key `all` can be used to apply the same<br />set of annotations to all resources.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
 
 
@@ -290,8 +291,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
-| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.<br />Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;<br />otherwise the value is a comma-separated list of permitted values for exact match.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
+| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.<br />If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `deniedAnnotations` _string array_ | DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of<br />PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
 | `defaultAnnotations` _object (keys:[AnnotatedResource](#annotatedresource), values:[Annotations](#annotations))_ | DefaultAnnotations defines the list of annotations(key-value pairs) that will be set on the load balancing resources if not already present. A special key `all` can be used to apply the same<br />set of annotations to all resources.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
 | `envoyProxy` _[EnvoyProxy](#envoyproxy)_ | EnvoyProxy defines the desired state of the Envoy Proxy |  |  |
 | `loadBalancer` _[LoadBalancerSettings](#loadbalancersettings)_ |  |  |  |
@@ -345,7 +347,8 @@ _Appears in:_
 
 
 
-EndpointAddress is a tuple that describes single IP address.
+EndpointAddress is a tuple that describes a single endpoint address. At least
+one of IP or Hostname must be set.
 
 
 
@@ -356,7 +359,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `ip` _string_ | The IP of the endpoint. This can be an IPv4 or IPv6 address.<br />The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses. |  |  |
-| `hostname` _string_ | The Hostname of this endpoint |  |  |
+| `hostname` _string_ | The Hostname of this endpoint. Used when the backend has no stable IP and<br />must be resolved by DNS. If both ip and hostname are set, ip wins. |  |  |
 
 
 #### EndpointPort
@@ -1158,8 +1161,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
-| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.<br />Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;<br />otherwise the value is a comma-separated list of permitted values for exact match.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
+| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.<br />If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `deniedAnnotations` _string array_ | DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of<br />PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
 | `defaultAnnotations` _object (keys:[AnnotatedResource](#annotatedresource), values:[Annotations](#annotations))_ | DefaultAnnotations defines the list of annotations(key-value pairs) that will be set on the load balancing resources if not already present. A special key `all` can be used to apply the same<br />set of annotations to all resources.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
 | `loadBalancer` _[LoadBalancerSettings](#loadbalancersettings)_ |  |  |  |
 | `ingress` _[IngressSettings](#ingresssettings)_ |  |  |  |

--- a/docs/generated/api-reference.md
+++ b/docs/generated/api-reference.md
@@ -135,8 +135,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
-| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.<br />Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;<br />otherwise the value is a comma-separated list of permitted values for exact match.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
+| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.<br />If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `deniedAnnotations` _string array_ | DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of<br />PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
 | `defaultAnnotations` _object (keys:[AnnotatedResource](#annotatedresource), values:[Annotations](#annotations))_ | DefaultAnnotations defines the list of annotations(key-value pairs) that will be set on the load balancing resources if not already present. A special key `all` can be used to apply the same<br />set of annotations to all resources.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
 
 
@@ -244,8 +245,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
-| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.<br />Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;<br />otherwise the value is a comma-separated list of permitted values for exact match.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
+| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.<br />If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `deniedAnnotations` _string array_ | DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of<br />PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
 | `defaultAnnotations` _object (keys:[AnnotatedResource](#annotatedresource), values:[Annotations](#annotations))_ | DefaultAnnotations defines the list of annotations(key-value pairs) that will be set on the load balancing resources if not already present. A special key `all` can be used to apply the same<br />set of annotations to all resources.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
 | `envoyProxy` _[EnvoyProxy](#envoyproxy)_ | EnvoyProxy defines the desired state of the Envoy Proxy |  |  |
 | `loadBalancer` _[LoadBalancerSettings](#loadbalancersettings)_ |  |  |  |
@@ -294,7 +296,8 @@ _Appears in:_
 
 
 
-EndpointAddress is a tuple that describes single IP address.
+EndpointAddress is a tuple that describes a single endpoint address. At least
+one of IP or Hostname must be set.
 
 
 
@@ -305,7 +308,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `ip` _string_ | The IP of the endpoint. This can be an IPv4 or IPv6 address.<br />The IP address must not be IP CIDR, Loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24) addresses. |  |  |
-| `hostname` _string_ | The Hostname of this endpoint |  |  |
+| `hostname` _string_ | The Hostname of this endpoint. Used when the backend has no stable IP and<br />must be resolved by DNS. If both ip and hostname are set, ip wins. |  |  |
 
 
 #### EndpointPort
@@ -1041,8 +1044,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the list of annotations(key-value pairs) that will be propagated to the LoadBalancer service. Keep the `value` field empty in the key-value pair to allow any value.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
-| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to the LoadBalancer service. If set to true, PropagatedAnnotations will be ignored.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `propagatedAnnotations` _map[string]string_ | PropagatedAnnotations defines the set of annotation key patterns that will be propagated to load balancing resources.<br />Keys support shell-style glob patterns (e.g. "nginx.ingress.kubernetes.io/*"). Keep the value empty to allow any value;<br />otherwise the value is a comma-separated list of permitted values for exact match.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
+| `propagateAllAnnotations` _boolean_ | PropagateAllAnnotations defines whether all annotations will be propagated to load balancing resources.<br />If set to true, PropagatedAnnotations is ignored. DeniedAnnotations still applies on top of this flag.<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
+| `deniedAnnotations` _string array_ | DeniedAnnotations is a list of annotation key patterns that are excluded from propagation, regardless of<br />PropagateAllAnnotations or PropagatedAnnotations. Patterns support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*").<br />Tenant configuration has higher precedence than the value specified at the Config level. |  |  |
 | `defaultAnnotations` _object (keys:[AnnotatedResource](#annotatedresource), values:[Annotations](#annotations))_ | DefaultAnnotations defines the list of annotations(key-value pairs) that will be set on the load balancing resources if not already present. A special key `all` can be used to apply the same<br />set of annotations to all resources.<br />Tenant configuration has higher precedence than the annotations specified at the Config level. |  |  |
 | `envoyProxy` _[TenantEnvoyProxy](#tenantenvoyproxy)_ | EnvoyProxy defines tenant-level overrides for Envoy Proxy configuration.<br />Fields set here take precedence over Config.Spec.EnvoyProxy. |  |  |
 | `loadBalancer` _[LoadBalancerSettings](#loadbalancersettings)_ |  |  |  |

--- a/docs/generated/helm-values-kubelb-manager.md
+++ b/docs/generated/helm-values-kubelb-manager.md
@@ -19,6 +19,7 @@
 | kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
 | kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
 | kubelb.debug | bool | `true` |  |
+| kubelb.deniedAnnotations | list | `[]` | Annotation key patterns to exclude from propagation. Patterns support shell-style globbing. Deny rules always take precedence over PropagatedAnnotations and PropagateAllAnnotations. |
 | kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
 | kubelb.enableLeaderElection | bool | `true` |  |
 | kubelb.envoyProxy.affinity | object | `{}` |  |
@@ -32,8 +33,8 @@
 | kubelb.envoyProxy.topology | string | `"shared"` | Topology defines the deployment topology for Envoy Proxy. Only "shared" is supported. "dedicated" and "global" are deprecated and will default to shared. |
 | kubelb.envoyProxy.useDaemonset | bool | `false` | Use DaemonSet for Envoy Proxy deployment instead of Deployment. |
 | kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
-| kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the LB resource to the LB service. |
-| kubelb.propagatedAnnotations | object | `{}` | Allowed annotations that will be propagated from the LB resource to the LB service. |
+| kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the source resource to load balancing resources. DeniedAnnotations still applies. |
+| kubelb.propagatedAnnotations | object | `{}` | Allowed annotation key patterns to propagate from the source resource to load balancing resources. Keys support shell-style globbing (e.g. "nginx.ingress.kubernetes.io/*"). Empty value means any value. |
 | kubelb.skipConfigGeneration | bool | `true` | Set to false to enable the generation of the Config CR. Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually. |
 | metrics.port | int | `9443` | Port where the manager exposes metrics (includes both manager and envoycp metrics) |
 | nameOverride | string | `""` |  |

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-test/deep v1.1.1
+	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.39.1
 	github.com/pkg/errors v0.9.1
@@ -62,7 +63,6 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/controllers/ccm/gateway_controller.go
+++ b/internal/controllers/ccm/gateway_controller.go
@@ -145,7 +145,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *GatewayReconciler) reconcile(ctx context.Context, log logr.Logger, gateway *gwapiv1.Gateway) error {
 	// Create/update the corresponding Route in LB cluster.
-	err := reconcileSourceForRoute(ctx, log, r.Client, r.LBManager.GetClient(), gateway, nil, nil, r.ClusterName)
+	err := reconcileSourceForRoute(ctx, log, r.Client, r.LBManager.GetClient(), gateway, nil, r.ClusterName)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile source for route: %w", err)
 	}

--- a/internal/controllers/ccm/gateway_grpcroute_controller.go
+++ b/internal/controllers/ccm/gateway_grpcroute_controller.go
@@ -18,35 +18,24 @@ package ccm
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/go-logr/logr"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
-	"k8c.io/kubelb/internal/kubelb"
-	"k8c.io/kubelb/internal/metricsutil"
 	ccmmetrics "k8c.io/kubelb/internal/metricsutil/ccm"
 	gatewayhelper "k8c.io/kubelb/internal/resources/gatewayapi/gateway"
 	grpcrouteHelpers "k8c.io/kubelb/internal/resources/gatewayapi/grpcroute"
-	serviceHelpers "k8c.io/kubelb/internal/resources/service"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
@@ -54,9 +43,10 @@ import (
 
 const (
 	GatewayGRPCRouteControllerName = "gateway-grpcroute-controller"
+	GRPCRouteGVK                   = "GRPCRoute.gateway.networking.k8s.io"
 )
 
-// GRPCRouteReconciler reconciles an GRPCRoute Object
+// GRPCRouteReconciler reconciles a GRPCRoute Object
 type GRPCRouteReconciler struct {
 	ctrlclient.Client
 
@@ -66,6 +56,8 @@ type GRPCRouteReconciler struct {
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
+
+	loop *SourceReconciler[*gwapiv1.GRPCRoute]
 }
 
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch
@@ -76,239 +68,69 @@ type GRPCRouteReconciler struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=grpcroutes/status,verbs=get;update;patch
 
 func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("name", req.NamespacedName)
-	startTime := time.Now()
-
-	// Track reconciliation duration
-	defer func() {
-		ccmmetrics.GRPCRouteReconcileDuration.WithLabelValues(req.Namespace).Observe(time.Since(startTime).Seconds())
-	}()
-
-	log.Info("Reconciling GRPCRoute")
-
-	resource := &gwapiv1.GRPCRoute{}
-	if err := r.Get(ctx, req.NamespacedName, resource); err != nil {
-		if kerrors.IsNotFound(err) {
-			return reconcile.Result{}, nil
-		}
-		ccmmetrics.GRPCRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-		return reconcile.Result{}, err
-	}
-
-	// Resource is marked for deletion
-	if resource.DeletionTimestamp != nil {
-		if controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
-			return r.cleanup(ctx, resource)
-		}
-		// Finalizer doesn't exist so clean up is already done
-		return reconcile.Result{}, nil
-	}
-
-	if !r.shouldReconcile(resource) {
-		ccmmetrics.GRPCRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSkipped).Inc()
-		return reconcile.Result{}, nil
-	}
-
-	// Add finalizer if it doesn't exist
-	if !controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
-		controllerutil.AddFinalizer(resource, CleanupFinalizer)
-		if err := r.Update(ctx, resource); err != nil {
-			ccmmetrics.GRPCRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
-		}
-	}
-
-	err := r.reconcile(ctx, log, resource)
-	if err != nil {
-		log.Error(err, "reconciling failed")
-		ccmmetrics.GRPCRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-		return reconcile.Result{}, err
-	}
-
-	// Update managed grpcroutes gauge
-	grpcRouteList := &gwapiv1.GRPCRouteList{}
-	if err := r.List(ctx, grpcRouteList, ctrlclient.InNamespace(req.Namespace)); err == nil {
-		count := 0
-		for _, gr := range grpcRouteList.Items {
-			if r.shouldReconcile(&gr) && gr.DeletionTimestamp == nil {
-				count++
-			}
-		}
-		ccmmetrics.ManagedGRPCRoutesTotal.WithLabelValues(req.Namespace).Set(float64(count))
-	}
-
-	ccmmetrics.GRPCRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSuccess).Inc()
-	return reconcile.Result{}, nil
-}
-
-func (r *GRPCRouteReconciler) reconcile(ctx context.Context, log logr.Logger, grpcRoute *gwapiv1.GRPCRoute) error {
-	// We need to traverse the GRPCRoute, find all the services associated with it, create/update the corresponding Route in LB cluster.
-	originalServices := grpcrouteHelpers.GetServicesFromGRPCRoute(grpcRoute)
-	err := reconcileSourceForRoute(ctx, log, r.Client, r.LBManager.GetClient(), grpcRoute, originalServices, nil, r.ClusterName)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile source for route: %w", err)
-	}
-
-	// Route was reconciled successfully, now we need to update the status of the Resource.
-	route := kubelbv1alpha1.Route{}
-	err = r.LBManager.GetClient().Get(ctx, types.NamespacedName{Name: string(grpcRoute.UID), Namespace: r.ClusterName}, &route)
-	if err != nil {
-		return fmt.Errorf("failed to get Route from LB cluster: %w", err)
-	}
-
-	// Update the status of the GRPCRoute
-	if len(route.Status.Resources.Route.GeneratedName) > 0 {
-		// First we need to ensure that status is available in the Route
-		resourceStatus := route.Status.Resources.Route.Status
-		jsonData, err := json.Marshal(resourceStatus.Raw)
-		if err != nil || string(jsonData) == kubelb.DefaultRouteStatus {
-			// Status is not available in the Route, so we need to wait for it
-			return nil
-		}
-
-		// Convert rawExtension to gwapiv1.GRPCRouteStatus
-		status := gwapiv1.GRPCRouteStatus{}
-		if err := yaml.UnmarshalStrict(resourceStatus.Raw, &status); err != nil {
-			return fmt.Errorf("failed to unmarshal GRPCRoute status: %w", err)
-		}
-
-		log.V(3).Info("updating GRPCRoute status", "name", grpcRoute.Name, "namespace", grpcRoute.Namespace)
-		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := r.Get(ctx, types.NamespacedName{Name: grpcRoute.Name, Namespace: grpcRoute.Namespace}, grpcRoute); err != nil {
-				return err
-			}
-			original := grpcRoute.DeepCopy()
-			for i := range status.Parents {
-				for j := range status.Parents[i].Conditions {
-					status.Parents[i].Conditions[j].ObservedGeneration = grpcRoute.Generation
-				}
-			}
-			grpcRoute.Status = status
-			if reflect.DeepEqual(original.Status, grpcRoute.Status) {
-				return nil
-			}
-			// update the status
-			return r.Status().Patch(ctx, grpcRoute, ctrlclient.MergeFrom(original))
-		})
-	}
-	return nil
-}
-
-func (r *GRPCRouteReconciler) cleanup(ctx context.Context, grpcRoute *gwapiv1.GRPCRoute) (ctrl.Result, error) {
-	impactedServices := grpcrouteHelpers.GetServicesFromGRPCRoute(grpcRoute)
-	services := corev1.ServiceList{}
-	err := r.List(ctx, &services, ctrlclient.InNamespace(grpcRoute.Namespace), ctrlclient.MatchingLabels{kubelb.LabelManagedBy: kubelb.LabelControllerName})
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list services: %w", err)
-	}
-
-	// Delete services created by the controller.
-	for _, service := range services.Items {
-		originalName := service.Name
-		if service.Labels[kubelb.LabelOriginName] != "" {
-			originalName = service.Labels[kubelb.LabelOriginName]
-		}
-
-		for _, serviceRef := range impactedServices {
-			if serviceRef.Name == originalName && serviceRef.Namespace == service.Namespace {
-				err := r.Delete(ctx, &service)
-				if err != nil {
-					return reconcile.Result{}, fmt.Errorf("failed to delete service: %w", err)
-				}
-			}
-		}
-	}
-
-	// Find the Route in LB cluster and delete it
-	err = cleanupRoute(ctx, r.LBManager.GetClient(), string(grpcRoute.UID), r.ClusterName)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to cleanup route: %w", err)
-	}
-
-	controllerutil.RemoveFinalizer(grpcRoute, CleanupFinalizer)
-	if err := r.Update(ctx, grpcRoute); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
-	}
-
-	return reconcile.Result{}, nil
-}
-
-// enqueueResources is a handler.MapFunc to be used to enqueue requests for reconciliation
-// for GRPCRoutes against the corresponding service.
-func (r *GRPCRouteReconciler) enqueueResources() handler.MapFunc {
-	return func(_ context.Context, o ctrlclient.Object) []ctrl.Request {
-		result := []reconcile.Request{}
-		grpcRouteList := &gwapiv1.GRPCRouteList{}
-		if err := r.List(context.Background(), grpcRouteList, ctrlclient.InNamespace(o.GetNamespace())); err != nil {
-			return nil
-		}
-
-		for _, grpcRoute := range grpcRouteList.Items {
-			if !r.shouldReconcile(&grpcRoute) {
-				continue
-			}
-
-			services := grpcrouteHelpers.GetServicesFromGRPCRoute(&grpcRoute)
-			for _, serviceRef := range services {
-				if (serviceRef.Name == o.GetName() || fmt.Sprintf(serviceHelpers.NodePortServicePattern, serviceRef.Name) == o.GetName()) && serviceRef.Namespace == o.GetNamespace() {
-					result = append(result, reconcile.Request{
-						NamespacedName: types.NamespacedName{
-							Name:      grpcRoute.Name,
-							Namespace: grpcRoute.Namespace,
-						},
-					})
-				}
-			}
-		}
-		return result
-	}
-}
-
-func (r *GRPCRouteReconciler) resourceFilter() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			if obj, ok := e.Object.(*gwapiv1.GRPCRoute); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if obj, ok := e.ObjectNew.(*gwapiv1.GRPCRoute); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if obj, ok := e.Object.(*gwapiv1.GRPCRoute); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			if obj, ok := e.Object.(*gwapiv1.GRPCRoute); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-	}
-}
-
-// shouldReconcile returns true if the GRPCRoute should be reconciled by the controller.
-func (r *GRPCRouteReconciler) shouldReconcile(grpcRoute *gwapiv1.GRPCRoute) bool {
-	return gatewayhelper.ShouldReconcileResource(grpcRoute, false)
+	return r.loop.Reconcile(ctx, req)
 }
 
 func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.loop = &SourceReconciler[*gwapiv1.GRPCRoute]{
+		Client:      r.Client,
+		LBClient:    r.LBManager.GetClient(),
+		ClusterName: r.ClusterName,
+		Log:         r.Log,
+		Adapter:     &grpcRouteAdapter{},
+	}
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gwapiv1.GRPCRoute{}, builder.WithPredicates(r.resourceFilter())).
 		Named(GatewayGRPCRouteControllerName).
+		For(&gwapiv1.GRPCRoute{}, builder.WithPredicates(r.loop.Predicate())).
 		Watches(
 			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(r.enqueueResources()),
+			handler.EnqueueRequestsFromMapFunc(r.loop.EnqueueForService()),
 		).
 		WatchesRawSource(
 			source.Kind(r.LBManager.GetCache(), &kubelbv1alpha1.Route{},
-				handler.TypedEnqueueRequestsFromMapFunc[*kubelbv1alpha1.Route](enqueueRoutes("GRPCRoute.gateway.networking.k8s.io", r.ClusterName))),
+				handler.TypedEnqueueRequestsFromMapFunc[*kubelbv1alpha1.Route](enqueueRoutes(GRPCRouteGVK, r.ClusterName))),
 		).
 		Complete(r)
+}
+
+type grpcRouteAdapter struct{}
+
+var _ SourceAdapter[*gwapiv1.GRPCRoute] = (*grpcRouteAdapter)(nil)
+
+func (a *grpcRouteAdapter) Kind() string                   { return "GRPCRoute" }
+func (a *grpcRouteAdapter) GVK() string                    { return GRPCRouteGVK }
+func (a *grpcRouteAdapter) NewObject() *gwapiv1.GRPCRoute  { return &gwapiv1.GRPCRoute{} }
+func (a *grpcRouteAdapter) NewList() ctrlclient.ObjectList { return &gwapiv1.GRPCRouteList{} }
+
+func (a *grpcRouteAdapter) Metrics() SourceMetrics {
+	return SourceMetrics{
+		ReconcileTotal:    ccmmetrics.GRPCRouteReconcileTotal,
+		ReconcileDuration: ccmmetrics.GRPCRouteReconcileDuration,
+		Managed:           ccmmetrics.ManagedGRPCRoutesTotal,
+	}
+}
+
+func (a *grpcRouteAdapter) ShouldReconcile(grpcRoute *gwapiv1.GRPCRoute) bool {
+	return gatewayhelper.ShouldReconcileResource(grpcRoute, false)
+}
+
+func (a *grpcRouteAdapter) ExtractServices(grpcRoute *gwapiv1.GRPCRoute) []types.NamespacedName {
+	return grpcrouteHelpers.GetServicesFromGRPCRoute(grpcRoute)
+}
+
+func (a *grpcRouteAdapter) ApplyRouteStatus(grpcRoute *gwapiv1.GRPCRoute, raw []byte) (bool, error) {
+	status := gwapiv1.GRPCRouteStatus{}
+	if err := yaml.UnmarshalStrict(raw, &status); err != nil {
+		return false, fmt.Errorf("failed to unmarshal GRPCRoute status: %w", err)
+	}
+	for i := range status.Parents {
+		for j := range status.Parents[i].Conditions {
+			status.Parents[i].Conditions[j].ObservedGeneration = grpcRoute.Generation
+		}
+	}
+	if reflect.DeepEqual(grpcRoute.Status, status) {
+		return false, nil
+	}
+	grpcRoute.Status = status
+	return true, nil
 }

--- a/internal/controllers/ccm/gateway_httproute_controller.go
+++ b/internal/controllers/ccm/gateway_httproute_controller.go
@@ -18,35 +18,24 @@ package ccm
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/go-logr/logr"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
-	"k8c.io/kubelb/internal/kubelb"
-	"k8c.io/kubelb/internal/metricsutil"
 	ccmmetrics "k8c.io/kubelb/internal/metricsutil/ccm"
 	gatewayhelper "k8c.io/kubelb/internal/resources/gatewayapi/gateway"
 	httprouteHelpers "k8c.io/kubelb/internal/resources/gatewayapi/httproute"
-	serviceHelpers "k8c.io/kubelb/internal/resources/service"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
@@ -54,6 +43,7 @@ import (
 
 const (
 	GatewayHTTPRouteControllerName = "gateway-httproute-controller"
+	HTTPRouteGVK                   = "HTTPRoute.gateway.networking.k8s.io"
 )
 
 // HTTPRouteReconciler reconciles an HTTPRoute Object
@@ -66,6 +56,8 @@ type HTTPRouteReconciler struct {
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
+
+	loop *SourceReconciler[*gwapiv1.HTTPRoute]
 }
 
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch
@@ -76,244 +68,69 @@ type HTTPRouteReconciler struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/status,verbs=get;update;patch
 
 func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("name", req.NamespacedName)
-	startTime := time.Now()
-
-	// Track reconciliation duration
-	defer func() {
-		ccmmetrics.HTTPRouteReconcileDuration.WithLabelValues(req.Namespace).Observe(time.Since(startTime).Seconds())
-	}()
-
-	log.Info("Reconciling HTTPRoute")
-
-	resource := &gwapiv1.HTTPRoute{}
-	if err := r.Get(ctx, req.NamespacedName, resource); err != nil {
-		if kerrors.IsNotFound(err) {
-			return reconcile.Result{}, nil
-		}
-		ccmmetrics.HTTPRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-		return reconcile.Result{}, err
-	}
-
-	// Resource is marked for deletion
-	if resource.DeletionTimestamp != nil {
-		if controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
-			return r.cleanup(ctx, resource)
-		}
-		// Finalizer doesn't exist so clean up is already done
-		return reconcile.Result{}, nil
-	}
-
-	if !r.shouldReconcile(resource) {
-		ccmmetrics.HTTPRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSkipped).Inc()
-		return reconcile.Result{}, nil
-	}
-
-	// Add finalizer if it doesn't exist
-	if !controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
-		if ok := controllerutil.AddFinalizer(resource, CleanupFinalizer); !ok {
-			log.Error(nil, "Failed to add finalizer for the HTTPRoute")
-			return ctrl.Result{Requeue: true}, nil
-		}
-
-		if err := r.Update(ctx, resource); err != nil {
-			ccmmetrics.HTTPRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
-		}
-	}
-
-	err := r.reconcile(ctx, log, resource)
-	if err != nil {
-		log.Error(err, "reconciling failed")
-		ccmmetrics.HTTPRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-		return reconcile.Result{}, err
-	}
-
-	// Update managed httproutes gauge
-	httpRouteList := &gwapiv1.HTTPRouteList{}
-	if err := r.List(ctx, httpRouteList, ctrlclient.InNamespace(req.Namespace)); err == nil {
-		count := 0
-		for _, hr := range httpRouteList.Items {
-			if r.shouldReconcile(&hr) && hr.DeletionTimestamp == nil {
-				count++
-			}
-		}
-		ccmmetrics.ManagedHTTPRoutesTotal.WithLabelValues(req.Namespace).Set(float64(count))
-	}
-
-	ccmmetrics.HTTPRouteReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSuccess).Inc()
-	return reconcile.Result{}, nil
-}
-
-func (r *HTTPRouteReconciler) reconcile(ctx context.Context, log logr.Logger, httpRoute *gwapiv1.HTTPRoute) error {
-	// We need to traverse the HTTPRoute, find all the services associated with it, create/update the corresponding Route in LB cluster.
-	originalServices := httprouteHelpers.GetServicesFromHTTPRoute(httpRoute)
-	err := reconcileSourceForRoute(ctx, log, r.Client, r.LBManager.GetClient(), httpRoute, originalServices, nil, r.ClusterName)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile source for route: %w", err)
-	}
-
-	// Route was reconciled successfully, now we need to update the status of the Resource.
-	route := kubelbv1alpha1.Route{}
-	err = r.LBManager.GetClient().Get(ctx, types.NamespacedName{Name: string(httpRoute.UID), Namespace: r.ClusterName}, &route)
-	if err != nil {
-		return fmt.Errorf("failed to get Route from LB cluster: %w", err)
-	}
-
-	// Update the status of the HTTPRoute
-	if len(route.Status.Resources.Route.GeneratedName) > 0 {
-		// First we need to ensure that status is available in the Route
-		resourceStatus := route.Status.Resources.Route.Status
-		jsonData, err := json.Marshal(resourceStatus.Raw)
-		if err != nil || string(jsonData) == kubelb.DefaultRouteStatus {
-			// Status is not available in the Route, so we need to wait for it
-			return nil
-		}
-
-		// Convert rawExtension to gwapiv1.HTTPRouteStatus
-		status := gwapiv1.HTTPRouteStatus{}
-		if err := yaml.UnmarshalStrict(resourceStatus.Raw, &status); err != nil {
-			return fmt.Errorf("failed to unmarshal HTTPRoute status: %w", err)
-		}
-
-		log.V(3).Info("updating HTTPRoute status", "name", httpRoute.Name, "namespace", httpRoute.Namespace)
-		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := r.Get(ctx, types.NamespacedName{Name: httpRoute.Name, Namespace: httpRoute.Namespace}, httpRoute); err != nil {
-				return err
-			}
-			original := httpRoute.DeepCopy()
-			for i := range status.Parents {
-				for j := range status.Parents[i].Conditions {
-					status.Parents[i].Conditions[j].ObservedGeneration = httpRoute.Generation
-				}
-			}
-			httpRoute.Status = status
-			if reflect.DeepEqual(original.Status, httpRoute.Status) {
-				return nil
-			}
-			// update the status
-			return r.Status().Patch(ctx, httpRoute, ctrlclient.MergeFrom(original))
-		})
-	}
-	return nil
-}
-
-func (r *HTTPRouteReconciler) cleanup(ctx context.Context, httpRoute *gwapiv1.HTTPRoute) (ctrl.Result, error) {
-	impactedServices := httprouteHelpers.GetServicesFromHTTPRoute(httpRoute)
-	services := corev1.ServiceList{}
-	err := r.List(ctx, &services, ctrlclient.InNamespace(httpRoute.Namespace), ctrlclient.MatchingLabels{kubelb.LabelManagedBy: kubelb.LabelControllerName})
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list services: %w", err)
-	}
-
-	// Delete services created by the controller.
-	for _, service := range services.Items {
-		originalName := service.Name
-		if service.Labels[kubelb.LabelOriginName] != "" {
-			originalName = service.Labels[kubelb.LabelOriginName]
-		}
-
-		for _, serviceRef := range impactedServices {
-			if serviceRef.Name == originalName && serviceRef.Namespace == service.Namespace {
-				err := r.Delete(ctx, &service)
-				if err != nil {
-					return reconcile.Result{}, fmt.Errorf("failed to delete service: %w", err)
-				}
-			}
-		}
-	}
-
-	// Find the Route in LB cluster and delete it
-	err = cleanupRoute(ctx, r.LBManager.GetClient(), string(httpRoute.UID), r.ClusterName)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to cleanup route: %w", err)
-	}
-
-	controllerutil.RemoveFinalizer(httpRoute, CleanupFinalizer)
-	if err := r.Update(ctx, httpRoute); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
-	}
-
-	return reconcile.Result{}, nil
-}
-
-// enqueueResources is a handler.MapFunc to be used to enqueue requests for reconciliation
-// for HTTPRoutes against the corresponding service.
-func (r *HTTPRouteReconciler) enqueueResources() handler.MapFunc {
-	return func(_ context.Context, o ctrlclient.Object) []ctrl.Request {
-		result := []reconcile.Request{}
-		httpRouteList := &gwapiv1.HTTPRouteList{}
-		if err := r.List(context.Background(), httpRouteList, ctrlclient.InNamespace(o.GetNamespace())); err != nil {
-			return nil
-		}
-
-		for _, httpRoute := range httpRouteList.Items {
-			if !r.shouldReconcile(&httpRoute) {
-				continue
-			}
-
-			services := httprouteHelpers.GetServicesFromHTTPRoute(&httpRoute)
-			for _, serviceRef := range services {
-				if (serviceRef.Name == o.GetName() || fmt.Sprintf(serviceHelpers.NodePortServicePattern, serviceRef.Name) == o.GetName()) && serviceRef.Namespace == o.GetNamespace() {
-					result = append(result, reconcile.Request{
-						NamespacedName: types.NamespacedName{
-							Name:      httpRoute.Name,
-							Namespace: httpRoute.Namespace,
-						},
-					})
-				}
-			}
-		}
-		return result
-	}
-}
-
-func (r *HTTPRouteReconciler) resourceFilter() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			if obj, ok := e.Object.(*gwapiv1.HTTPRoute); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if obj, ok := e.ObjectNew.(*gwapiv1.HTTPRoute); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if obj, ok := e.Object.(*gwapiv1.HTTPRoute); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			if obj, ok := e.Object.(*gwapiv1.HTTPRoute); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-	}
-}
-
-// shouldReconcile returns true if the HTTPRoute should be reconciled by the controller.
-// In Community Edition, the controller only reconciles HTTPRoutes against the gateway named "kubelb".
-func (r *HTTPRouteReconciler) shouldReconcile(httpRoute *gwapiv1.HTTPRoute) bool {
-	return gatewayhelper.ShouldReconcileResource(httpRoute, false)
+	return r.loop.Reconcile(ctx, req)
 }
 
 func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.loop = &SourceReconciler[*gwapiv1.HTTPRoute]{
+		Client:      r.Client,
+		LBClient:    r.LBManager.GetClient(),
+		ClusterName: r.ClusterName,
+		Log:         r.Log,
+		Adapter:     &httpRouteAdapter{},
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(GatewayHTTPRouteControllerName).
-		For(&gwapiv1.HTTPRoute{}, builder.WithPredicates(r.resourceFilter())).
+		For(&gwapiv1.HTTPRoute{}, builder.WithPredicates(r.loop.Predicate())).
 		Watches(
 			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(r.enqueueResources()),
+			handler.EnqueueRequestsFromMapFunc(r.loop.EnqueueForService()),
 		).
 		WatchesRawSource(
 			source.Kind(r.LBManager.GetCache(), &kubelbv1alpha1.Route{},
-				handler.TypedEnqueueRequestsFromMapFunc[*kubelbv1alpha1.Route](enqueueRoutes("HTTPRoute.gateway.networking.k8s.io", r.ClusterName))),
+				handler.TypedEnqueueRequestsFromMapFunc[*kubelbv1alpha1.Route](enqueueRoutes(HTTPRouteGVK, r.ClusterName))),
 		).
 		Complete(r)
+}
+
+type httpRouteAdapter struct{}
+
+var _ SourceAdapter[*gwapiv1.HTTPRoute] = (*httpRouteAdapter)(nil)
+
+func (a *httpRouteAdapter) Kind() string                   { return "HTTPRoute" }
+func (a *httpRouteAdapter) GVK() string                    { return HTTPRouteGVK }
+func (a *httpRouteAdapter) NewObject() *gwapiv1.HTTPRoute  { return &gwapiv1.HTTPRoute{} }
+func (a *httpRouteAdapter) NewList() ctrlclient.ObjectList { return &gwapiv1.HTTPRouteList{} }
+
+func (a *httpRouteAdapter) Metrics() SourceMetrics {
+	return SourceMetrics{
+		ReconcileTotal:    ccmmetrics.HTTPRouteReconcileTotal,
+		ReconcileDuration: ccmmetrics.HTTPRouteReconcileDuration,
+		Managed:           ccmmetrics.ManagedHTTPRoutesTotal,
+	}
+}
+
+func (a *httpRouteAdapter) ShouldReconcile(httpRoute *gwapiv1.HTTPRoute) bool {
+	return gatewayhelper.ShouldReconcileResource(httpRoute, false)
+}
+
+func (a *httpRouteAdapter) ExtractServices(httpRoute *gwapiv1.HTTPRoute) []types.NamespacedName {
+	return httprouteHelpers.GetServicesFromHTTPRoute(httpRoute)
+}
+
+func (a *httpRouteAdapter) ApplyRouteStatus(httpRoute *gwapiv1.HTTPRoute, raw []byte) (bool, error) {
+	status := gwapiv1.HTTPRouteStatus{}
+	if err := yaml.UnmarshalStrict(raw, &status); err != nil {
+		return false, fmt.Errorf("failed to unmarshal HTTPRoute status: %w", err)
+	}
+	for i := range status.Parents {
+		for j := range status.Parents[i].Conditions {
+			status.Parents[i].Conditions[j].ObservedGeneration = httpRoute.Generation
+		}
+	}
+	if reflect.DeepEqual(httpRoute.Status, status) {
+		return false, nil
+	}
+	httpRoute.Status = status
+	return true, nil
 }

--- a/internal/controllers/ccm/ingress_controller.go
+++ b/internal/controllers/ccm/ingress_controller.go
@@ -18,35 +18,24 @@ package ccm
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/go-logr/logr"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
-	"k8c.io/kubelb/internal/kubelb"
-	"k8c.io/kubelb/internal/metricsutil"
 	ccmmetrics "k8c.io/kubelb/internal/metricsutil/ccm"
 	ingressHelpers "k8c.io/kubelb/internal/resources/ingress"
-	serviceHelpers "k8c.io/kubelb/internal/resources/service"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/yaml"
 )
@@ -54,6 +43,7 @@ import (
 const (
 	IngressControllerName = "ingress-controller"
 	IngressClassName      = "kubelb"
+	IngressGVK            = "Ingress.networking.k8s.io"
 )
 
 // IngressReconciler reconciles an Ingress Object
@@ -67,6 +57,8 @@ type IngressReconciler struct {
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
+
+	loop *SourceReconciler[*networkingv1.Ingress]
 }
 
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch
@@ -77,240 +69,69 @@ type IngressReconciler struct {
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=get;update;patch
 
 func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("name", req.NamespacedName)
-	startTime := time.Now()
-
-	// Track reconciliation duration
-	defer func() {
-		ccmmetrics.IngressReconcileDuration.WithLabelValues(req.Namespace).Observe(time.Since(startTime).Seconds())
-	}()
-
-	log.Info("Reconciling Ingress")
-
-	resource := &networkingv1.Ingress{}
-	if err := r.Get(ctx, req.NamespacedName, resource); err != nil {
-		if kerrors.IsNotFound(err) {
-			return reconcile.Result{}, nil
-		}
-		ccmmetrics.IngressReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-		return reconcile.Result{}, err
-	}
-
-	// Resource is marked for deletion
-	if resource.DeletionTimestamp != nil {
-		if controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
-			return r.cleanup(ctx, resource)
-		}
-		// Finalizer doesn't exist so clean up is already done
-		return reconcile.Result{}, nil
-	}
-
-	if !r.shouldReconcile(resource) {
-		ccmmetrics.IngressReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSkipped).Inc()
-		return reconcile.Result{}, nil
-	}
-
-	// Add finalizer if it doesn't exist
-	if !controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
-		if ok := controllerutil.AddFinalizer(resource, CleanupFinalizer); !ok {
-			log.Error(nil, "Failed to add finalizer for the Ingress")
-			return ctrl.Result{Requeue: true}, nil
-		}
-
-		if err := r.Update(ctx, resource); err != nil {
-			ccmmetrics.IngressReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
-		}
-	}
-
-	err := r.reconcile(ctx, log, resource)
-	if err != nil {
-		log.Error(err, "reconciling failed")
-		ccmmetrics.IngressReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-		return reconcile.Result{}, err
-	}
-
-	// Update managed ingresses gauge
-	ingressList := &networkingv1.IngressList{}
-	if err := r.List(ctx, ingressList, ctrlclient.InNamespace(req.Namespace)); err == nil {
-		count := 0
-		for _, ing := range ingressList.Items {
-			if r.shouldReconcile(&ing) && ing.DeletionTimestamp == nil {
-				count++
-			}
-		}
-		ccmmetrics.ManagedIngressesTotal.WithLabelValues(req.Namespace).Set(float64(count))
-	}
-
-	ccmmetrics.IngressReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSuccess).Inc()
-	return reconcile.Result{}, nil
+	return r.loop.Reconcile(ctx, req)
 }
 
-func (r *IngressReconciler) reconcile(ctx context.Context, log logr.Logger, ingress *networkingv1.Ingress) error {
-	// We need to traverse the Ingress, find all the services associated with it, create/update the corresponding Route in LB cluster.
-	originalServices := ingressHelpers.GetServicesFromIngress(*ingress)
-	err := reconcileSourceForRoute(ctx, log, r.Client, r.LBManager.GetClient(), ingress, originalServices, nil, r.ClusterName)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile source for route: %w", err)
+func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.loop = &SourceReconciler[*networkingv1.Ingress]{
+		Client:      r.Client,
+		LBClient:    r.LBManager.GetClient(),
+		ClusterName: r.ClusterName,
+		Log:         r.Log,
+		Adapter:     &ingressAdapter{useClass: r.UseIngressClass},
 	}
-
-	// Route was reconciled successfully, now we need to update the status of the Ingress.
-	route := kubelbv1alpha1.Route{}
-	err = r.LBManager.GetClient().Get(ctx, types.NamespacedName{Name: string(ingress.UID), Namespace: r.ClusterName}, &route)
-	if err != nil {
-		return fmt.Errorf("failed to get Route from LB cluster: %w", err)
-	}
-
-	// Update the status of the Ingress
-	if len(route.Status.Resources.Route.GeneratedName) > 0 {
-		// First we need to ensure that status is available in the Route
-		resourceStatus := route.Status.Resources.Route.Status
-		jsonData, err := json.Marshal(resourceStatus.Raw)
-		if err != nil || string(jsonData) == kubelb.DefaultRouteStatus {
-			// Status is not available in the Route, so we need to wait for it
-			return nil
-		}
-
-		// Convert rawExtension to networkingv1.IngressStatus
-		status := networkingv1.IngressStatus{}
-		if err := yaml.UnmarshalStrict(resourceStatus.Raw, &status); err != nil {
-			return fmt.Errorf("failed to unmarshal Ingress status: %w", err)
-		}
-
-		log.V(3).Info("updating Ingress status", "name", ingress.Name, "namespace", ingress.Namespace)
-		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := r.Get(ctx, types.NamespacedName{Name: ingress.Name, Namespace: ingress.Namespace}, ingress); err != nil {
-				return err
-			}
-			original := ingress.DeepCopy()
-			ingress.Status = status
-			if reflect.DeepEqual(original.Status, ingress.Status) {
-				return nil
-			}
-			// update the status
-			return r.Status().Patch(ctx, ingress, ctrlclient.MergeFrom(original))
-		})
-	}
-	return nil
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(IngressControllerName).
+		For(&networkingv1.Ingress{}, builder.WithPredicates(r.loop.Predicate())).
+		Watches(
+			&corev1.Service{},
+			handler.EnqueueRequestsFromMapFunc(r.loop.EnqueueForService()),
+		).
+		WatchesRawSource(
+			source.Kind(r.LBManager.GetCache(), &kubelbv1alpha1.Route{},
+				handler.TypedEnqueueRequestsFromMapFunc[*kubelbv1alpha1.Route](enqueueRoutes(IngressGVK, r.ClusterName))),
+		).
+		Complete(r)
 }
 
-func (r *IngressReconciler) cleanup(ctx context.Context, ingress *networkingv1.Ingress) (ctrl.Result, error) {
-	impactedServices := ingressHelpers.GetServicesFromIngress(*ingress)
-	services := corev1.ServiceList{}
-	err := r.List(ctx, &services, ctrlclient.InNamespace(ingress.Namespace), ctrlclient.MatchingLabels{kubelb.LabelManagedBy: kubelb.LabelControllerName})
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list services: %w", err)
-	}
-
-	// Delete services created by the controller.
-	for _, service := range services.Items {
-		originalName := service.Name
-		if service.Labels[kubelb.LabelOriginName] != "" {
-			originalName = service.Labels[kubelb.LabelOriginName]
-		}
-
-		for _, serviceRef := range impactedServices {
-			if serviceRef.Name == originalName && serviceRef.Namespace == service.Namespace {
-				err := r.Delete(ctx, &service)
-				if err != nil {
-					return reconcile.Result{}, fmt.Errorf("failed to delete service: %w", err)
-				}
-			}
-		}
-	}
-
-	// Find the Route in LB cluster and delete it
-	err = cleanupRoute(ctx, r.LBManager.GetClient(), string(ingress.UID), r.ClusterName)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to cleanup route: %w", err)
-	}
-
-	controllerutil.RemoveFinalizer(ingress, CleanupFinalizer)
-	if err := r.Update(ctx, ingress); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
-	}
-
-	return reconcile.Result{}, nil
+type ingressAdapter struct {
+	useClass bool
 }
 
-// enqueueResources is a handler.MapFunc to be used to enqueue requests for reconciliation
-// for Ingresses against the corresponding service.
-func (r *IngressReconciler) enqueueResources() handler.MapFunc {
-	return func(_ context.Context, o ctrlclient.Object) []ctrl.Request {
-		result := []reconcile.Request{}
-		ingressList := &networkingv1.IngressList{}
-		if err := r.List(context.Background(), ingressList, ctrlclient.InNamespace(o.GetNamespace())); err != nil {
-			return nil
-		}
+var _ SourceAdapter[*networkingv1.Ingress] = (*ingressAdapter)(nil)
 
-		for _, ingress := range ingressList.Items {
-			if !r.shouldReconcile(&ingress) {
-				continue
-			}
+func (a *ingressAdapter) Kind() string                     { return "Ingress" }
+func (a *ingressAdapter) GVK() string                      { return IngressGVK }
+func (a *ingressAdapter) NewObject() *networkingv1.Ingress { return &networkingv1.Ingress{} }
+func (a *ingressAdapter) NewList() ctrlclient.ObjectList   { return &networkingv1.IngressList{} }
 
-			services := ingressHelpers.GetServicesFromIngress(ingress)
-			for _, serviceRef := range services {
-				if (serviceRef.Name == o.GetName() || fmt.Sprintf(serviceHelpers.NodePortServicePattern, serviceRef.Name) == o.GetName()) && serviceRef.Namespace == o.GetNamespace() {
-					result = append(result, reconcile.Request{
-						NamespacedName: types.NamespacedName{
-							Name:      ingress.Name,
-							Namespace: ingress.Namespace,
-						},
-					})
-				}
-			}
-		}
-		return result
+func (a *ingressAdapter) Metrics() SourceMetrics {
+	return SourceMetrics{
+		ReconcileTotal:    ccmmetrics.IngressReconcileTotal,
+		ReconcileDuration: ccmmetrics.IngressReconcileDuration,
+		Managed:           ccmmetrics.ManagedIngressesTotal,
 	}
 }
 
-func (r *IngressReconciler) resourceFilter() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			if obj, ok := e.Object.(*networkingv1.Ingress); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if obj, ok := e.ObjectNew.(*networkingv1.Ingress); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if obj, ok := e.Object.(*networkingv1.Ingress); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			if obj, ok := e.Object.(*networkingv1.Ingress); ok {
-				return r.shouldReconcile(obj)
-			}
-			return false
-		},
-	}
-}
-
-func (r *IngressReconciler) shouldReconcile(ingress *networkingv1.Ingress) bool {
-	if r.UseIngressClass {
+func (a *ingressAdapter) ShouldReconcile(ingress *networkingv1.Ingress) bool {
+	if a.useClass {
 		return ingress.Spec.IngressClassName != nil && *ingress.Spec.IngressClassName == IngressClassName
 	}
 	return true
 }
 
-func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		Named(IngressControllerName).
-		For(&networkingv1.Ingress{}, builder.WithPredicates(r.resourceFilter())).
-		Watches(
-			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(r.enqueueResources()),
-		).
-		WatchesRawSource(
-			source.Kind(r.LBManager.GetCache(), &kubelbv1alpha1.Route{},
-				handler.TypedEnqueueRequestsFromMapFunc[*kubelbv1alpha1.Route](enqueueRoutes("Ingress.networking.k8s.io", r.ClusterName))),
-		).
-		Complete(r)
+func (a *ingressAdapter) ExtractServices(ingress *networkingv1.Ingress) []types.NamespacedName {
+	return ingressHelpers.GetServicesFromIngress(*ingress)
+}
+
+func (a *ingressAdapter) ApplyRouteStatus(ingress *networkingv1.Ingress, raw []byte) (bool, error) {
+	status := networkingv1.IngressStatus{}
+	if err := yaml.UnmarshalStrict(raw, &status); err != nil {
+		return false, fmt.Errorf("failed to unmarshal Ingress status: %w", err)
+	}
+	if reflect.DeepEqual(ingress.Status, status) {
+		return false, nil
+	}
+	ingress.Status = status
+	return true, nil
 }

--- a/internal/controllers/ccm/shared.go
+++ b/internal/controllers/ccm/shared.go
@@ -33,14 +33,13 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	gwapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 const (
 	CleanupFinalizer = "kubelb.k8c.io/cleanup"
 )
 
-func reconcileSourceForRoute(ctx context.Context, log logr.Logger, client ctrlclient.Client, lbClient ctrlclient.Client, resource ctrlclient.Object, originalServices []types.NamespacedName, referenceGrants []gwapiv1alpha2.ReferenceGrant, namespace string) error {
+func reconcileSourceForRoute(ctx context.Context, log logr.Logger, client ctrlclient.Client, lbClient ctrlclient.Client, resource ctrlclient.Object, originalServices []types.NamespacedName, namespace string) error {
 	log.V(2).Info("reconciling source for producing route")
 
 	unstructuredResource, err := unstructured.ConvertObjectToUnstructured(resource)
@@ -55,8 +54,7 @@ func reconcileSourceForRoute(ctx context.Context, log logr.Logger, client ctrlcl
 	}
 
 	routeSubresources := route.Subresources{
-		Services:        services,
-		ReferenceGrants: referenceGrants,
+		Services: services,
 	}
 
 	err = route.CreateRouteForResource(ctx, log, lbClient, *unstructuredResource, routeSubresources, namespace)

--- a/internal/controllers/ccm/source_reconciler.go
+++ b/internal/controllers/ccm/source_reconciler.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ccm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
+	"k8c.io/kubelb/internal/metricsutil"
+	serviceHelpers "k8c.io/kubelb/internal/resources/service"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type SourceMetrics struct {
+	ReconcileTotal    *prometheus.CounterVec
+	ReconcileDuration *prometheus.HistogramVec
+	Managed           *prometheus.GaugeVec
+}
+
+// SourceAdapter encapsulates the per-Source-kind variation in the
+// Source-to-Route reconcile loop. One adapter per Source kind.
+type SourceAdapter[T ctrlclient.Object] interface {
+	Kind() string
+	// GVK is the "Kind.group" string the LB-cluster Route carries in its
+	// kubelb.LabelOriginResourceKind label; used by enqueueRoutes.
+	GVK() string
+	NewObject() T
+	NewList() ctrlclient.ObjectList
+	ShouldReconcile(T) bool
+	ExtractServices(T) []types.NamespacedName
+	// ApplyRouteStatus mutates src in-place with the Route's projected
+	// status and reports whether the result differs from src's existing
+	// status. The loop owns the GET-mutate-PATCH retry.
+	ApplyRouteStatus(src T, raw []byte) (changed bool, err error)
+	Metrics() SourceMetrics
+}
+
+type SourceReconciler[T ctrlclient.Object] struct {
+	Client      ctrlclient.Client
+	LBClient    ctrlclient.Client
+	ClusterName string
+	Log         logr.Logger
+	Adapter     SourceAdapter[T]
+}
+
+func (r *SourceReconciler[T]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("name", req.NamespacedName)
+	startTime := time.Now()
+	m := r.Adapter.Metrics()
+
+	defer func() {
+		m.ReconcileDuration.WithLabelValues(req.Namespace).Observe(time.Since(startTime).Seconds())
+	}()
+
+	log.Info("Reconciling " + r.Adapter.Kind())
+
+	resource := r.Adapter.NewObject()
+	if err := r.Client.Get(ctx, req.NamespacedName, resource); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+		return reconcile.Result{}, err
+	}
+
+	if resource.GetDeletionTimestamp() != nil {
+		if controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
+			return r.cleanup(ctx, resource)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	if !r.Adapter.ShouldReconcile(resource) {
+		m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSkipped).Inc()
+		return reconcile.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
+		controllerutil.AddFinalizer(resource, CleanupFinalizer)
+		if err := r.Client.Update(ctx, resource); err != nil {
+			m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+	}
+
+	if err := r.reconcile(ctx, log, resource); err != nil {
+		log.Error(err, "reconciling failed")
+		m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+		return reconcile.Result{}, err
+	}
+
+	if count, err := r.countManaged(ctx, req.Namespace); err == nil {
+		m.Managed.WithLabelValues(req.Namespace).Set(float64(count))
+	}
+
+	m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSuccess).Inc()
+	return reconcile.Result{}, nil
+}
+
+func (r *SourceReconciler[T]) reconcile(ctx context.Context, log logr.Logger, resource T) error {
+	originalServices := r.Adapter.ExtractServices(resource)
+	if err := reconcileSourceForRoute(ctx, log, r.Client, r.LBClient, resource, originalServices, r.ClusterName); err != nil {
+		return fmt.Errorf("failed to reconcile source for route: %w", err)
+	}
+
+	route := kubelbv1alpha1.Route{}
+	if err := r.LBClient.Get(ctx, types.NamespacedName{Name: string(resource.GetUID()), Namespace: r.ClusterName}, &route); err != nil {
+		return fmt.Errorf("failed to get Route from LB cluster: %w", err)
+	}
+
+	if len(route.Status.Resources.Route.GeneratedName) == 0 {
+		return nil
+	}
+
+	resourceStatus := route.Status.Resources.Route.Status
+	jsonData, err := json.Marshal(resourceStatus.Raw)
+	if err != nil || string(jsonData) == kubelb.DefaultRouteStatus {
+		return nil
+	}
+
+	log.V(3).Info("updating "+r.Adapter.Kind()+" status", "name", resource.GetName(), "namespace", resource.GetNamespace())
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := r.Client.Get(ctx, ctrlclient.ObjectKeyFromObject(resource), resource); err != nil {
+			return err
+		}
+		original, ok := resource.DeepCopyObject().(ctrlclient.Object)
+		if !ok {
+			return fmt.Errorf("failed to deep copy %s as ctrlclient.Object", r.Adapter.Kind())
+		}
+		changed, err := r.Adapter.ApplyRouteStatus(resource, resourceStatus.Raw)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			return nil
+		}
+		return r.Client.Status().Patch(ctx, resource, ctrlclient.MergeFrom(original))
+	})
+}
+
+func (r *SourceReconciler[T]) cleanup(ctx context.Context, resource T) (ctrl.Result, error) {
+	impactedServices := r.Adapter.ExtractServices(resource)
+	services := corev1.ServiceList{}
+	if err := r.Client.List(ctx, &services, ctrlclient.InNamespace(resource.GetNamespace()), ctrlclient.MatchingLabels{kubelb.LabelManagedBy: kubelb.LabelControllerName}); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list services: %w", err)
+	}
+
+	for _, service := range services.Items {
+		originalName := service.Name
+		if service.Labels[kubelb.LabelOriginName] != "" {
+			originalName = service.Labels[kubelb.LabelOriginName]
+		}
+		for _, serviceRef := range impactedServices {
+			if serviceRef.Name == originalName && serviceRef.Namespace == service.Namespace {
+				if err := r.Client.Delete(ctx, &service); err != nil {
+					return reconcile.Result{}, fmt.Errorf("failed to delete service: %w", err)
+				}
+			}
+		}
+	}
+
+	if err := cleanupRoute(ctx, r.LBClient, string(resource.GetUID()), r.ClusterName); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to cleanup route: %w", err)
+	}
+
+	controllerutil.RemoveFinalizer(resource, CleanupFinalizer)
+	if err := r.Client.Update(ctx, resource); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *SourceReconciler[T]) countManaged(ctx context.Context, namespace string) (int, error) {
+	list := r.Adapter.NewList()
+	if err := r.Client.List(ctx, list, ctrlclient.InNamespace(namespace)); err != nil {
+		return 0, err
+	}
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, item := range items {
+		obj, ok := item.(T)
+		if !ok {
+			continue
+		}
+		if r.Adapter.ShouldReconcile(obj) && obj.GetDeletionTimestamp() == nil {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (r *SourceReconciler[T]) Predicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(o ctrlclient.Object) bool {
+		obj, ok := o.(T)
+		if !ok {
+			return false
+		}
+		return r.Adapter.ShouldReconcile(obj)
+	})
+}
+
+func (r *SourceReconciler[T]) EnqueueForService() handler.MapFunc {
+	return func(ctx context.Context, o ctrlclient.Object) []ctrl.Request {
+		list := r.Adapter.NewList()
+		if err := r.Client.List(ctx, list, ctrlclient.InNamespace(o.GetNamespace())); err != nil {
+			return nil
+		}
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			return nil
+		}
+		result := []reconcile.Request{}
+		for _, item := range items {
+			obj, ok := item.(T)
+			if !ok {
+				continue
+			}
+			if !r.Adapter.ShouldReconcile(obj) {
+				continue
+			}
+			for _, serviceRef := range r.Adapter.ExtractServices(obj) {
+				if serviceRef.Namespace != o.GetNamespace() {
+					continue
+				}
+				if serviceRef.Name != o.GetName() && fmt.Sprintf(serviceHelpers.NodePortServicePattern, serviceRef.Name) != o.GetName() {
+					continue
+				}
+				result = append(result, reconcile.Request{NamespacedName: types.NamespacedName{
+					Name:      obj.GetName(),
+					Namespace: obj.GetNamespace(),
+				}})
+				break
+			}
+		}
+		return result
+	}
+}

--- a/internal/controllers/ccm/source_reconciler_test.go
+++ b/internal/controllers/ccm/source_reconciler_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ccm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	testNS      = "tenant-ns"
+	testCluster = "tenant1"
+	testIngName = "demo"
+	testIngUID  = "ing-uid-1"
+	testSvcName = "backend"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("corev1 scheme: %v", err)
+	}
+	if err := networkingv1.AddToScheme(s); err != nil {
+		t.Fatalf("networkingv1 scheme: %v", err)
+	}
+	if err := kubelbv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("kubelb scheme: %v", err)
+	}
+	return s
+}
+
+func newIngress(opts ...func(*networkingv1.Ingress)) *networkingv1.Ingress {
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testIngName,
+			Namespace: testNS,
+			UID:       testIngUID,
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{Name: testSvcName},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+	for _, o := range opts {
+		o(ing)
+	}
+	return ing
+}
+
+func newLoop(t *testing.T, src ctrlclient.Client, lb ctrlclient.Client) *SourceReconciler[*networkingv1.Ingress] {
+	t.Helper()
+	return &SourceReconciler[*networkingv1.Ingress]{
+		Client:      src,
+		LBClient:    lb,
+		ClusterName: testCluster,
+		Log:         logr.Discard(),
+		Adapter:     &ingressAdapter{useClass: false},
+	}
+}
+
+func req() ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Name: testIngName, Namespace: testNS}}
+}
+
+func TestSourceReconciler_NotFound(t *testing.T) {
+	s := newScheme(t)
+	src := fake.NewClientBuilder().WithScheme(s).Build()
+	lb := fake.NewClientBuilder().WithScheme(s).Build()
+	loop := newLoop(t, src, lb)
+
+	got, err := loop.Reconcile(context.Background(), req())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got.RequeueAfter != 0 {
+		t.Fatalf("expected empty result, got %+v", got)
+	}
+}
+
+func TestSourceReconciler_DeletionWithoutFinalizer(t *testing.T) {
+	s := newScheme(t)
+	now := metav1.Now()
+	ing := newIngress(func(i *networkingv1.Ingress) {
+		i.DeletionTimestamp = &now
+		// Unrelated finalizer; the fake client GCs objects once the last finalizer is removed.
+		i.Finalizers = []string{"keep-alive"}
+	})
+	src := fake.NewClientBuilder().WithScheme(s).WithObjects(ing).Build()
+	lb := fake.NewClientBuilder().WithScheme(s).Build()
+	loop := newLoop(t, src, lb)
+
+	if _, err := loop.Reconcile(context.Background(), req()); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	route := &kubelbv1alpha1.Route{}
+	err := lb.Get(context.Background(), types.NamespacedName{Name: testIngUID, Namespace: testCluster}, route)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected Route to be absent, got err=%v", err)
+	}
+}
+
+func TestSourceReconciler_DeletionWithFinalizer_CleansUp(t *testing.T) {
+	s := newScheme(t)
+	now := metav1.Now()
+	ing := newIngress(func(i *networkingv1.Ingress) {
+		i.DeletionTimestamp = &now
+		i.Finalizers = []string{CleanupFinalizer}
+	})
+	managedSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSvcName,
+			Namespace: testNS,
+			Labels: map[string]string{
+				kubelb.LabelManagedBy: kubelb.LabelControllerName,
+			},
+		},
+	}
+	route := &kubelbv1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{Name: testIngUID, Namespace: testCluster},
+	}
+	src := fake.NewClientBuilder().WithScheme(s).WithObjects(ing, managedSvc).Build()
+	lb := fake.NewClientBuilder().WithScheme(s).WithObjects(route).Build()
+	loop := newLoop(t, src, lb)
+
+	if _, err := loop.Reconcile(context.Background(), req()); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	gotSvc := &corev1.Service{}
+	if err := src.Get(context.Background(), types.NamespacedName{Name: testSvcName, Namespace: testNS}, gotSvc); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected managed service deleted, got err=%v", err)
+	}
+
+	gotRoute := &kubelbv1alpha1.Route{}
+	if err := lb.Get(context.Background(), types.NamespacedName{Name: testIngUID, Namespace: testCluster}, gotRoute); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected route deleted, got err=%v", err)
+	}
+
+	// After finalizer removal the fake client may GC the object; either NotFound or
+	// a present object without the cleanup finalizer is acceptable.
+	gotIng := &networkingv1.Ingress{}
+	err := src.Get(context.Background(), types.NamespacedName{Name: testIngName, Namespace: testNS}, gotIng)
+	if err == nil {
+		if controllerutil.ContainsFinalizer(gotIng, CleanupFinalizer) {
+			t.Fatalf("finalizer not removed: %+v", gotIng.Finalizers)
+		}
+	} else if !apierrors.IsNotFound(err) {
+		t.Fatalf("unexpected err fetching ingress: %v", err)
+	}
+}
+
+func TestSourceReconciler_OutOfScope_Skipped(t *testing.T) {
+	s := newScheme(t)
+	cls := "other"
+	ing := newIngress(func(i *networkingv1.Ingress) {
+		i.Spec.IngressClassName = &cls
+	})
+	src := fake.NewClientBuilder().WithScheme(s).WithObjects(ing).Build()
+	lb := fake.NewClientBuilder().WithScheme(s).Build()
+	loop := newLoop(t, src, lb)
+	loop.Adapter = &ingressAdapter{useClass: true}
+
+	if _, err := loop.Reconcile(context.Background(), req()); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := lb.Get(context.Background(), types.NamespacedName{Name: testIngUID, Namespace: testCluster}, &kubelbv1alpha1.Route{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected no route, got err=%v", err)
+	}
+}
+
+func TestSourceReconciler_FinalizerAdded_OnFirstPass(t *testing.T) {
+	s := newScheme(t)
+	ing := newIngress()
+	src := fake.NewClientBuilder().WithScheme(s).WithObjects(ing).Build()
+	lb := fake.NewClientBuilder().WithScheme(s).Build()
+	loop := newLoop(t, src, lb)
+
+	// Finalizer must be persisted before any downstream Route work runs;
+	// downstream may fail because the LB cluster has no Route yet, so the
+	// returned error is intentionally not asserted on.
+	_, _ = loop.Reconcile(context.Background(), req())
+
+	got := &networkingv1.Ingress{}
+	if err := src.Get(context.Background(), types.NamespacedName{Name: testIngName, Namespace: testNS}, got); err != nil {
+		t.Fatalf("get ingress: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, CleanupFinalizer) {
+		t.Fatalf("expected finalizer %q, got %+v", CleanupFinalizer, got.Finalizers)
+	}
+}
+
+func TestIngressAdapter_ApplyRouteStatus(t *testing.T) {
+	a := &ingressAdapter{}
+	ing := newIngress()
+
+	raw := []byte(`{"loadBalancer":{"ingress":[{"ip":"1.2.3.4"}]}}`)
+	changed, err := a.ApplyRouteStatus(ing, raw)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true on first apply")
+	}
+	if len(ing.Status.LoadBalancer.Ingress) != 1 || ing.Status.LoadBalancer.Ingress[0].IP != "1.2.3.4" {
+		t.Fatalf("unexpected status: %+v", ing.Status)
+	}
+
+	changed, err = a.ApplyRouteStatus(ing, raw)
+	if err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected changed=false on identical apply")
+	}
+}
+
+func TestIngressAdapter_ApplyRouteStatus_BadJSON(t *testing.T) {
+	a := &ingressAdapter{}
+	ing := newIngress()
+	if _, err := a.ApplyRouteStatus(ing, []byte("not-json")); err == nil {
+		t.Fatalf("expected error for bad raw bytes")
+	}
+}

--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -55,6 +55,9 @@ import (
 const (
 	RequeueAllResources   = "requeue-all-for-route"
 	EnvoyCPControllerName = "envoy-cp-controller"
+
+	envoyProxyAppName      = "kubelb-envoy-proxy"
+	envoyProxyManagedByVal = "kubelb"
 )
 
 type EnvoyCPReconciler struct {
@@ -272,9 +275,9 @@ func (r *EnvoyCPReconciler) ensureEnvoyProxy(ctx context.Context, namespace, app
 		Name:      fmt.Sprintf(envoyResourcePattern, appName),
 		Namespace: namespace,
 		Labels: map[string]string{
-			kubelb.LabelAppKubernetesName:      "kubelb-envoy-proxy",
+			kubelb.LabelAppKubernetesName:      envoyProxyAppName,
 			kubelb.LabelAppKubernetesInstance:  appName,
-			kubelb.LabelAppKubernetesManagedBy: "kubelb",
+			kubelb.LabelAppKubernetesManagedBy: envoyProxyManagedByVal,
 		},
 	}
 	if r.Config.Spec.EnvoyProxy.UseDaemonset {

--- a/internal/controllers/kubelb/resources/tenant/rbac.go
+++ b/internal/controllers/kubelb/resources/tenant/rbac.go
@@ -27,6 +27,9 @@ const (
 	serviceAccountName = "kubelb-ccm"
 	roleName           = "kubelb-ccm"
 	roleBindingName    = "kubelb-ccm"
+
+	apiGroupKubeLB = "kubelb.k8c.io"
+	verbGet        = "get"
 )
 
 func ServiceAccountReconciler() reconciling.NamedServiceAccountReconcilerFactory {
@@ -42,12 +45,12 @@ func RoleReconciler() reconciling.NamedRoleReconcilerFactory {
 		return roleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Rules = []rbacv1.PolicyRule{
 				{
-					APIGroups: []string{"kubelb.k8c.io"},
+					APIGroups: []string{apiGroupKubeLB},
 					Resources: []string{"loadbalancers", "routes", "addresses", "syncsecrets"},
 					Verbs: []string{
 						"create",
 						"update",
-						"get",
+						verbGet,
 						"list",
 						"delete",
 						"patch",
@@ -55,27 +58,27 @@ func RoleReconciler() reconciling.NamedRoleReconcilerFactory {
 					},
 				},
 				{
-					APIGroups: []string{"kubelb.k8c.io"},
+					APIGroups: []string{apiGroupKubeLB},
 					Resources: []string{"tenantstates"},
 					Verbs: []string{
-						"get",
+						verbGet,
 						"list",
 						"watch",
 					},
 				},
 				{
-					APIGroups: []string{"kubelb.k8c.io"},
+					APIGroups: []string{apiGroupKubeLB},
 					Resources: []string{"tenantstates/status"},
 					Verbs: []string{
-						"get",
+						verbGet,
 					},
 				},
 				{
-					APIGroups: []string{"kubelb.k8c.io"},
+					APIGroups: []string{apiGroupKubeLB},
 					Resources: []string{"loadbalancers/status", "routes/status", "addresses/status", "syncsecrets/status"},
 					Verbs: []string{
 						"update",
-						"get",
+						verbGet,
 						"patch",
 					},
 				},

--- a/internal/controllers/kubelb/route_controller.go
+++ b/internal/controllers/kubelb/route_controller.go
@@ -60,6 +60,10 @@ import (
 const (
 	RouteControllerName = "route-controller"
 	CleanupFinalizer    = "kubelb.k8c.io/cleanup"
+
+	conditionMessageSuccess   = "Success"
+	conditionReasonSuccessful = "InstallationSuccessful"
+	conditionReasonFailed     = "InstallationFailed"
 )
 
 // RouteReconciler reconciles a Route Object
@@ -645,13 +649,13 @@ func getResourceStatus(v any) runtime.RawExtension {
 }
 
 func setCondition(conditions *[]metav1.Condition, err error) {
-	conditionMessage := "Success"
+	conditionMessage := conditionMessageSuccess
 	conditionStatus := metav1.ConditionTrue
-	conditionReason := "InstallationSuccessful"
+	conditionReason := conditionReasonSuccessful
 	if err != nil {
 		conditionMessage = err.Error()
 		conditionStatus = metav1.ConditionFalse
-		conditionReason = "InstallationFailed"
+		conditionReason = conditionReasonFailed
 	}
 	apimeta.SetStatusCondition(conditions, metav1.Condition{
 		Type:    kubelbv1alpha1.ConditionResourceAppliedSuccessfully.String(),

--- a/internal/controllers/kubelb/tenant_controller.go
+++ b/internal/controllers/kubelb/tenant_controller.go
@@ -446,14 +446,14 @@ func (r *TenantReconciler) reconcilePodMonitor(ctx context.Context, namespace st
 				"name":      podMonitorName,
 				"namespace": namespace,
 				"labels": map[string]interface{}{
-					kubelb.LabelAppKubernetesName:      "kubelb-envoy-proxy",
-					kubelb.LabelAppKubernetesManagedBy: "kubelb",
+					kubelb.LabelAppKubernetesName:      envoyProxyAppName,
+					kubelb.LabelAppKubernetesManagedBy: envoyProxyManagedByVal,
 				},
 			},
 			"spec": map[string]interface{}{
 				"selector": map[string]interface{}{
 					"matchLabels": map[string]interface{}{
-						kubelb.LabelAppKubernetesName: "kubelb-envoy-proxy",
+						kubelb.LabelAppKubernetesName: envoyProxyAppName,
 					},
 				},
 				"podMetricsEndpoints": []interface{}{

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -44,6 +44,10 @@ const xdsClusterName = "xds_cluster"
 const controlPlaneAddress = "envoycp.kubelb.svc"
 const adminClusterName = "admin_cluster"
 
+// wildcardBindAddress is the IPv4 any-address used by Envoy listeners that
+// should accept traffic from any interface inside the pod.
+const wildcardBindAddress = "0.0.0.0"
+
 const EnvoyAdminPort = 9001
 
 const EnvoyStatsPort = 19001
@@ -84,7 +88,7 @@ var EnvoyAdminListenerAddress = "127.0.0.1"
 func (s *Server) GenerateBootstrap() string {
 	// If debug is enabled, allow external access to the admin interface
 	if s.enableAdmin {
-		EnvoyAdminListenerAddress = "0.0.0.0"
+		EnvoyAdminListenerAddress = wildcardBindAddress
 	}
 
 	http2ProtocolOptions := marshalAny(&envoyExtensionsUpstreamsHttpV3.HttpProtocolOptions{
@@ -308,7 +312,7 @@ func getReadinessProbeListener() *envoyListener.Listener {
 		Address: &envoyCore.Address{
 			Address: &envoyCore.Address_SocketAddress{
 				SocketAddress: &envoyCore.SocketAddress{
-					Address: "0.0.0.0",
+					Address: wildcardBindAddress,
 					PortSpecifier: &envoyCore.SocketAddress_PortValue{
 						PortValue: EnvoyReadinessPort,
 					},
@@ -378,7 +382,7 @@ func getHealthCheckListener() *envoyListener.Listener {
 		Address: &envoyCore.Address{
 			Address: &envoyCore.Address_SocketAddress{
 				SocketAddress: &envoyCore.SocketAddress{
-					Address: "0.0.0.0",
+					Address: wildcardBindAddress,
 					PortSpecifier: &envoyCore.SocketAddress_PortValue{
 						PortValue: EnvoyHealthCheckPort,
 					},
@@ -441,7 +445,7 @@ func getStatsListener() *envoyListener.Listener {
 		Address: &envoyCore.Address{
 			Address: &envoyCore.Address_SocketAddress{
 				SocketAddress: &envoyCore.SocketAddress{
-					Address: "0.0.0.0",
+					Address: wildcardBindAddress,
 					PortSpecifier: &envoyCore.SocketAddress_PortValue{
 						PortValue: EnvoyStatsPort,
 					},

--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -59,6 +59,11 @@ import (
 )
 
 const (
+	// nginx ingress backend-protocol annotation values that signal a TLS
+	// upstream — see isTLSBackend.
+	backendProtocolHTTPS = "HTTPS"
+	backendProtocolGRPCS = "GRPCS"
+
 	endpointAddressReferencePattern = "%s-address-%s"
 
 	// Health check configuration constants
@@ -448,7 +453,7 @@ func makeTCPListener(clusterName string, listenerName string, listenerPort uint3
 			Address: &envoyCore.Address_SocketAddress{
 				SocketAddress: &envoyCore.SocketAddress{
 					Protocol: envoyCore.SocketAddress_TCP,
-					Address:  "0.0.0.0",
+					Address:  wildcardBindAddress,
 					PortSpecifier: &envoyCore.SocketAddress_PortValue{
 						PortValue: listenerPort,
 					},
@@ -500,7 +505,7 @@ func makeUDPListener(clusterName string, listenerName string, listenerPort uint3
 			Address: &envoyCore.Address_SocketAddress{
 				SocketAddress: &envoyCore.SocketAddress{
 					Protocol: envoyCore.SocketAddress_UDP,
-					Address:  "0.0.0.0",
+					Address:  wildcardBindAddress,
 					PortSpecifier: &envoyCore.SocketAddress_PortValue{
 						PortValue: listenerPort,
 					},
@@ -618,7 +623,7 @@ func makeHTTPListener(listenerName string, clusterName string, listenerPort uint
 			Address: &envoyCore.Address_SocketAddress{
 				SocketAddress: &envoyCore.SocketAddress{
 					Protocol: envoyCore.SocketAddress_TCP,
-					Address:  "0.0.0.0",
+					Address:  wildcardBindAddress,
 					PortSpecifier: &envoyCore.SocketAddress_PortValue{
 						PortValue: listenerPort,
 					},
@@ -760,7 +765,7 @@ func isTLSBackend(route *kubelbv1alpha1.Route) bool {
 	}
 	annotations := route.Spec.Source.Kubernetes.Route.GetAnnotations()
 	switch strings.ToUpper(annotations["nginx.ingress.kubernetes.io/backend-protocol"]) {
-	case "HTTPS", "GRPCS":
+	case backendProtocolHTTPS, backendProtocolGRPCS:
 		return true
 	}
 	return strings.EqualFold(annotations["nginx.ingress.kubernetes.io/ssl-passthrough"], "true")

--- a/internal/ingress-to-gateway/controller.go
+++ b/internal/ingress-to-gateway/controller.go
@@ -229,7 +229,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, ingress *ne
 		acceptance := r.waitForRouteAcceptance(ctx, httpRoute.Name, httpRoute.Namespace)
 		routeAcceptance[httpRoute.Name] = acceptance.accepted
 		if !acceptance.accepted {
-			if acceptance.reason == "Timeout" {
+			if acceptance.reason == routeAcceptanceReasonTimeout {
 				hasTimeout = true
 				log.V(1).Info("HTTPRoute acceptance timed out", "name", httpRoute.Name)
 			} else {
@@ -244,7 +244,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, ingress *ne
 		acceptance := r.waitForGRPCRouteAcceptance(ctx, grpcRoute.Name, grpcRoute.Namespace)
 		routeAcceptance[grpcRoute.Name] = acceptance.accepted
 		if !acceptance.accepted {
-			if acceptance.reason == "Timeout" {
+			if acceptance.reason == routeAcceptanceReasonTimeout {
 				hasTimeout = true
 				log.V(1).Info("GRPCRoute acceptance timed out", "name", grpcRoute.Name)
 			} else {
@@ -737,6 +737,10 @@ func secretDataEqual(a, b map[string][]byte) bool {
 	return true
 }
 
+// routeAcceptanceReasonTimeout marks an acceptance check that exhausted its
+// polling budget before the Gateway reported a terminal Accepted condition.
+const routeAcceptanceReasonTimeout = "Timeout"
+
 // routeAcceptanceResult holds result of checking route acceptance
 type routeAcceptanceResult struct {
 	accepted bool
@@ -814,7 +818,7 @@ func (r *Reconciler) waitForRouteAcceptance(ctx context.Context, routeName, rout
 		}
 		time.Sleep(interval)
 	}
-	return routeAcceptanceResult{accepted: false, reason: "Timeout"}
+	return routeAcceptanceResult{accepted: false, reason: routeAcceptanceReasonTimeout}
 }
 
 // waitForGRPCRouteAcceptance polls GRPCRoute status until Accepted or timeout
@@ -848,7 +852,7 @@ func (r *Reconciler) waitForGRPCRouteAcceptance(ctx context.Context, routeName, 
 		}
 		time.Sleep(interval)
 	}
-	return routeAcceptanceResult{accepted: false, reason: "Timeout"}
+	return routeAcceptanceResult{accepted: false, reason: routeAcceptanceReasonTimeout}
 }
 
 // isAlreadyConverted checks if an Ingress has been successfully converted

--- a/internal/kubelb/loadbalancer.go
+++ b/internal/kubelb/loadbalancer.go
@@ -277,7 +277,7 @@ func ShouldConfigureHostname(log logr.Logger, annotations map[string]string, res
 			"resourceName", resourceName,
 			"annotation", AnnotationRequestWildcardDomain)
 		return false
-	} else if val != "true" {
+	} else if val != AnnotationValueTrue {
 		log.V(4).Info("Hostname configuration denied: wildcard domain annotation not set to 'true'",
 			"resourceName", resourceName,
 			"annotation", AnnotationRequestWildcardDomain,

--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -62,6 +62,10 @@ const DefaultRouteStatus = "{}"
 const ServiceKind = "Service"
 const NameSuffixLength = 4
 
+// AnnotationValueTrue is the canonical truthy value for boolean-style
+// KubeLB annotations.
+const AnnotationValueTrue = "true"
+
 // We limit the name length slightly lower than the kubernetes limit of 63 characters to avoid issues with the name length.
 // In case if the name exceeds the limit, we truncate the name and append a suffix ensuring that it's always less than 63 characters.
 const MaxNameLength = 60

--- a/internal/metricsutil/envoycp/metrics.go
+++ b/internal/metricsutil/envoycp/metrics.go
@@ -38,14 +38,14 @@ var (
 	SnapshotUpdatesTotal = factory.NewCounterVec(
 		"snapshot_updates_total",
 		"Total number of Envoy snapshot updates",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// SnapshotGenerationDuration tracks the duration of snapshot generation.
 	SnapshotGenerationDuration = factory.NewHistogramVec(
 		"snapshot_generation_duration_seconds",
 		"Duration of Envoy snapshot generation in seconds",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 		nil,
 	)
 )
@@ -56,35 +56,35 @@ var (
 	ClustersTotal = factory.NewGaugeVec(
 		"clusters",
 		"Current number of clusters in the Envoy snapshot",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// ListenersTotal tracks the number of listeners across all snapshots.
 	ListenersTotal = factory.NewGaugeVec(
 		"listeners",
 		"Current number of listeners in the Envoy snapshot",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// EndpointsTotal tracks the number of endpoints across all snapshots.
 	EndpointsTotal = factory.NewGaugeVec(
 		"endpoints",
 		"Current number of endpoints in the Envoy snapshot",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// RoutesTotal tracks the number of routes across all snapshots.
 	RoutesTotal = factory.NewGaugeVec(
 		"routes",
 		"Current number of routes in the Envoy snapshot",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// SecretsTotal tracks the number of secrets across all snapshots.
 	SecretsTotal = factory.NewGaugeVec(
 		"secrets",
 		"Current number of secrets in the Envoy snapshot",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 )
 
@@ -117,21 +117,21 @@ var (
 	CacheHitsTotal = factory.NewCounterVec(
 		"cache_hits_total",
 		"Total number of cache hits for snapshot lookups",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// CacheMissesTotal counts cache misses for snapshot lookups.
 	CacheMissesTotal = factory.NewCounterVec(
 		"cache_misses_total",
 		"Total number of cache misses for snapshot lookups",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// CacheClearsTotal counts the total number of cache clears.
 	CacheClearsTotal = factory.NewCounterVec(
 		"cache_clears_total",
 		"Total number of cache clears",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 )
 

--- a/internal/metricsutil/manager/metrics.go
+++ b/internal/metricsutil/manager/metrics.go
@@ -167,28 +167,28 @@ var (
 	EnvoyCPSnapshotUpdatesTotal = factory.NewCounterVec(
 		"envoycp_snapshot_updates_total",
 		"Total number of Envoy snapshot updates",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// EnvoyCPClusters tracks the number of clusters in the Envoy snapshot.
 	EnvoyCPClusters = factory.NewGaugeVec(
 		"envoycp_clusters",
 		"Current number of clusters in the Envoy snapshot",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// EnvoyCPListeners tracks the number of listeners in the Envoy snapshot.
 	EnvoyCPListeners = factory.NewGaugeVec(
 		"envoycp_listeners",
 		"Current number of listeners in the Envoy snapshot",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// EnvoyCPEndpoints tracks the number of endpoints in the Envoy snapshot.
 	EnvoyCPEndpoints = factory.NewGaugeVec(
 		"envoycp_endpoints",
 		"Current number of endpoints in the Envoy snapshot",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 
 	// EnvoyDuplicateListenersDropped counts listeners dropped from the xDS snapshot
@@ -198,7 +198,7 @@ var (
 	EnvoyDuplicateListenersDropped = factory.NewCounterVec(
 		"envoy_duplicate_listeners_dropped_total",
 		"Total number of listeners dropped from the Envoy snapshot due to duplicate bind addresses",
-		[]string{"snapshot_name"},
+		[]string{metricsutil.LabelSnapshotName},
 	)
 )
 

--- a/internal/metricsutil/metrics.go
+++ b/internal/metricsutil/metrics.go
@@ -30,12 +30,13 @@ const (
 
 // Common label names used across metrics.
 const (
-	LabelNamespace = "namespace"
-	LabelTenant    = "tenant"
-	LabelResult    = "result"
-	LabelRouteType = "route_type"
-	LabelTopology  = "topology"
-	LabelOperation = "operation"
+	LabelNamespace    = "namespace"
+	LabelTenant       = "tenant"
+	LabelResult       = "result"
+	LabelRouteType    = "route_type"
+	LabelTopology     = "topology"
+	LabelOperation    = "operation"
+	LabelSnapshotName = "snapshot_name"
 )
 
 // Result label values for reconciliation outcomes.

--- a/pkg/conversion/annotations/complex.go
+++ b/pkg/conversion/annotations/complex.go
@@ -23,7 +23,14 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-const defaultConfigEnabled = "enabled"
+const (
+	defaultConfigEnabled = "enabled"
+
+	affinityCookie       = "cookie"
+	authTypeDigest       = "digest"
+	backendProtocolGRPC  = "GRPC"
+	backendProtocolGRPCS = "GRPCS"
+)
 
 // handleAffinity handles session affinity annotations
 // nginx.ingress.kubernetes.io/affinity: "cookie"
@@ -32,7 +39,7 @@ func handleAffinity(_, value string, annotations map[string]string) ([]gwapiv1.H
 		return nil, nil
 	}
 
-	if value != "cookie" {
+	if value != affinityCookie {
 		return nil, []string{fmt.Sprintf("affinity=%q is not supported; only 'cookie' affinity can be converted", value)}
 	}
 
@@ -100,7 +107,7 @@ func handleAuthType(_, value string, annotations map[string]string) ([]gwapiv1.H
 		)
 		return nil, []string{warning}
 
-	case "digest":
+	case authTypeDigest:
 		return nil, []string{"auth-type=digest is not supported in Gateway API; consider using basic auth or external auth"}
 
 	default:
@@ -138,7 +145,7 @@ func handleBackendProtocol(_, value string, _ map[string]string) ([]gwapiv1.HTTP
 	value = strings.ToUpper(value)
 
 	switch value {
-	case "GRPC", "GRPCS":
+	case backendProtocolGRPC, backendProtocolGRPCS:
 		return nil, []string{fmt.Sprintf(
 			"backend-protocol=%s indicates this Ingress should be converted to GRPCRoute instead of HTTPRoute",
 			value,

--- a/pkg/conversion/annotations/converter.go
+++ b/pkg/conversion/annotations/converter.go
@@ -23,7 +23,12 @@ import (
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-const boolTrue = "true"
+const (
+	boolTrue  = "true"
+	boolFalse = "false"
+
+	schemeHTTPS = "https"
+)
 
 // AnnotationConversionResult holds the converted filters and any warnings
 type AnnotationConversionResult struct {
@@ -271,7 +276,7 @@ func handleAuthTypeSilent(_, value string, _ map[string]string) ([]gwapiv1.HTTPR
 	case AuthTypeBasic:
 		// Auto-converted to SecurityPolicy - no warning needed
 		return nil, nil
-	case "digest":
+	case authTypeDigest:
 		return nil, []string{"auth-type=digest is not supported in Gateway API; consider using basic auth or external auth"}
 	default:
 		return nil, []string{fmt.Sprintf("auth-type=%q is not supported", value)}

--- a/pkg/conversion/annotations/headers.go
+++ b/pkg/conversion/annotations/headers.go
@@ -138,7 +138,7 @@ func handleXForwardedPrefix(_, value string, _ map[string]string) ([]gwapiv1.HTT
 // When true (default), the original Host header is preserved
 // When false, the Host header should be rewritten to the service name
 func handlePreserveHost(_, value string, _ map[string]string) ([]gwapiv1.HTTPRouteFilter, []string) {
-	if value != "false" {
+	if value != boolFalse {
 		return nil, nil // default is true, no action needed
 	}
 	warning := "preserve-host=false requires URLRewrite filter with Hostname at backend level; " +
@@ -227,12 +227,12 @@ func buildHSTSHeaderValue(annotations map[string]string) string {
 	value := "max-age=" + maxAge
 
 	// Include subdomains if enabled
-	if v, ok := annotations[HSTSIncludeSubdomains]; ok && v == "true" {
+	if v, ok := annotations[HSTSIncludeSubdomains]; ok && v == boolTrue {
 		value += "; includeSubDomains"
 	}
 
 	// Add preload if enabled
-	if v, ok := annotations[HSTSPreload]; ok && v == "true" {
+	if v, ok := annotations[HSTSPreload]; ok && v == boolTrue {
 		value += "; preload"
 	}
 

--- a/pkg/conversion/annotations/policy_converter.go
+++ b/pkg/conversion/annotations/policy_converter.go
@@ -158,7 +158,7 @@ func buildBackendTrafficPolicy(input PolicyConversionInput) (*egv1alpha1.Backend
 
 	// Session affinity - not directly supported in BackendTrafficPolicy the same way
 	// Envoy Gateway uses different mechanisms for session persistence
-	if input.Annotations[Affinity] == "cookie" {
+	if input.Annotations[Affinity] == affinityCookie {
 		warnings = append(warnings,
 			"affinity=cookie requires manual BackendTrafficPolicy configuration for session persistence")
 	}

--- a/pkg/conversion/annotations/redirects.go
+++ b/pkg/conversion/annotations/redirects.go
@@ -103,7 +103,7 @@ func handleTemporalRedirect(key, value string, _ map[string]string) ([]gwapiv1.H
 
 // createHTTPSRedirectFilter creates a RequestRedirect filter for HTTP->HTTPS
 func createHTTPSRedirectFilter(statusCode int) []gwapiv1.HTTPRouteFilter {
-	scheme := "https"
+	scheme := schemeHTTPS
 	code := statusCodeToGatewayAPI(statusCode)
 
 	return []gwapiv1.HTTPRouteFilter{

--- a/pkg/conversion/constants.go
+++ b/pkg/conversion/constants.go
@@ -22,6 +22,13 @@ const (
 	// Common string constants
 	BoolTrue = "true"
 
+	// nginx ingress backend-protocol values that signal a gRPC upstream.
+	BackendProtocolGRPC  = "GRPC"
+	BackendProtocolGRPCS = "GRPCS"
+
+	// Gateway listener name for plaintext HTTP.
+	ListenerNameHTTP = "http"
+
 	// Annotations
 	AnnotationSkipConversion     = "kubelb.k8c.io/skip-conversion"
 	AnnotationConversionStatus   = "kubelb.k8c.io/conversion-status"

--- a/pkg/conversion/converter.go
+++ b/pkg/conversion/converter.go
@@ -136,7 +136,7 @@ func isGRPCIngress(ingress *networkingv1.Ingress) bool {
 		return false
 	}
 	protocol := strings.ToUpper(ingress.Annotations[NginxBackendProtocol])
-	return protocol == "GRPC" || protocol == "GRPCS"
+	return protocol == BackendProtocolGRPC || protocol == BackendProtocolGRPCS
 }
 
 // hostRuleGroup holds hosts that share the same rules
@@ -152,7 +152,7 @@ func convertToHTTPRoutes(input Input, parentRef gwapiv1.ParentReference, filters
 	var httpRoutes []*gwapiv1.HTTPRoute
 
 	// Check for use-regex annotation
-	useRegex := ingress.Annotations != nil && ingress.Annotations[annotations.UseRegex] == "true"
+	useRegex := ingress.Annotations != nil && ingress.Annotations[annotations.UseRegex] == BoolTrue
 
 	// Collect rules per host
 	hostRules := make(map[string][]gwapiv1.HTTPRouteRule)

--- a/pkg/conversion/gateway.go
+++ b/pkg/conversion/gateway.go
@@ -75,7 +75,7 @@ func BuildListeners(tlsListeners []TLSListener) []gwapiv1.Listener {
 	listeners := []gwapiv1.Listener{
 		// Always include HTTP listener
 		{
-			Name:     "http",
+			Name:     ListenerNameHTTP,
 			Port:     80,
 			Protocol: gwapiv1.HTTPProtocolType,
 			AllowedRoutes: &gwapiv1.AllowedRoutes{


### PR DESCRIPTION
**What this PR does / why we need it**:

The CCM had three controllers `IngressReconciler`, `HTTPRouteReconciler`, `GRPCRouteReconciler`,  each ~300 lines of structurally identical Source-to-Route reconcile code. The only true variation per Source kind was: scope predicate, service extraction, status apply (Gateway-API ObservedGeneration), and metric handles. The shared `reconcileSourceForRoute` helper was a thin pass-through that didn't capture the bulk of the duplication.

The number of controllers is much higher for EE version. This adapter helps us abstract the same parts out and now adding a fourth Source kind is simply: write one adapter (~50 lines) and register it in `cmd/ccm/main.go`.

**Which issue(s) this PR fixes**:

Fixes #

**What type of PR is this?**

/kind cleanup

**Special notes for your reviewer**:

Pure refactor; no behavioural change to the reconcile loop, status semantics, finalizer handling, metrics labels, or watch wiring.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
NONE
```

**Documentation**:

```documentation
NONE
```