### PR TITLE
feat(addons): add valkey and envoy ratelimit subcharts

### DIFF
--- a/charts/kubelb-addons/Chart.lock
+++ b/charts/kubelb-addons/Chart.lock
@@ -20,5 +20,11 @@ dependencies:
 - name: agentgateway
   repository: oci://cr.agentgateway.dev/charts
   version: v1.3.1
-digest: sha256:20f84bc9fbbc458128e050b77e5885206d820fc69e97df6b4e7839f275685f13
-generated: "2026-07-22T12:29:22.196353+05:00"
+- name: valkey
+  repository: oci://ghcr.io/valkey-io/valkey-helm
+  version: 0.10.0
+- name: ratelimit
+  repository: file://./ratelimit
+  version: 0.1.0
+digest: sha256:5277458f8ac4c74382bb97c07d49649a8338301e510aac1bc6c025c29258361e
+generated: "2026-07-22T16:48:10.87871+05:00"

--- a/charts/kubelb-addons/Chart.yaml
+++ b/charts/kubelb-addons/Chart.yaml
@@ -39,3 +39,11 @@ dependencies:
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway.enabled
     version: v1.3.1
+  - name: valkey
+    repository: oci://ghcr.io/valkey-io/valkey-helm
+    condition: valkey.enabled
+    version: 0.10.0
+  - name: ratelimit
+    repository: file://./ratelimit
+    condition: ratelimit.enabled
+    version: 0.1.0

--- a/charts/kubelb-addons/README.md
+++ b/charts/kubelb-addons/README.md
@@ -87,12 +87,14 @@ These are the default values to use when Gateway API is disabled for KubeLB in f
 
 | Repository | Name | Version |
 |------------|------|---------|
+| file://./ratelimit | ratelimit | 0.1.0 |
 | https://kubernetes-sigs.github.io/external-dns | external-dns | 1.20.0 |
 | https://kubernetes.github.io/ingress-nginx | ingress-nginx | 4.15.1 |
-| oci://cr.agentgateway.dev/charts | agentgateway | v1.1.0 |
-| oci://cr.agentgateway.dev/charts | agentgateway-crds | v1.1.0 |
+| oci://cr.agentgateway.dev/charts | agentgateway | v1.3.1 |
+| oci://cr.agentgateway.dev/charts | agentgateway-crds | v1.3.1 |
 | oci://docker.io/envoyproxy | envoy-gateway(gateway-helm) | 1.7.2 |
-| oci://quay.io/jetstack/charts | cert-manager | v1.20.2 |
+| oci://ghcr.io/valkey-io/valkey-helm | valkey | 0.10.0 |
+| oci://quay.io/jetstack/charts | cert-manager | 1.21.0 |
 | oci://quay.io/metallb/chart | metallb | 0.15.3 |
 
 ## Values
@@ -132,6 +134,8 @@ These are the default values to use when Gateway API is disabled for KubeLB in f
 | global.imageRegistry | string | `""` | Override the registry for all images (prefix replacement). When set, all supported addon images are rewritten to this registry host. |
 | ingress-nginx | object | `{"enabled":false}` | ---------------------------------------------------------- |
 | metallb.enabled | bool | `false` |  |
+| ratelimit.enabled | bool | `false` |  |
+| valkey.enabled | bool | `false` |  |
 
 ## Maintainers
 

--- a/charts/kubelb-addons/ratelimit/Chart.yaml
+++ b/charts/kubelb-addons/ratelimit/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: ratelimit
+description: Envoy global rate limit service (RLS) backing agentgateway global rate-limit policies
+type: application
+version: 0.1.0
+# Upstream envoyproxy/ratelimit publishes no semver releases since v1.4.0;
+# images are tagged with commit SHAs. appVersion tracks the pinned SHA.
+appVersion: "1e50889b"
+maintainers:
+  - name: Kubermatic
+    email: support@kubermatic.com
+    url: https://kubermatic.com

