### PR TITLE
fix(envoy-cp): reconcile on tenant deletion so the snapshot is cleared

### DIFF
--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -698,8 +698,12 @@ func tenantSpecChangedPredicate() predicate.Predicate {
 			}
 			return false
 		},
-		CreateFunc:  func(_ event.CreateEvent) bool { return false },
-		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		CreateFunc: func(_ event.CreateEvent) bool { return false },
+		// Deletion must reconcile. The SnapshotCache entry for a tenant lives for
+		// the manager's process lifetime, and once the tenant namespace is gone
+		// the namespace-scoped watches stop delivering anything that would clear
+		// it, because their predicate resolves the namespace on every event.
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
 }

--- a/internal/controllers/kubelb/envoy_cp_controller_test.go
+++ b/internal/controllers/kubelb/envoy_cp_controller_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelb
+
+import (
+	"testing"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// The xDS SnapshotCache is keyed by tenant namespace and holds an entry for the
+// process lifetime. Tenant deletion must reconcile so that entry is cleared,
+// otherwise it survives until the manager restarts.
+func TestTenantSpecChangedPredicateTriggersOnDelete(t *testing.T) {
+	if !tenantSpecChangedPredicate().Delete(event.DeleteEvent{Object: &kubelbv1alpha1.Tenant{}}) {
+		t.Fatal("tenant deletion must enqueue a reconcile so the tenant's snapshot is cleared")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`tenantSpecChangedPredicate` returned `false` from `DeleteFunc`, so deleting a Tenant never enqueued a reconcile.

The xDS `SnapshotCache` entry is keyed by tenant namespace and lives for the manager's process lifetime. Nothing else clears it: once the tenant namespace is gone the namespace-scoped watches stop delivering, because their predicate resolves the namespace on every event. The entry survived until the manager restarted.

**What type of PR is this?**
/kind bug

```release-note
Deleting a Tenant now clears its Envoy snapshot from the xDS cache instead of leaving it until the manager restarts.
```

```documentation
NONE
```