### PR TITLE
fix: make release-prep re-runnable

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -242,6 +242,10 @@ jobs:
           git status
           echo "::endgroup::"
           git add -A
+          if git diff --cached --quiet; then
+            echo "::error::No changes to commit — generated artifacts are identical to ${BASE_BRANCH}. Prep may already be applied; nothing to release."
+            exit 1
+          fi
           git commit -s -m "chore: prepare ${VERSION}"
 
           MINOR=$(echo "${VERSION}" | grep -oE 'v[0-9]+\.[0-9]+')
@@ -304,6 +308,11 @@ jobs:
           fi
 
           git remote set-url origin "https://x-access-token:${KUBELB_EE_TOKEN}@github.com/${{ github.repository }}.git"
+          # A prep branch from a prior (closed/superseded) run persists on the
+          # remote — closing a PR does not delete its branch. Drop any stale
+          # branch so re-running prep for the same version pushes cleanly
+          # instead of failing non-fast-forward.
+          git push origin --delete "${BRANCH}" 2>/dev/null || true
           git push origin "${BRANCH}"
 
           printf '%s\n' "$PR_BODY" | gh pr create \


### PR DESCRIPTION
**What this PR does / why we need it**:

The `Release Prep` workflow fails when re-run for a version whose prep PR was
previously closed. Closing a PR does **not** delete its branch, so the stale
`chore/prepare-<version>` ref persists on the remote. A re-run creates a fresh
branch of the same name and `git push origin <branch>` is rejected
non-fast-forward:

```
! [rejected]  chore/prepare-v1.4.3 -> chore/prepare-v1.4.3 (non-fast-forward)
```

Two fixes make the prep step idempotent:
- Delete any stale prep branch before pushing, so re-runs push cleanly.
- Fail loud with an actionable message if there is nothing to commit, instead
  of dying on `git commit`'s opaque "nothing to commit".

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```