### PR TITLE
fix: ignore GO-2026-5932 (unused x/crypto/openpgp) in OSV scan

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "golang.org/x/crypto/openpgp is deprecated with no fixed version; kubelb does not import any openpgp package (verified with `go mod why golang.org/x/crypto/openpgp` in both modules), x/crypto is only an indirect dependency"


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignores GO-2026-5932 via `osv-scanner.toml`: `golang.org/x/crypto/openpgp` has no fixed version and is never imported by kubelb (`x/crypto` is indirect-only)

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```