### PR TITLE
fix: normalize generated route service names

### DIFF
--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -77,9 +77,7 @@ func GenerateName(name, namespace string) string {
 	output := fmt.Sprintf("%s-%s", namespace, name)
 
 	if len(output) >= MaxNameLength {
-		hash := sha256.Sum256([]byte(output))
-		suffix := hex.EncodeToString(hash[:])[:NameSuffixLength]
-		output = fmt.Sprintf("%s-%s", output[:MaxNameLength-(NameSuffixLength+1)], suffix)
+		output = truncateName(output)
 	}
 
 	return output
@@ -88,15 +86,48 @@ func GenerateName(name, namespace string) string {
 // GenerateRouteServiceName generates a unique service name that includes route identifier.
 // Format: namespace-routeName-serviceName[-uid] (truncated to MaxNameLength)
 func GenerateRouteServiceName(routeName, serviceName, namespace string) string {
-	output := fmt.Sprintf("%s-%s-%s", namespace, routeName, serviceName)
+	output := dns1035Name(fmt.Sprintf("%s-%s-%s", namespace, routeName, serviceName))
 
 	if len(output) >= MaxNameLength {
-		hash := sha256.Sum256([]byte(output))
-		suffix := hex.EncodeToString(hash[:])[:NameSuffixLength]
-		output = fmt.Sprintf("%s-%s", output[:MaxNameLength-(NameSuffixLength+1)], suffix)
+		output = truncateName(output)
 	}
 
 	return output
+}
+
+func dns1035Name(name string) string {
+	name = strings.ToLower(name)
+	var builder strings.Builder
+	builder.Grow(len(name))
+
+	for _, char := range name {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char)
+		case char >= '0' && char <= '9':
+			builder.WriteRune(char)
+		case char == '-':
+			builder.WriteRune(char)
+		default:
+			builder.WriteRune('-')
+		}
+	}
+
+	output := strings.Trim(builder.String(), "-")
+	if output == "" {
+		return "k"
+	}
+	if output[0] < 'a' || output[0] > 'z' {
+		output = fmt.Sprintf("k-%s", output)
+	}
+	return output
+}
+
+func truncateName(name string) string {
+	hash := sha256.Sum256([]byte(name))
+	suffix := hex.EncodeToString(hash[:])[:NameSuffixLength]
+	prefix := strings.TrimRight(name[:MaxNameLength-(NameSuffixLength+1)], "-")
+	return fmt.Sprintf("%s-%s", prefix, suffix)
 }
 
 func GetName(obj client.Object) string {

--- a/internal/kubelb/utils_test.go
+++ b/internal/kubelb/utils_test.go
@@ -31,18 +31,103 @@ func ptrBool(b bool) *bool { return &b }
 
 func ptrMap(m map[string]string) *map[string]string { return &m }
 
-func TestGenerateRouteServiceName(t *testing.T) {
+func TestGenerateRouteServiceNameReturnsDNS1035Name(t *testing.T) {
+	tests := []struct {
+		name        string
+		routeName   string
+		serviceName string
+		namespace   string
+		want        string
+	}{
+		{
+			name:        "short name is unchanged",
+			routeName:   "route",
+			serviceName: "service",
+			namespace:   "default",
+			want:        "default-route-service",
+		},
+		{
+			name:        "route dots are normalized",
+			routeName:   "app.example.com",
+			serviceName: "service",
+			namespace:   "default",
+			want:        "default-app-example-com-service",
+		},
+		{
+			name:        "uppercase chars are lowercased",
+			routeName:   "Route",
+			serviceName: "Service",
+			namespace:   "Default",
+			want:        "default-route-service",
+		},
+		{
+			name:        "invalid separators are normalized",
+			routeName:   "route/name",
+			serviceName: "service_name",
+			namespace:   "default",
+			want:        "default-route-name-service-name",
+		},
+		{
+			name:        "digit-leading namespace is prefixed",
+			routeName:   "route",
+			serviceName: "service",
+			namespace:   "1default",
+			want:        "k-1default-route-service",
+		},
+		{
+			name:        "trailing invalid chars are trimmed",
+			routeName:   "route.",
+			serviceName: "service.",
+			namespace:   "default.",
+			want:        "default--route--service",
+		},
+		{
+			name:        "all invalid chars fall back to valid name",
+			routeName:   "...",
+			serviceName: "___",
+			namespace:   "///",
+			want:        "k",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateRouteServiceName(tt.routeName, tt.serviceName, tt.namespace)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+			if errs := validation.IsDNS1035Label(got); len(errs) > 0 {
+				t.Fatalf("expected DNS-1035 service name, got %q: %v", got, errs)
+			}
+		})
+	}
+}
+
+func TestGenerateRouteServiceNameTruncatesLongName(t *testing.T) {
+	got := GenerateRouteServiceName(strings.Repeat("a", 52), "bbbbbbbb", "a")
+
+	if len(got) > MaxNameLength {
+		t.Fatalf("expected name length <= %d, got %d: %q", MaxNameLength, len(got), got)
+	}
+	if errs := validation.IsDNS1035Label(got); len(errs) > 0 {
+		t.Fatalf("expected DNS-1035 service name, got %q: %v", got, errs)
+	}
+}
+
+func TestGenerateRouteServiceNameTruncatesIssue470Name(t *testing.T) {
+	const invalidName = "argocd-default-xx-yyyy-argocd-server-default-xx-yyyy-argocd-"
+
 	got := GenerateRouteServiceName(
 		"default-xx-yyyy-argocd-server",
 		"default-xx-yyyy-argocd-server",
 		"argocd",
 	)
 
+	if got == invalidName {
+		t.Fatalf("expected name not to match reported invalid name %q", invalidName)
+	}
 	if len(got) > MaxNameLength {
 		t.Fatalf("expected name length <= %d, got %d: %q", MaxNameLength, len(got), got)
-	}
-	if strings.HasSuffix(got, "-") {
-		t.Fatalf("expected name not to end with '-', got %q", got)
 	}
 	if errs := validation.IsDNS1035Label(got); len(errs) > 0 {
 		t.Fatalf("expected DNS-1035 service name, got %q: %v", got, errs)


### PR DESCRIPTION
**What this PR does / why we need it**:

Normalizes generated Route service names so they always comply with Kubernetes DNS-1035 Service name validation. This prevents truncated generated names from ending with invalid characters and also handles other invalid input characters before creating Services.

Adds regression coverage for the exact invalid name reported in #470 and broader DNS-1035 cases.

**Which issue(s) this PR fixes**:
Fixes #470

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix generated KubeLB Route service names to comply with Kubernetes DNS-1035 validation.
```

```documentation
NONE
```