### PR TITLE
ci: verify addon chart patches apply cleanly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,9 @@ verify-imports:  ## Run verify-imports code.
 verify-helm-lock:  ## Verify Helm chart lock files are in sync.
 	./hack/verify-helm-lock.sh
 
+verify-addons-patches:  ## Verify addon chart patches apply cleanly.
+	./hack/verify-addons-patches.sh
+
 clean:  ## Clean binaries
 	rm -rf bin/*
 	@cd cli && $(MAKE) clean

--- a/hack/build-addons-chart-deps.sh
+++ b/hack/build-addons-chart-deps.sh
@@ -20,6 +20,9 @@
 #
 # Usage:
 #   ./hack/build-addons-chart-deps.sh [chart-dir]
+#
+# STRICT_PATCH=true forces git apply, which rejects fuzz that `patch` would
+# silently tolerate. Used by hack/verify-addons-patches.sh in CI.
 
 set -euo pipefail
 
@@ -56,7 +59,7 @@ for tgz in "${CHARTS_SUBDIR}"/*.tgz; do
 
   if [ -f "$patch_file" ]; then
     echo "Applying patch: ${patch_file}"
-    if command -v patch > /dev/null 2>&1; then
+    if [ "${STRICT_PATCH:-false}" != "true" ] && command -v patch > /dev/null 2>&1; then
       patch -d "${CHARTS_SUBDIR}" -p1 < "$patch_file"
     else
       git apply --unsafe-paths --directory="${CHARTS_SUBDIR}" -p1 "$patch_file"

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -28,6 +28,7 @@ echodate "Installing tools..."
 
 apt-get update -qq && apt-get install -y -qq yamllint > /dev/null 2>&1 &
 curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.17.0 bash > /dev/null 2>&1 &
+curl -fsSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 && chmod +x /usr/local/bin/yq &
 go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 &
 go install go.xrstf.de/gimps@v0.6.2 &
 go install github.com/kubermatic-labs/boilerplate@v0.3.0 &

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -72,6 +72,7 @@ try() {
 }
 
 try "Verify Helm lock" ./hack/verify-helm-lock.sh
+try "Verify addons patches" make verify-addons-patches
 try "Verify go.mod" make check-dependencies
 try "Verify YAML" yamllint -c .yamllint.conf .
 try "Verify boilerplate" make verify-boilerplate

--- a/hack/verify-addons-patches.sh
+++ b/hack/verify-addons-patches.sh
@@ -25,6 +25,10 @@ cd $(dirname $0)/..
 
 CHARTS_SUBDIR="charts/kubelb-addons/charts"
 
+# Register the HTTP(S) addon repos; helm dependency build needs them for
+# non-OCI deps (ingress-nginx, external-dns). Requires yq.
+./hack/ensure-helm-repos.sh
+
 STRICT_PATCH=true ./hack/build-addons-chart-deps.sh
 
 rejects="$(find "${CHARTS_SUBDIR}" -name '*.rej' 2> /dev/null || true)"

--- a/hack/verify-addons-patches.sh
+++ b/hack/verify-addons-patches.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The KubeLB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that every hack/patches/*.patch applies cleanly against the pinned
+# addon chart dependencies. Runs the real build script in strict mode so a
+# chart bump that drifts a patch (or renames a chart, orphaning its patch)
+# fails CI instead of surfacing at release time.
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+
+CHARTS_SUBDIR="charts/kubelb-addons/charts"
+
+STRICT_PATCH=true ./hack/build-addons-chart-deps.sh
+
+rejects="$(find "${CHARTS_SUBDIR}" -name '*.rej' 2> /dev/null || true)"
+if [ -n "$rejects" ]; then
+  echo "ERROR: patch rejects found:"
+  echo "$rejects"
+  exit 1
+fi
+
+for patch_file in hack/patches/*.patch; do
+  chart_name="$(basename "$patch_file" .patch)"
+  if [ ! -d "${CHARTS_SUBDIR}/${chart_name}" ]; then
+    echo "ERROR: ${patch_file} matches no addon chart dependency, so it is never applied."
+    echo "Rename it to match the chart directory under ${CHARTS_SUBDIR}, or delete it."
+    exit 1
+  fi
+done
+
+echo "All addon chart patches applied cleanly."


### PR DESCRIPTION
**What this PR does / why we need it**:

Nothing in CI runs `hack/build-addons-chart-deps.sh`, so the air-gap patches under `hack/patches/` are never exercised on a PR. When Dependabot bumped cert-manager to 1.21.0 (#499), the chart renamed its `image` helm helper to `cert-manager.image` and 6 of 8 cert-manager patch hunks stopped applying. CI stayed green; the break only surfaced later and was fixed in #524.

This adds `hack/verify-addons-patches.sh`, wired into `hack/ci/verify.sh` (the `pull-kubelb-verify` job) and exposed as `make verify-addons-patches`. It runs the real build script with `STRICT_PATCH=true`, which forces `git apply` instead of local `patch` so fuzz that `patch` silently tolerates is rejected. It fails on any `*.rej` file and flags any `hack/patches/*.patch` whose chart dependency no longer exists (an orphaned patch that would silently never apply).

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore
/kind flake

**Special notes for your reviewer**:

Verified locally against the pinned deps: passes on current patches, and fails with a non-zero exit on the pre-#524 stale cert-manager patch.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```