### PR TITLE
[release/v1.4] fix: normalize generated route service names

### DIFF
--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -72,9 +72,7 @@ func GenerateName(name, namespace string) string {
 	output := fmt.Sprintf("%s-%s", namespace, name)
 
 	if len(output) >= MaxNameLength {
-		hash := sha256.Sum256([]byte(output))
-		suffix := hex.EncodeToString(hash[:])[:NameSuffixLength]
-		output = fmt.Sprintf("%s-%s", output[:MaxNameLength-(NameSuffixLength+1)], suffix)
+		output = truncateName(output)
 	}
 
 	return output
@@ -83,15 +81,48 @@ func GenerateName(name, namespace string) string {
 // GenerateRouteServiceName generates a unique service name that includes route identifier.
 // Format: namespace-routeName-serviceName[-uid] (truncated to MaxNameLength)
 func GenerateRouteServiceName(routeName, serviceName, namespace string) string {
-	output := fmt.Sprintf("%s-%s-%s", namespace, routeName, serviceName)
+	output := dns1035Name(fmt.Sprintf("%s-%s-%s", namespace, routeName, serviceName))
 
 	if len(output) >= MaxNameLength {
-		hash := sha256.Sum256([]byte(output))
-		suffix := hex.EncodeToString(hash[:])[:NameSuffixLength]
-		output = fmt.Sprintf("%s-%s", output[:MaxNameLength-(NameSuffixLength+1)], suffix)
+		output = truncateName(output)
 	}
 
 	return output
+}
+
+func dns1035Name(name string) string {
+	name = strings.ToLower(name)
+	var builder strings.Builder
+	builder.Grow(len(name))
+
+	for _, char := range name {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char)
+		case char >= '0' && char <= '9':
+			builder.WriteRune(char)
+		case char == '-':
+			builder.WriteRune(char)
+		default:
+			builder.WriteRune('-')
+		}
+	}
+
+	output := strings.Trim(builder.String(), "-")
+	if output == "" {
+		return "k"
+	}
+	if output[0] < 'a' || output[0] > 'z' {
+		output = fmt.Sprintf("k-%s", output)
+	}
+	return output
+}
+
+func truncateName(name string) string {
+	hash := sha256.Sum256([]byte(name))
+	suffix := hex.EncodeToString(hash[:])[:NameSuffixLength]
+	prefix := strings.TrimRight(name[:MaxNameLength-(NameSuffixLength+1)], "-")
+	return fmt.Sprintf("%s-%s", prefix, suffix)
 }
 
 func GetName(obj client.Object) string {

--- a/internal/kubelb/utils_test.go
+++ b/internal/kubelb/utils_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelb
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestGenerateRouteServiceNameReturnsDNS1035Name(t *testing.T) {
+	tests := []struct {
+		name        string
+		routeName   string
+		serviceName string
+		namespace   string
+		want        string
+	}{
+		{
+			name:        "short name is unchanged",
+			routeName:   "route",
+			serviceName: "service",
+			namespace:   "default",
+			want:        "default-route-service",
+		},
+		{
+			name:        "route dots are normalized",
+			routeName:   "app.example.com",
+			serviceName: "service",
+			namespace:   "default",
+			want:        "default-app-example-com-service",
+		},
+		{
+			name:        "uppercase chars are lowercased",
+			routeName:   "Route",
+			serviceName: "Service",
+			namespace:   "Default",
+			want:        "default-route-service",
+		},
+		{
+			name:        "invalid separators are normalized",
+			routeName:   "route/name",
+			serviceName: "service_name",
+			namespace:   "default",
+			want:        "default-route-name-service-name",
+		},
+		{
+			name:        "digit-leading namespace is prefixed",
+			routeName:   "route",
+			serviceName: "service",
+			namespace:   "1default",
+			want:        "k-1default-route-service",
+		},
+		{
+			name:        "trailing invalid chars are trimmed",
+			routeName:   "route.",
+			serviceName: "service.",
+			namespace:   "default.",
+			want:        "default--route--service",
+		},
+		{
+			name:        "all invalid chars fall back to valid name",
+			routeName:   "...",
+			serviceName: "___",
+			namespace:   "///",
+			want:        "k",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateRouteServiceName(tt.routeName, tt.serviceName, tt.namespace)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+			if errs := validation.IsDNS1035Label(got); len(errs) > 0 {
+				t.Fatalf("expected DNS-1035 service name, got %q: %v", got, errs)
+			}
+		})
+	}
+}
+
+func TestGenerateRouteServiceNameTruncatesLongName(t *testing.T) {
+	got := GenerateRouteServiceName(strings.Repeat("a", 52), "bbbbbbbb", "a")
+
+	if len(got) > MaxNameLength {
+		t.Fatalf("expected name length <= %d, got %d: %q", MaxNameLength, len(got), got)
+	}
+	if errs := validation.IsDNS1035Label(got); len(errs) > 0 {
+		t.Fatalf("expected DNS-1035 service name, got %q: %v", got, errs)
+	}
+}
+
+func TestGenerateRouteServiceNameTruncatesIssue470Name(t *testing.T) {
+	const invalidName = "argocd-default-xx-yyyy-argocd-server-default-xx-yyyy-argocd-"
+
+	got := GenerateRouteServiceName(
+		"default-xx-yyyy-argocd-server",
+		"default-xx-yyyy-argocd-server",
+		"argocd",
+	)
+
+	if got == invalidName {
+		t.Fatalf("expected name not to match reported invalid name %q", invalidName)
+	}
+	if len(got) > MaxNameLength {
+		t.Fatalf("expected name length <= %d, got %d: %q", MaxNameLength, len(got), got)
+	}
+	if errs := validation.IsDNS1035Label(got); len(errs) > 0 {
+		t.Fatalf("expected DNS-1035 service name, got %q: %v", got, errs)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #477 to `release/v1.4`.

**Which issue(s) this PR fixes**:
Refs #470

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix generated KubeLB Route service names to comply with Kubernetes DNS-1035 validation.
```

**Documentation**:
```documentation
NONE
```
