### PR TITLE
fix(xds): keepalive, graceful drain, NACK visibility, logr logger

### DIFF
--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -98,6 +98,7 @@ Metrics exposed by the KubeLB Envoy Control Plane component.
 | `kubelb_envoy_control_plane_snapshot_generation_duration_seconds` | Histogram | Duration of Envoy snapshot generation in seconds | `snapshot_name` |
 | `kubelb_envoy_control_plane_snapshot_updates_total` | Counter | Total number of Envoy snapshot updates | `snapshot_name` |
 | `kubelb_envoy_control_plane_snapshots` | Gauge | Current number of active Envoy snapshots | - |
+| `kubelb_envoy_control_plane_xds_nacks_total` | Counter | Total number of xDS config rejections (NACKs) received from Envoy | `type_url` |
 
 ---
 

--- a/internal/envoy/logger.go
+++ b/internal/envoy/logger.go
@@ -17,36 +17,43 @@ limitations under the License.
 package envoy
 
 import (
-	"log"
+	"fmt"
+
+	envoylog "github.com/envoyproxy/go-control-plane/pkg/log"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// An example of a logger that implements `pkg/log/Logger`.  Logs to
-// stdout.  If Debug == false then Debugf() and Infof() won't output
-// anything.
+// xdsLog is shared with the xDS stream callbacks in server.go.
+var xdsLog = log.Log.WithName("envoy-xds")
+
+// Logger routes go-control-plane's logging through logr. go-control-plane calls
+// it from inside stream callbacks, where the std log package's global stderr
+// mutex becomes a contention point during reconnect storms.
+//
+// Debug gates the verbose levels; warnings and errors are always emitted.
 type Logger struct {
 	Debug bool
 }
 
-// Log to stdout only if Debug is true.
+var _ envoylog.Logger = Logger{}
+
 func (logger Logger) Debugf(format string, args ...interface{}) {
 	if logger.Debug {
-		log.Printf(format+"\n", args...)
+		xdsLog.V(2).Info(fmt.Sprintf(format, args...))
 	}
 }
 
-// Log to stdout only if Debug is true.
 func (logger Logger) Infof(format string, args ...interface{}) {
 	if logger.Debug {
-		log.Printf(format+"\n", args...)
+		xdsLog.V(1).Info(fmt.Sprintf(format, args...))
 	}
 }
 
-// Log to stdout always.
 func (logger Logger) Warnf(format string, args ...interface{}) {
-	log.Printf(format+"\n", args...)
+	xdsLog.Info(fmt.Sprintf(format, args...))
 }
 
-// Log to stdout always.
 func (logger Logger) Errorf(format string, args ...interface{}) {
-	log.Printf(format+"\n", args...)
+	xdsLog.Error(nil, fmt.Sprintf(format, args...))
 }

--- a/internal/envoy/server.go
+++ b/internal/envoy/server.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
@@ -34,6 +35,7 @@ import (
 	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 
 	"k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 	envoycpmetrics "k8c.io/kubelb/internal/metricsutil/envoycp"
@@ -41,6 +43,26 @@ import (
 
 const (
 	grpcMaxConcurrentStreams = 1000000
+
+	// xDS streams are long-lived and mostly idle, so a proxy that dies without
+	// closing its TCP connection is otherwise only reaped by kernel timeouts and
+	// its stream state leaks on the manager for hours.
+	grpcKeepaliveTime    = 30 * time.Second
+	grpcKeepaliveTimeout = 10 * time.Second
+
+	// Bounding connection lifetime lets proxies redistribute over manager
+	// replicas instead of pinning to whichever one they first reached. gRPC
+	// closes an aged connection with GOAWAY plus this grace period, so the proxy
+	// reconnects without ever seeing a mid-response reset.
+	grpcMaxConnectionAge      = 30 * time.Minute
+	grpcMaxConnectionAgeGrace = 5 * time.Minute
+
+	// Envoy's own keepalive must not be rejected as too aggressive, which would
+	// have the server tear the connection down as a policy violation.
+	grpcKeepaliveMinTime = 10 * time.Second
+
+	// Cap on draining so a stuck stream cannot block manager shutdown forever.
+	grpcGracefulStopTimeout = 30 * time.Second
 )
 
 func registerServer(grpcServer *grpc.Server, server serverv3.Server) {
@@ -85,7 +107,6 @@ func (s *Server) UpdateConfig(config *v1alpha1.Config) {
 
 // Start the Envoy control plane server.
 func (s *Server) Start(ctx context.Context) error {
-	// Create a Cache
 	srv3 := serverv3.NewServer(ctx, s.Cache, &serverv3.CallbackFuncs{
 		StreamOpenFunc: func(_ context.Context, _ int64, _ string) error {
 			envoycpmetrics.GRPCConnectionsTotal.Inc()
@@ -96,10 +117,21 @@ func (s *Server) Start(ctx context.Context) error {
 		},
 		StreamRequestFunc: func(_ int64, req *discoveryv3.DiscoveryRequest) error {
 			envoycpmetrics.GRPCRequestsTotal.WithLabelValues(req.GetTypeUrl()).Inc()
+			// A DiscoveryRequest carrying an ErrorDetail is a NACK: Envoy rejected
+			// the config we pushed. Surface it so a rejected snapshot is not
+			// silently invisible on the control plane.
+			if detail := req.GetErrorDetail(); detail != nil {
+				envoycpmetrics.XDSNACKsTotal.WithLabelValues(req.GetTypeUrl()).Inc()
+				xdsLog.Info("Envoy NACKed xDS config",
+					"type_url", req.GetTypeUrl(),
+					"version", req.GetVersionInfo(),
+					"nonce", req.GetResponseNonce(),
+					"error", detail.GetMessage())
+			}
 			return nil
 		},
-		StreamResponseFunc: func(_ context.Context, _ int64, _ *discoveryv3.DiscoveryRequest, resp *discoveryv3.DiscoveryResponse) {
-			envoycpmetrics.GRPCResponsesTotal.WithLabelValues(resp.GetTypeUrl()).Inc()
+		StreamResponseFunc: func(_ context.Context, _ int64, req *discoveryv3.DiscoveryRequest, _ *discoveryv3.DiscoveryResponse) {
+			envoycpmetrics.GRPCResponsesTotal.WithLabelValues(req.GetTypeUrl()).Inc()
 		},
 	})
 
@@ -108,7 +140,19 @@ func (s *Server) Start(ctx context.Context) error {
 	// a single connection to the management server, then it might lead to
 	// availability problems.
 	var grpcOptions []grpc.ServerOption
-	grpcOptions = append(grpcOptions, grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams))
+	grpcOptions = append(grpcOptions,
+		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:                  grpcKeepaliveTime,
+			Timeout:               grpcKeepaliveTimeout,
+			MaxConnectionAge:      grpcMaxConnectionAge,
+			MaxConnectionAgeGrace: grpcMaxConnectionAgeGrace,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             grpcKeepaliveMinTime,
+			PermitWithoutStream: true,
+		}),
+	)
 	grpcServer := grpc.NewServer(grpcOptions...)
 
 	var lc net.ListenConfig
@@ -119,8 +163,24 @@ func (s *Server) Start(ctx context.Context) error {
 
 	registerServer(grpcServer, srv3)
 
-	// s.Log.Infow("starting management service", "listen-address", s.listenAddress)
-	if err = grpcServer.Serve(lis); err != nil {
+	// Drain on shutdown. Serve does not observe ctx, so without this the process
+	// exits with every ADS stream still open and the whole proxy fleet
+	// reconnects at once against the next manager.
+	go func() {
+		<-ctx.Done()
+		stopped := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(stopped)
+		}()
+		select {
+		case <-stopped:
+		case <-time.After(grpcGracefulStopTimeout):
+			grpcServer.Stop()
+		}
+	}()
+
+	if err = grpcServer.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 		return errors.Wrap(err, "envoy control plane server failed while start serving incoming connections")
 	}
 

--- a/internal/envoy/server_test.go
+++ b/internal/envoy/server_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+)
+
+// On shutdown the xDS server must drain its streams. Without it the process
+// exits with every ADS stream still open, so each connected proxy sees a reset
+// mid-response and the whole fleet reconnects at once.
+func TestServerStartDrainsOnContextCancellation(t *testing.T) {
+	server, err := NewServer(&v1alpha1.Config{}, "127.0.0.1:0", false)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- server.Start(ctx) }()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start() returned error = %v, want clean shutdown", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Start() did not return after context cancellation")
+	}
+}

--- a/internal/metricsutil/envoycp/metrics.go
+++ b/internal/metricsutil/envoycp/metrics.go
@@ -100,14 +100,23 @@ var (
 	GRPCRequestsTotal = factory.NewCounterVec(
 		"grpc_requests_total",
 		"Total number of gRPC xDS requests",
-		[]string{"type_url"},
+		[]string{metricsutil.LabelTypeURL},
 	)
 
 	// GRPCResponsesTotal counts the total number of gRPC responses.
 	GRPCResponsesTotal = factory.NewCounterVec(
 		"grpc_responses_total",
 		"Total number of gRPC xDS responses",
-		[]string{"type_url"},
+		[]string{metricsutil.LabelTypeURL},
+	)
+
+	// XDSNACKsTotal counts xDS config rejections (NACKs) from Envoy, labeled by
+	// resource type. A rejected snapshot is otherwise invisible on the
+	// control-plane side.
+	XDSNACKsTotal = factory.NewCounterVec(
+		"xds_nacks_total",
+		"Total number of xDS config rejections (NACKs) received from Envoy",
+		[]string{metricsutil.LabelTypeURL},
 	)
 )
 
@@ -176,6 +185,7 @@ func allCollectors() []prometheus.Collector {
 		GRPCConnectionsTotal,
 		GRPCRequestsTotal,
 		GRPCResponsesTotal,
+		XDSNACKsTotal,
 		// Cache metrics
 		CacheHitsTotal,
 		CacheMissesTotal,

--- a/internal/metricsutil/metrics.go
+++ b/internal/metricsutil/metrics.go
@@ -37,6 +37,7 @@ const (
 	LabelTopology     = "topology"
 	LabelOperation    = "operation"
 	LabelSnapshotName = "snapshot_name"
+	LabelTypeURL      = "type_url"
 )
 
 // Result label values for reconciliation outcomes.


### PR DESCRIPTION
**What this PR does / why we need it**:

Four fixes to the xDS server, all on the transport and observability side. No change to what goes into a snapshot.

| Change | Why |
|---|---|
| gRPC keepalive (`Time` 30s, `Timeout` 10s) | xDS streams are long-lived and mostly idle, so a proxy that dies without closing its TCP connection was only reaped by kernel timeouts and leaked stream state for hours |
| `MaxConnectionAge` 30m + 5m grace | proxies pinned to whichever manager replica they first reached and never redistributed. gRPC closes an aged connection with GOAWAY plus the grace period, so the proxy reconnects without seeing a mid-response reset |
| `KeepaliveEnforcementPolicy` `MinTime` 10s, `PermitWithoutStream` | Envoy's own keepalive would otherwise be rejected as too aggressive and the server would tear the connection down as a policy violation |
| `GracefulStop` on context cancellation, capped at 30s | `Serve` does not observe ctx, so the process exited with every ADS stream open and the whole fleet reconnected at once |

Also adds `kubelb_envoy_control_plane_xds_nacks_total` plus a log line when a `DiscoveryRequest` carries an `ErrorDetail`. A NACK means Envoy rejected the config we pushed, and until now that was invisible on the control plane side.

`internal/envoy/logger.go` moves from the std `log` package to logr. go-control-plane calls it from inside stream callbacks, where the std package's global stderr mutex becomes a contention point during reconnect storms.

`type_url` became a shared label constant since it now appears on three metrics.

**What type of PR is this?**
/kind bug

```release-note
Envoy control plane now uses gRPC keepalive and bounded connection age, drains xDS streams on shutdown, and exports `kubelb_envoy_control_plane_xds_nacks_total` for configs rejected by Envoy.
```

```documentation
NONE
```