### PR TITLE
fix(addons): repair agentgateway chart pin, block dependabot from dead 2.x lineage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,3 +100,10 @@ updates:
       - docs/none
       - release-note-none
       - ok-to-test
+    ignore:
+      # The agentgateway charts renumbered their versioning: the dead pre-v1.0
+      # lineage ended at 2.2.x, which semver-sorts above the current 1.x line,
+      # so dependabot "upgrades" into the obsolete lineage (see #504, #508).
+      # Upstream minors are also breaking (v1alpha1 CRDs); bump these manually.
+      - dependency-name: "agentgateway"
+      - dependency-name: "agentgateway-crds"

--- a/charts/kubelb-addons/Chart.lock
+++ b/charts/kubelb-addons/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 0.15.3
 - name: agentgateway-crds
   repository: oci://cr.agentgateway.dev/charts
-  version: v2.2.1
+  version: v1.3.1
 - name: agentgateway
   repository: oci://cr.agentgateway.dev/charts
-  version: v2.2.1
-digest: sha256:25fcaa7efbce3aa525e6e474162445f032a8e59c28d4a228f20212d407f92faf
-generated: "2026-07-20T02:56:48.491171986Z"
+  version: v1.3.1
+digest: sha256:20f84bc9fbbc458128e050b77e5885206d820fc69e97df6b4e7839f275685f13
+generated: "2026-07-22T12:29:22.196353+05:00"

--- a/charts/kubelb-addons/Chart.yaml
+++ b/charts/kubelb-addons/Chart.yaml
@@ -34,8 +34,8 @@ dependencies:
   - name: agentgateway-crds
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway-crds.enabled
-    version: v2.2.1
+    version: v1.3.1
   - name: agentgateway
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway.enabled
-    version: v2.2.1
+    version: v1.3.1

--- a/hack/patches/agentgateway.patch
+++ b/hack/patches/agentgateway.patch
@@ -1,11 +1,10 @@
 diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/agentgateway/templates/_helpers.tpl b/agentgateway/templates/_helpers.tpl
---- a/agentgateway/templates/_helpers.tpl	2026-04-20 00:00:00
-+++ b/agentgateway/templates/_helpers.tpl	2026-04-20 00:00:00
-@@ -94,4 +94,31 @@
- {{- $tag -}}
+--- a/agentgateway/templates/_helpers.tpl	2026-07-22 14:19:21
++++ b/agentgateway/templates/_helpers.tpl	2026-07-22 14:19:21
+@@ -95,3 +95,30 @@
  {{- end -}}
  {{- end }}
-+
+ 
 +{{/*
 +Resolve a mirrored image registry value. Takes a dict with:
 +  registry: source registry (e.g. .Values.controller.image.registry | default .Values.image.registry)
@@ -32,20 +31,20 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/agentgateway/template
 +  {{- $registry -}}
 +{{- end -}}
 +{{- end }}
-
++
 diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/agentgateway/templates/deployment.yaml b/agentgateway/templates/deployment.yaml
---- a/agentgateway/templates/deployment.yaml	2026-04-20 00:00:00
-+++ b/agentgateway/templates/deployment.yaml	2026-04-20 00:00:00
-@@ -27,7 +27,7 @@
-       labels:
-         {{- include "agentgateway.selectorLabels" . | nindent 8 }}
+--- a/agentgateway/templates/deployment.yaml	2026-07-22 14:19:21
++++ b/agentgateway/templates/deployment.yaml	2026-07-22 14:19:21
+@@ -30,7 +30,7 @@
+         {{- toYaml . | nindent 8 }}
+         {{- end }}
      spec:
 -      {{- with .Values.imagePullSecrets }}
 +      {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
        imagePullSecrets:
          {{- toYaml . | nindent 8 }}
        {{- end }}
-@@ -53,7 +53,7 @@
+@@ -56,7 +56,7 @@
                drop:
                - ALL
            {{- end }}
@@ -54,7 +53,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/agentgateway/template
            imagePullPolicy: {{ .Values.controller.image.pullPolicy | default .Values.image.pullPolicy }}
            ports:
              - containerPort: {{ .Values.controller.service.ports.agwGrpc }}
-@@ -90,7 +90,7 @@
+@@ -93,7 +93,7 @@
                  resourceFieldRef:
                    divisor: "1"
                    resource: limits.cpu


### PR DESCRIPTION
**What this PR does / why we need it**:

agentgateway renumbered its chart versioning: the old lineage ended at 2.2.x (Feb 2026), the current line restarted at v1.0. Both live in the same OCI repo, and 2.2.1 semver-sorts above 1.3.1, so dependabot bumped both charts into the obsolete lineage (#504, #508).

| Dep | Was | Now |
|---|---|---|
| `agentgateway-crds` | v2.2.1 (dead pre-v1.0 lineage) | v1.3.1 |
| `agentgateway` | v2.2.1 (dead pre-v1.0 lineage) | v1.3.1 |

Both deps are now on dependabot's ignore list: besides the 2.x trap, upstream minors are breaking (v1alpha1 CRDs), so bumps stay manual.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

`hack/patches/agentgateway.patch` applies cleanly to the v1.3.1 chart; verified the `global.imageRegistry` rewrite still renders. Same fix in the EE repo: kubermatic/kubelb-ee#469.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```