### PR TITLE
fix: guard PortAllocator reads with the mutex to fix concurrent-map crash

### DIFF
--- a/internal/port-lookup/allocator.go
+++ b/internal/port-lookup/allocator.go
@@ -41,7 +41,7 @@ const (
 type LookupTable map[string]map[string]int
 
 type PortAllocator struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	portLookup LookupTable
 	// portLookupReverse is a reverse lookup table for available ports. It is used to quickly determine if a port is available.
@@ -57,9 +57,22 @@ func NewPortAllocator() *PortAllocator {
 }
 
 func (pa *PortAllocator) GetPortLookupTable() LookupTable {
-	return pa.portLookup
+	pa.mu.RLock()
+	defer pa.mu.RUnlock()
+	out := make(LookupTable, len(pa.portLookup))
+	for endpointKey, ports := range pa.portLookup {
+		inner := make(map[string]int, len(ports))
+		for k, v := range ports {
+			inner[k] = v
+		}
+		out[endpointKey] = inner
+	}
+	return out
 }
+
 func (pa *PortAllocator) Lookup(endpointKey, portKey string) (int, bool) {
+	pa.mu.RLock()
+	defer pa.mu.RUnlock()
 	if endpointLookup, exists := pa.portLookup[endpointKey]; exists {
 		if port, exists := endpointLookup[portKey]; exists {
 			return port, true
@@ -246,6 +259,8 @@ func (pa *PortAllocator) LoadState(ctx context.Context, apiReader client.Reader)
 	// clear duplicates so the next reconcile allocates fresh ports for them.
 	healLoadStateCollisions(lookupTable)
 
+	pa.mu.Lock()
+	defer pa.mu.Unlock()
 	pa.portLookup = lookupTable
 	pa.recomputeAvailablePorts()
 	return nil

--- a/internal/port-lookup/allocator_test.go
+++ b/internal/port-lookup/allocator_test.go
@@ -19,6 +19,7 @@ package portlookup
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
@@ -251,6 +252,34 @@ func TestLoadState_HealsDuplicateRoutePort(t *testing.T) {
 	if aHas == bHas {
 		t.Fatalf("expected exactly one route to retain the port after heal; got A=%v B=%v", aHas, bHas)
 	}
+}
+
+// TestPortAllocator_ConcurrentReadWrite hammers readers and writers on shared
+// keys concurrently. Without the reader locks it triggers a data race (and the
+// runtime "concurrent map read and map write" fatal) under -race.
+func TestPortAllocator_ConcurrentReadWrite(t *testing.T) {
+	pa := NewPortAllocator()
+	const goroutines = 8
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(2)
+		go func(n int) {
+			defer wg.Done()
+			ep := fmt.Sprintf("ep-%d", n)
+			for j := 0; j < 500; j++ {
+				pa.AllocatePorts(ep, []string{"a", "b", "c"})
+			}
+		}(i)
+		go func(n int) {
+			defer wg.Done()
+			ep := fmt.Sprintf("ep-%d", n)
+			for j := 0; j < 500; j++ {
+				pa.Lookup(ep, "a")
+				_ = pa.GetPortLookupTable()
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 // TestHealLoadStateCollisions_EndpointPatternKeys uses realistic kubelb pattern


### PR DESCRIPTION
**What this PR does / why we need it**:

`PortAllocator` guards shared maps with a mutex, but the two readers (`Lookup`, `GetPortLookupTable`) and `LoadState` touch those maps without taking it, while writers hold it on other goroutines. A concurrent map read and write is a fatal Go runtime error that crashes the whole manager, and controller-runtime's panic guard can't catch it.

This switches the mutex to an `RWMutex`, takes a read lock in both readers (`GetPortLookupTable` now returns a copy so callers can't touch the live maps after unlocking), and locks the final assignment in `LoadState`. Also adds a `-race` test that runs readers and writers concurrently.

**Which issue(s) this PR fixes**:

N/A

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed a potential manager crash (concurrent map read and map write) caused by unsynchronized reads of the port allocator.
```

**Documentation**:
```documentation
NONE
```
