### PR TITLE
fix: requeue Route when a backing Service apply fails

### DIFF
--- a/internal/controllers/kubelb/route_controller.go
+++ b/internal/controllers/kubelb/route_controller.go
@@ -19,6 +19,7 @@ package kubelb
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -270,6 +271,7 @@ func (r *RouteReconciler) manageServices(ctx context.Context, log logr.Logger, r
 	}
 
 	routeStatus := route.Status.DeepCopy()
+	var svcErrs []error
 	for _, svc := range services {
 		log.V(4).Info("Creating/Updating service", "name", svc.Name, "namespace", svc.Namespace)
 		var err error
@@ -278,6 +280,7 @@ func (r *RouteReconciler) manageServices(ctx context.Context, log logr.Logger, r
 			log.Error(err, "failed to create or update Service", "name", svc.Name, "namespace", svc.Namespace)
 			errorMessage := fmt.Errorf("failed to create or update Service: %w", err)
 			r.Recorder.Eventf(route, nil, corev1.EventTypeWarning, "ServiceApplyFailed", "Reconciling", errorMessage.Error())
+			svcErrs = append(svcErrs, errorMessage)
 		}
 		updateServiceStatus(routeStatus, &svc, err)
 	}
@@ -285,7 +288,16 @@ func (r *RouteReconciler) manageServices(ctx context.Context, log logr.Logger, r
 	// Cleanup orphaned services from naming change (old: ns-svc, new: ns-route-svc)
 	r.cleanupRenamedServices(ctx, log, route, originalRouteName)
 
-	return r.UpdateRouteStatus(ctx, route, *routeStatus)
+	// Write status first so the failure condition is visible, then surface the
+	// error so the workqueue retries (the For(...) uses GenerationChangedPredicate,
+	// so a status-only write would not re-enqueue).
+	if err := r.UpdateRouteStatus(ctx, route, *routeStatus); err != nil {
+		return err
+	}
+	if len(svcErrs) > 0 {
+		return errors.Join(svcErrs...)
+	}
+	return nil
 }
 
 func (r *RouteReconciler) cleanupOrphanedServices(ctx context.Context, log logr.Logger, route *kubelbv1alpha1.Route) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a backing Service fails to apply, the Route controller logs the error and writes it to the status, but then returns nil. So the reconcile reports success and nothing requeues. The watch uses `GenerationChangedPredicate`, so the status write doesn't re-enqueue either, and the Route stays broken until some unrelated event happens to trigger it again.

This collects the per-Service errors and returns them after the status write, so the workqueue retries with backoff and the Route recovers on its own. Status is still written first so the failure stays visible.

**Which issue(s) this PR fixes**:

N/A

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed Routes staying broken after a transient backing-Service apply failure; these now requeue and recover automatically.
```

**Documentation**:
```documentation
NONE
```
