### PR TITLE
feat(addons): AI usage recording rules and ratelimit response headers

### DIFF
--- a/charts/kubelb-addons/README.md
+++ b/charts/kubelb-addons/README.md
@@ -103,6 +103,11 @@ These are the default values to use when Gateway API is disabled for KubeLB in f
 |-----|------|---------|-------------|
 | agentgateway-crds.enabled | bool | `false` |  |
 | agentgateway.enabled | bool | `false` |  |
+| aiRecordingRules.configMap.enabled | bool | `false` | Render the same rule file into a plain ConfigMap for vanilla Prometheus (mount it and list it under rule_files). |
+| aiRecordingRules.enabled | bool | `false` | Render the AI usage recording rules. |
+| aiRecordingRules.interval | string | `"1m"` | Evaluation interval for the rule group. |
+| aiRecordingRules.prometheusRule.enabled | bool | `true` | Render a monitoring.coreos.com/v1 PrometheusRule (requires the prometheus-operator CRDs in the cluster). |
+| aiRecordingRules.prometheusRule.labels | object | `{}` | Extra labels for the PrometheusRule, e.g. a `release` label matching the operator's ruleSelector. |
 | cert-manager.config.apiVersion | string | `"controller.config.cert-manager.io/v1alpha1"` |  |
 | cert-manager.config.enableGatewayAPI | bool | `true` |  |
 | cert-manager.config.kind | string | `"ControllerConfiguration"` |  |

--- a/charts/kubelb-addons/ratelimit/templates/deployment.yaml
+++ b/charts/kubelb-addons/ratelimit/templates/deployment.yaml
@@ -67,6 +67,11 @@ spec:
               value: "true"
             - name: MERGE_DOMAIN_CONFIG
               value: "true"
+            # Returns RateLimit-Limit/-Remaining/-Reset for the most exhausted
+            # descriptor; the gateway copies them onto its 429 so clients see
+            # when the window resets.
+            - name: LIMIT_RESPONSE_HEADERS_ENABLED
+              value: "true"
           ports:
             - name: grpc
               containerPort: {{ .Values.service.grpcPort }}

--- a/charts/kubelb-addons/templates/_ai-recording-rules.tpl
+++ b/charts/kubelb-addons/templates/_ai-recording-rules.tpl
@@ -1,0 +1,26 @@
+{{/*
+Recording rule groups for AI usage showback. This is the stable metrics
+contract consumers (the KubeLB Dashboard, customer billing pipelines) bind
+to: kubelb:* series survive upstream agentgateway metric renames, which only
+cost a rule edit here.
+
+Rules record hourly increases rather than calendar windows because recording
+rules cannot parametrize "since Monday"; consumers sum the hourly series over
+whatever window they render. Input/output token splits are preserved so
+token-type budgets can land later without a contract break.
+
+USD rules are deliberately absent until the data-plane cost catalog story
+lands; the cost series name cannot be verified without one.
+*/}}
+{{- define "kubelb-addons.aiRecordingRuleGroups" -}}
+groups:
+  - name: kubelb-ai-usage
+    interval: {{ .Values.aiRecordingRules.interval }}
+    rules:
+      - record: kubelb:ai_tokens:increase1h
+        expr: sum by (tenant_id, key_id, gen_ai_token_type) (increase(agentgateway_gen_ai_client_token_usage_sum{tenant_id!=""}[1h]))
+      - record: kubelb:ai_requests:increase1h
+        expr: sum by (tenant_id, key_id) (increase(agentgateway_gen_ai_client_token_usage_count{tenant_id!="",gen_ai_token_type="input"}[1h]))
+      - record: kubelb:ai_tokens_by_model:increase1h
+        expr: sum by (tenant_id, gen_ai_system, gen_ai_response_model) (increase(agentgateway_gen_ai_client_token_usage_sum{tenant_id!=""}[1h]))
+{{- end -}}

--- a/charts/kubelb-addons/templates/ai-recording-rules.yaml
+++ b/charts/kubelb-addons/templates/ai-recording-rules.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.aiRecordingRules.enabled }}
+{{- if .Values.aiRecordingRules.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kubelb-ai-usage
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: kubelb-addons
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.aiRecordingRules.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- include "kubelb-addons.aiRecordingRuleGroups" . | nindent 2 }}
+{{- end }}
+{{- if .Values.aiRecordingRules.configMap.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubelb-ai-usage-rules
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: kubelb-addons
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  kubelb-ai-usage.rules.yaml: |
+    {{- include "kubelb-addons.aiRecordingRuleGroups" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/kubelb-addons/values.yaml
+++ b/charts/kubelb-addons/values.yaml
@@ -83,3 +83,20 @@ valkey:
 ## Redis-protocol endpoint via ratelimit.redis.url).
 ratelimit:
   enabled: false
+
+aiRecordingRules:
+  # -- Render the AI usage recording rules.
+  enabled: false
+  # -- Evaluation interval for the rule group.
+  interval: 1m
+  prometheusRule:
+    # -- Render a monitoring.coreos.com/v1 PrometheusRule (requires the
+    # prometheus-operator CRDs in the cluster).
+    enabled: true
+    # -- Extra labels for the PrometheusRule, e.g. a `release` label matching
+    # the operator's ruleSelector.
+    labels: {}
+  configMap:
+    # -- Render the same rule file into a plain ConfigMap for vanilla
+    # Prometheus (mount it and list it under rule_files).
+    enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds optional Prometheus recording rules (`kubelb:ai_*` hourly usage series, behind `aiRecordingRules.enabled`, default off) rendered as a PrometheusRule or a plain ConfigMap. Also sets `LIMIT_RESPONSE_HEADERS_ENABLED` on the ratelimit service so `RateLimit-Limit/-Remaining/-Reset` are emitted for the most exhausted descriptor and copied onto 429 responses.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add optional AI usage recording rules (aiRecordingRules, default off) and enable RateLimit response headers on the ratelimit addon.
```

**Documentation**:
```documentation
NONE
```