### PR TITLE
fix(xds): stable snapshot versions and cold-cache consistency check

### DIFF
--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -150,32 +150,26 @@ func (r *EnvoyCPReconciler) updateCache(ctx context.Context, snapshotName string
 		return err
 	}
 
+	desiredVersion := desiredSnapshot.GetVersion(envoyresource.ClusterType)
 	currentSnapshot, err := r.EnvoyCache.GetSnapshot(snapshotName)
 	if err != nil {
 		envoycpmetrics.CacheMissesTotal.WithLabelValues(snapshotName).Inc()
-		log.Info("init snapshot", "service-node", snapshotName, "version", desiredSnapshot.GetVersion(envoyresource.ClusterType))
-		if err := r.EnvoyCache.SetSnapshot(ctx, snapshotName, desiredSnapshot); err != nil {
-			return err
+		log.Info("init snapshot", "service-node", snapshotName, "version", desiredVersion)
+	} else {
+		envoycpmetrics.CacheHitsTotal.WithLabelValues(snapshotName).Inc()
+		if currentSnapshot.GetVersion(envoyresource.ClusterType) == desiredVersion {
+			log.V(2).Info("snapshot is in desired state")
+			return nil
 		}
-		r.recordSnapshotMetrics(snapshotName, desiredSnapshot)
-		managermetrics.EnvoyCPSnapshotUpdatesTotal.WithLabelValues(snapshotName).Inc()
-		envoycpmetrics.SnapshotUpdatesTotal.WithLabelValues(snapshotName).Inc()
-		return nil
-	}
-	envoycpmetrics.CacheHitsTotal.WithLabelValues(snapshotName).Inc()
-
-	lastUsedVersion := currentSnapshot.GetVersion(envoyresource.ClusterType)
-	desiredVersion := desiredSnapshot.GetVersion(envoyresource.ClusterType)
-	if lastUsedVersion == desiredVersion {
-		log.V(2).Info("snapshot is in desired state")
-		return nil
+		log.Info("updating snapshot", "service-node", snapshotName, "version", desiredVersion)
 	}
 
+	// Validated on both the init and update paths: an inconsistent snapshot (a
+	// cluster without its endpoints) must never reach a proxy, and a cold cache
+	// is exactly when a bad first snapshot would go out unnoticed.
 	if err := desiredSnapshot.Consistent(); err != nil {
 		return fmt.Errorf("new Envoy config snapshot is not consistent: %w", err)
 	}
-
-	log.Info("updating snapshot", "service-node", snapshotName, "version", desiredSnapshot.GetVersion(envoyresource.ClusterType))
 
 	if err := r.EnvoyCache.SetSnapshot(ctx, snapshotName, desiredSnapshot); err != nil {
 		return fmt.Errorf("failed to set a new Envoy cache snapshot: %w", err)

--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"sort"
 	"strings"
 	"time"
 
@@ -237,6 +238,15 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 			}
 		}
 	}
+
+	// The source LoadBalancers/Routes arrive in controller-runtime cache order,
+	// which is Go map order and therefore varies between reconciles. Sorting here
+	// keeps both the version hash below and the first-wins choice in
+	// dedupListenersByAddress stable, so an unchanged config keeps its version
+	// instead of republishing to every connected proxy on every reconcile.
+	sortResourcesByName(cluster)
+	sortResourcesByName(listener)
+	sortResourcesByName(endpoints)
 
 	listener = dedupListenersByAddress(listener, snapshotName)
 
@@ -692,6 +702,12 @@ func makeHTTPListener(listenerName string, clusterName string, listenerPort uint
 			}},
 		}},
 	}
+}
+
+func sortResourcesByName(resources []types.Resource) {
+	sort.Slice(resources, func(i, j int) bool {
+		return envoycache.GetResourceName(resources[i]) < envoycache.GetResourceName(resources[j])
+	})
 }
 
 // dedupListenersByAddress drops listeners with duplicate bind addresses before

--- a/internal/envoy/resource_test.go
+++ b/internal/envoy/resource_test.go
@@ -18,6 +18,7 @@ package envoy
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -623,6 +624,42 @@ func ingressSourceRoute() kubelbv1alpha1.Route {
 				},
 			},
 		},
+	}
+}
+
+// The manager lists LoadBalancers and Routes through the controller-runtime
+// cache, whose List() returns items in Go map iteration order. If the snapshot
+// version depended on that order it would churn on every reconcile,
+// republishing an unchanged config to every connected proxy.
+func TestMapSnapshot_VersionIsIndependentOfResourceOrder(t *testing.T) {
+	ctx := context.Background()
+	cl := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	lbs := make([]kubelbv1alpha1.LoadBalancer, 0, 3)
+	for i, name := range []string{"lb-a", "lb-b", "lb-c"} {
+		lb := inlineAddressLB()
+		lb.Name = name
+		lb.Spec.Endpoints[0].Addresses[0].IP = fmt.Sprintf("10.0.1.%d", i+1)
+		lbs = append(lbs, lb)
+	}
+
+	pa := portlookup.NewPortAllocator()
+	if err := pa.AllocatePortsForLoadBalancers(kubelbv1alpha1.LoadBalancerList{Items: lbs}); err != nil {
+		t.Fatalf("allocate LB ports: %v", err)
+	}
+
+	versionFor := func(in []kubelbv1alpha1.LoadBalancer) string {
+		t.Helper()
+		snap, err := MapSnapshot(ctx, cl, in, nil, pa, "test-node", ResolveHeaderLimits(nil))
+		if err != nil {
+			t.Fatalf("MapSnapshot: %v", err)
+		}
+		return snap.GetVersion(resource.ClusterType)
+	}
+
+	reversed := []kubelbv1alpha1.LoadBalancer{lbs[2], lbs[1], lbs[0]}
+	if got, want := versionFor(reversed), versionFor(lbs); got != want {
+		t.Errorf("snapshot version depends on input order: %q != %q", got, want)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Two fixes in the snapshot path.

**Version churn.** `MapSnapshot` appended clusters, listeners and endpoints in the order the LoadBalancers and Routes arrived, which is controller-runtime cache order, which is Go map order. The version hash is computed over the marshalled resources in that order, so an unchanged config could produce a different version on every reconcile and republish to every connected proxy. Sorting by resource name before hashing also makes the first-wins choice in `dedupListenersByAddress` deterministic.

`TestMapSnapshot_VersionIsIndependentOfResourceOrder` covers it. Confirmed it fails without the sort:

```
snapshot version depends on input order: "ce76cbd7..." != "ee6d8244..."
```

**Consistency check on the init path.** `Consistent()` only ran when a snapshot already existed in the cache. A cold cache is exactly when a bad first snapshot would go out unnoticed, so the init and update paths are now merged and both validate before `SetSnapshot`.

**What type of PR is this?**
/kind bug

```release-note
Envoy snapshot versions no longer change when the underlying config is unchanged, which stopped needless xDS pushes to every connected proxy. Snapshot consistency is now validated on the first push as well as subsequent ones.
```

```documentation
NONE
```