### PR TITLE
fix(rbac): drop unused clusterroles create/escalate from manager ClusterRole

### DIFF
--- a/charts/kubelb-manager/templates/clusterrole.yaml
+++ b/charts/kubelb-manager/templates/clusterrole.yaml
@@ -235,7 +235,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  - clusterroles
   - roles
   verbs:
   - bind


### PR DESCRIPTION
**What this PR does / why we need it**:

The manager's Helm ClusterRole grants `create`, `bind`, and `escalate` on cluster-scoped `clusterroles`, but nothing in the code creates a ClusterRole. The tenant reconciler only creates a namespaced Role and RoleBinding, and the generated `config/rbac/role.yaml` has no `clusterroles` either. That leaves an unused grant that would let a compromised manager mint a ClusterRole and bind itself to cluster-admin.

This removes `clusterroles` from that rule. The `bind`/`escalate` verbs on the namespaced `roles`/`rolebindings` stay, since tenant provisioning needs them.

**Which issue(s) this PR fixes**:

N/A

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The KubeLB manager ClusterRole no longer requests unused create/bind/escalate permissions on cluster-scoped clusterroles.
```

**Documentation**:
```documentation
NONE
```
