### PR TITLE
chore(ci): pin setup-envtest and quote retry args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ GO_VERSION = 1.26.5
 HELM_DOCS_VERSION ?= v1.14.2
 CRD_REF_DOCS_VERSION ?= v0.3.0
 CHAINSAW_VERSION ?= v0.2.14
+# Nested module, tagged tools/setup-envtest/vX.Y.Z. Must be a tag: a branch ref
+# makes go install fall back to the parent module, which lacks the package.
+# Keep in sync with the controller-runtime minor version in go.mod.
+SETUP_ENVTEST_VERSION ?= v0.24.1
 
 CRD_CODE_GEN_PATH = "./api/ce/..."
 RECONCILE_HELPER_PATH = "internal/resources/reconciling/zz_generated_reconcile.go"
@@ -288,7 +292,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION)
 
 .PHONY: chainsaw
 chainsaw: $(CHAINSAW) ## Download chainsaw locally if necessary.

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -40,7 +40,7 @@ retry() {
   # Works only with bash but doesn't fail on other shells
   start_time=$(date +%s)
   set +e
-  actual_retry $@
+  actual_retry "$@"
   rc=$?
   set -e
   elapsed_time=$(($(date +%s) - $start_time))


### PR DESCRIPTION
**What this PR does / why we need it**:

Two unrelated one-liners in the build tooling.

`setup-envtest` was installed from `@latest`, so any upstream release could break CI without a commit here. Pinned to `v0.24.1`, matching the controller-runtime minor in `go.mod`. It has to be a tag: a branch ref makes `go install` fall back to the parent module, which does not contain the package.

`retry()` in `hack/lib.sh` passed `$@` unquoted, word-splitting any argument containing a space.

**What type of PR is this?**
/kind cleanup

```release-note
NONE
```

```documentation
NONE
```