### PR TITLE
fix(rbac): grant events.k8s.io to manager and CCM

### DIFF
--- a/charts/kubelb-ccm/templates/clusterrole.yaml
+++ b/charts/kubelb-ccm/templates/clusterrole.yaml
@@ -34,6 +34,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 {{- if .Values.kubelb.installGatewayAPICRDs }}
 - apiGroups:
   - apiextensions.k8s.io

--- a/charts/kubelb-manager/templates/clusterrole.yaml
+++ b/charts/kubelb-manager/templates/clusterrole.yaml
@@ -66,6 +66,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gateways

--- a/config/ccm/rbac/role.yaml
+++ b/config/ccm/rbac/role.yaml
@@ -44,6 +44,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gateways

--- a/config/kubelb/rbac/role.yaml
+++ b/config/kubelb/rbac/role.yaml
@@ -41,6 +41,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gateways

--- a/internal/controllers/ccm/shared.go
+++ b/internal/controllers/ccm/shared.go
@@ -39,6 +39,8 @@ const (
 	CleanupFinalizer = "kubelb.k8c.io/cleanup"
 )
 
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+
 func reconcileSourceForRoute(ctx context.Context, log logr.Logger, client ctrlclient.Client, lbClient ctrlclient.Client, resource ctrlclient.Object, originalServices []types.NamespacedName, namespace string) error {
 	log.V(2).Info("reconciling source for producing route")
 

--- a/internal/controllers/kubelb/route_controller.go
+++ b/internal/controllers/kubelb/route_controller.go
@@ -89,6 +89,7 @@ type RouteReconciler struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=grpcroutes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=grpcroutes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 func (r *RouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("name", req.NamespacedName)


### PR DESCRIPTION
**What this PR does / why we need it**:

The Route reconciler emits a `ServiceApplyFailed` event, and six CCM controllers hold an `EventRecorder`. No ClusterRole granted `events.k8s.io`, so every emission was rejected by the API server and the events never showed up on the object.

Adds the kubebuilder marker on both sides, regenerates `config/*/rbac/role.yaml`, and mirrors the rule into both chart ClusterRoles.

**What type of PR is this?**
/kind bug

```release-note
Fix manager and CCM ClusterRoles missing permission to create events, which silently dropped every event the controllers emitted.
```

```documentation
NONE
```