--- a/charts/kubelb-addons/ratelimit/README.md
+++ b/charts/kubelb-addons/ratelimit/README.md
@@ -1,0 +1,36 @@
+# ratelimit
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1e50889b](https://img.shields.io/badge/AppVersion-1e50889b-informational?style=flat-square)
+
+Envoy global rate limit service (RLS) backing agentgateway global rate-limit policies
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Kubermatic | <support@kubermatic.com> | <https://kubermatic.com> |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| config.configMapName | string | `"ratelimit-config"` |  |
+| config.create | bool | `false` |  |
+| config.inline | object | `{}` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"envoyproxy/ratelimit"` |  |
+| image.tag | string | `"1e50889b"` |  |
+| imagePullSecrets | list | `[]` |  |
+| logLevel | string | `"info"` |  |
+| nodeSelector | object | `{}` |  |
+| redis.authSecretName | string | `""` |  |
+| redis.url | string | `""` |  |
+| replicaCount | int | `2` |  |
+| resources | object | `{}` |  |
+| service.grpcPort | int | `8081` |  |
+| service.httpPort | int | `8080` |  |
+| service.metricsPort | int | `9090` |  |
+| tolerations | list | `[]` |  |
+

--- a/charts/kubelb-addons/ratelimit/templates/_helpers.tpl
+++ b/charts/kubelb-addons/ratelimit/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{- define "ratelimit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ratelimit.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ratelimit.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{ include "ratelimit.selectorLabels" . }}
+{{- end -}}
+
+{{- define "ratelimit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ratelimit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "ratelimit.image" -}}
+{{- $registry := .Values.image.registry -}}
+{{- if and .Values.global .Values.global.imageRegistry -}}
+{{- $registry = .Values.global.imageRegistry -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+
+{{- define "ratelimit.redisUrl" -}}
+{{- if .Values.redis.url -}}
+{{- .Values.redis.url -}}
+{{- else -}}
+{{- printf "%s-valkey:6379" .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kubelb-addons/ratelimit/templates/configmap.yaml
+++ b/charts/kubelb-addons/ratelimit/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.config.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.config.configMapName }}
+  labels:
+    {{- include "ratelimit.labels" . | nindent 4 }}
+data:
+  {{- range $file, $content := .Values.config.inline }}
+  {{ $file }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kubelb-addons/ratelimit/templates/deployment.yaml
+++ b/charts/kubelb-addons/ratelimit/templates/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ratelimit.fullname" . }}
+  labels:
+    {{- include "ratelimit.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ratelimit.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ratelimit.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ratelimit.fullname" . }}
+      containers:
+        - name: ratelimit
+          image: {{ include "ratelimit.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/ratelimit"]
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel | quote }}
+            - name: USE_STATSD
+              value: "false"
+            - name: USE_PROMETHEUS
+              value: "true"
+            - name: PROMETHEUS_ADDR
+              value: ":{{ .Values.service.metricsPort }}"
+            - name: GRPC_PORT
+              value: {{ .Values.service.grpcPort | quote }}
+            - name: PORT
+              value: {{ .Values.service.httpPort | quote }}
+            - name: REDIS_SOCKET_TYPE
+              value: tcp
+            - name: REDIS_URL
+              value: {{ include "ratelimit.redisUrl" . }}
+            {{- if .Values.redis.authSecretName }}
+            - name: REDIS_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.authSecretName }}
+                  key: password
+            {{- end }}
+            # Config files are read from RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/
+            # RUNTIME_APPDIRECTORY. RUNTIME_WATCH_ROOT=false watches that
+            # directory directly, which is what fires on the kubelet symlink
+            # swap when the mounted ConfigMap changes; the default root-watch
+            # mode expects Lyft's runtime-deploy layout and never triggers.
+            - name: RUNTIME_ROOT
+              value: /data
+            - name: RUNTIME_SUBDIRECTORY
+              value: ratelimit
+            - name: RUNTIME_APPDIRECTORY
+              value: config
+            - name: RUNTIME_WATCH_ROOT
+              value: "false"
+            - name: RUNTIME_IGNOREDOTFILES
+              value: "true"
+            - name: FORCE_START_WITHOUT_INITIAL_CONFIG
+              value: "true"
+            - name: MERGE_DOMAIN_CONFIG
+              value: "true"
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.service.grpcPort }}
+            - name: http
+              containerPort: {{ .Values.service.httpPort }}
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /data/ratelimit/config
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.config.configMapName }}
+            optional: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kubelb-addons/ratelimit/templates/poddisruptionbudget.yaml
+++ b/charts/kubelb-addons/ratelimit/templates/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+# agentgateway rate-limit policies default to FailClosed, so losing every RLS
+# pod at once blocks all rate-limited traffic.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ratelimit.fullname" . }}
+  labels:
+    {{- include "ratelimit.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "ratelimit.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/kubelb-addons/ratelimit/templates/service.yaml
+++ b/charts/kubelb-addons/ratelimit/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ratelimit.fullname" . }}
+  labels:
+    {{- include "ratelimit.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "ratelimit.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc
+      port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+    - name: http
+      port: {{ .Values.service.httpPort }}
+      targetPort: http
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: metrics

--- a/charts/kubelb-addons/ratelimit/templates/serviceaccount.yaml
+++ b/charts/kubelb-addons/ratelimit/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ratelimit.fullname" . }}
+  labels:
+    {{- include "ratelimit.labels" . | nindent 4 }}

--- a/charts/kubelb-addons/ratelimit/values.yaml
+++ b/charts/kubelb-addons/ratelimit/values.yaml
@@ -1,0 +1,55 @@
+# Envoy global rate limit service (github.com/envoyproxy/ratelimit).
+# Backs agentgateway global rate-limit policies. The KubeLB manager owns the
+# descriptor ConfigMap at runtime; this chart only provisions the service and
+# its wiring.
+
+image:
+  registry: docker.io
+  repository: envoyproxy/ratelimit
+  # Upstream tags are bare commit SHAs (no semver since v1.4.0). This pin
+  # tracks the SHA Envoy Gateway blesses in its current release branch.
+  tag: "1e50889b"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Two replicas because agentgateway rate-limit policies default to
+# FailClosed: an RLS outage blocks all traffic on rate-limited routes.
+# Counters live in the Redis-protocol backend, replicas need no coordination.
+replicaCount: 2
+
+logLevel: info
+
+redis:
+  # Redis-protocol endpoint as host:port. When empty, defaults to the valkey
+  # subchart's service in the same release: <release-name>-valkey:6379.
+  url: ""
+  # Name of a Secret holding the auth password under the key `password`,
+  # injected as REDIS_AUTH. Empty means no authentication.
+  authSecretName: ""
+
+config:
+  # Name of the ConfigMap carrying ratelimit domain YAML files. Mounted as a
+  # whole directory so ConfigMap updates hot-reload through the kubelet
+  # symlink swap (a subPath mount would never see updates). The volume is
+  # marked optional: the KubeLB manager creates and manages this ConfigMap,
+  # and the service starts without it (FORCE_START_WITHOUT_INITIAL_CONFIG).
+  configMapName: ratelimit-config
+  # Set to true to render the ConfigMap from `inline` for standalone use
+  # without the KubeLB manager.
+  create: false
+  # Map of file name to ratelimit domain YAML content.
+  inline: {}
+
+service:
+  # gRPC endpoint agentgateway's rateLimit.global.backendRef targets.
+  grpcPort: 8081
+  # HTTP healthcheck/debug endpoint.
+  httpPort: 8080
+  # Native Prometheus metrics endpoint.
+  metricsPort: 9090
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/kubelb-addons/values.yaml
+++ b/charts/kubelb-addons/values.yaml
@@ -71,3 +71,15 @@ agentgateway-crds:
 ## Agentgateway
 agentgateway:
   enabled: false
+
+## Valkey: counter store for the Envoy global rate-limit service. Single
+## instance, no persistence: counters are TTL'd increments, loss on restart
+## means one window of overcounting at worst.
+valkey:
+  enabled: false
+
+## Envoy global rate limit service (RLS): shared-counter enforcement for
+## agentgateway global rate-limit policies. Requires valkey (or an external
+## Redis-protocol endpoint via ratelimit.redis.url).
+ratelimit:
+  enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds two optional addon subcharts (disabled by default): valkey as a counter store and the Envoy global rate limit service (RLS) that backs agentgateway global rate-limit policies. Bumps agentgateway/agentgateway-crds to v1.3.1. The RLS descriptor ConfigMap is owned by the KubeLB manager at runtime; this chart only provisions the service and its wiring.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add optional valkey and Envoy ratelimit addon subcharts (disabled by default) to the kubelb-addons chart.
```

**Documentation**:
```documentation
NONE
```