### PR TITLE
ci: harden e2e harness against flakes

### DIFF
--- a/hack/e2e/setup-kind.sh
+++ b/hack/e2e/setup-kind.sh
@@ -142,8 +142,8 @@ increase_inotify_limits() {
 }
 
 is_docker_network_reachable() {
-  # Test if host can reach Docker network gateway without docker-mac-net-connect
-  # This indicates Docker Desktop host networking is enabled
+  # Verify that the host can actually reach the Docker bridge. A utun route can
+  # survive a Docker Desktop restart even when docker-mac-net-connect is stale.
   local gateway
   gateway=$(docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}' 2> /dev/null)
   [[ -n "$gateway" ]] && ping -c 1 -t 1 "$gateway" &> /dev/null
@@ -163,16 +163,18 @@ setup_mac_docker_networking() {
     return 0
   fi
 
-  # Check if routes already exist (docker-mac-net-connect running)
-  if netstat -rnf inet 2> /dev/null | grep -q "172.*utun"; then
-    echodate "Docker network routes already configured"
+  # A successful probe is authoritative; route presence alone is not.
+  if is_docker_network_reachable; then
+    if netstat -rnf inet 2> /dev/null | grep -q "172.*utun"; then
+      echodate "Docker network connectivity verified"
+    else
+      echodate "Using Docker Desktop host networking (native)"
+    fi
     return 0
   fi
 
-  # Check if Docker Desktop host networking is enabled (native reachability)
-  if is_docker_network_reachable; then
-    echodate "Using Docker Desktop host networking (native)"
-    return 0
+  if netstat -rnf inet 2> /dev/null | grep -q "172.*utun"; then
+    echodate "Detected stale Docker network routes; restarting docker-mac-net-connect"
   fi
 
   # docker-mac-net-connect path needs root. Get one sudo prompt out of the way
@@ -242,11 +244,12 @@ setup_mac_docker_networking() {
   echodate "Starting docker-mac-net-connect..."
   sudo DOCKER_HOST="${docker_socket}" DOCKER_API_VERSION=1.44 "${dmn_bin}" &> /dev/null &
 
-  # Wait for routes to appear with exponential backoff (0.1s, 0.2s, 0.4s, ...)
+  # Wait for real connectivity with exponential backoff (0.1s, 0.2s, ...).
+  # Checking routes would accept the stale-route state we are repairing.
   local retries=10
   local wait_time=0.1
   while [[ $retries -gt 0 ]]; do
-    if netstat -rnf inet 2> /dev/null | grep -q "172.*utun"; then
+    if is_docker_network_reachable; then
       echodate "Docker network connectivity configured"
       return 0
     fi
@@ -255,7 +258,7 @@ setup_mac_docker_networking() {
     ((retries--))
   done
 
-  echodate "WARNING: Docker network routes not detected. LoadBalancer IPs may not be reachable."
+  echodate "WARNING: Docker network connectivity could not be verified. LoadBalancer IPs may not be reachable."
   echodate "  Enable Docker Desktop host networking: Settings → Resources → Network → Host networking"
   return 0
 }

--- a/hack/ensure-helm-repos.sh
+++ b/hack/ensure-helm-repos.sh
@@ -99,7 +99,18 @@ done
 # Update all repositories (only if any exist)
 if helm repo list &> /dev/null; then
   echo "Updating Helm repositories..."
-  helm repo update
+  # Transient index fetch failures are common in CI; retry before giving up.
+  for attempt in 1 2 3; do
+    if helm repo update; then
+      break
+    fi
+    if [ "$attempt" -eq 3 ]; then
+      echo "helm repo update failed after ${attempt} attempts" >&2
+      exit 1
+    fi
+    echo "helm repo update failed (attempt ${attempt}), retrying in 5s..." >&2
+    sleep 5
+  done
 else
   echo "No Helm repositories configured, skipping update"
 fi

--- a/test/e2e/step-templates/common/deploy-echo-backend.yaml
+++ b/test/e2e/step-templates/common/deploy-echo-backend.yaml
@@ -89,7 +89,8 @@ spec:
           ($error == null): true
     - assert:
         cluster: tenant1
-        timeout: 60s
+        # Covers a cold-node image pull, not just pod scheduling.
+        timeout: 120s
         resource:
           apiVersion: apps/v1
           kind: Deployment

--- a/test/e2e/step-templates/common/verify-http-response.yaml
+++ b/test/e2e/step-templates/common/verify-http-response.yaml
@@ -37,7 +37,9 @@ spec:
       value: "20"
   try:
     - script:
-        timeout: 60s
+        # Must cover the worst-case retry loop: default 20 retries x (5s
+        # curl --max-time + 2s sleep) = 140s.
+        timeout: 180s
         env:
           - name: IP
             value: ($ip)

--- a/test/e2e/tests/layer4/service/multi-node/chainsaw-test.yaml
+++ b/test/e2e/tests/layer4/service/multi-node/chainsaw-test.yaml
@@ -133,17 +133,22 @@ spec:
       cluster: tenant1
       try:
         - script:
-            timeout: 60s
+            timeout: 240s
             content: |
               set -e
               IP=$(kubectl get svc echo-multinode -n default \
                 -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
               SUCCESS=0
               for i in $(seq 1 10); do
-                RESPONSE=$(curl -s --max-time 5 "http://${IP}" || true)
-                if echo "$RESPONSE" | grep -q "hello-from-multinode"; then
-                  SUCCESS=$((SUCCESS + 1))
-                fi
+                for attempt in 1 2 3; do
+                  RESPONSE=$(curl -s --max-time 5 "http://${IP}" || true)
+                  if echo "$RESPONSE" | grep -q "hello-from-multinode"; then
+                    SUCCESS=$((SUCCESS + 1))
+                    break
+                  fi
+                  echo "request $i attempt $attempt failed"
+                  sleep 1
+                done
               done
               if [ "$SUCCESS" -eq 10 ]; then
                 echo "All 10 requests succeeded"

--- a/test/e2e/tests/layer4/service/multi-port-multi-node/chainsaw-test.yaml
+++ b/test/e2e/tests/layer4/service/multi-port-multi-node/chainsaw-test.yaml
@@ -130,7 +130,7 @@ spec:
       cluster: tenant1
       try:
         - script:
-            timeout: 60s
+            timeout: 420s
             content: |
               set -e
               IP=$(kubectl get svc echo-mpmnod -n default -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -138,17 +138,27 @@ spec:
               SUCCESS_PORT2=0
 
               for i in $(seq 1 10); do
-                RESPONSE=$(curl -s --max-time 5 "http://${IP}:80" || true)
-                if echo "$RESPONSE" | grep -q "hello-from-mpmnod-port-80"; then
-                  SUCCESS_PORT1=$((SUCCESS_PORT1 + 1))
-                fi
+                for attempt in 1 2 3; do
+                  RESPONSE=$(curl -s --max-time 5 "http://${IP}:80" || true)
+                  if echo "$RESPONSE" | grep -q "hello-from-mpmnod-port-80"; then
+                    SUCCESS_PORT1=$((SUCCESS_PORT1 + 1))
+                    break
+                  fi
+                  echo "port 80 request $i attempt $attempt failed"
+                  sleep 1
+                done
               done
 
               for i in $(seq 1 10); do
-                RESPONSE=$(curl -s --max-time 5 "http://${IP}:81" || true)
-                if echo "$RESPONSE" | grep -q "hello-from-mpmnod-port-81"; then
-                  SUCCESS_PORT2=$((SUCCESS_PORT2 + 1))
-                fi
+                for attempt in 1 2 3; do
+                  RESPONSE=$(curl -s --max-time 5 "http://${IP}:81" || true)
+                  if echo "$RESPONSE" | grep -q "hello-from-mpmnod-port-81"; then
+                    SUCCESS_PORT2=$((SUCCESS_PORT2 + 1))
+                    break
+                  fi
+                  echo "port 81 request $i attempt $attempt failed"
+                  sleep 1
+                done
               done
 
               if [ "$SUCCESS_PORT1" -eq 10 ] && [ "$SUCCESS_PORT2" -eq 10 ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Four independent sources of e2e flakiness.

| Where | Change |
|---|---|
| `hack/ensure-helm-repos.sh` | retry `helm repo update` 3x with 5s backoff. Transient index fetch failures are common in CI and killed the whole run |
| `step-templates/common/verify-http-response.yaml` | timeout 60s to 180s. The step's own retry loop is 20 x (5s curl + 2s sleep) = 140s, so the step could not finish its own retries |
| `step-templates/common/deploy-echo-backend.yaml` | Deployment assert 60s to 120s, to cover a cold-node image pull rather than just scheduling |
| `layer4/service/{multi-node,multi-port-multi-node}` | retry each request up to 3x before counting it as failed |

The multi-node tests assert 10/10 successful requests, so a single dropped connection failed the test even though the load balancing behaviour under test was fine.

`setup-kind.sh` also now probes the Docker bridge instead of trusting the presence of a `172.*utun` route. The route survives a Docker Desktop restart while `docker-mac-net-connect` is stale, so the script reported connectivity that did not exist. A successful probe is authoritative; route presence alone is not.

**What type of PR is this?**
/kind flake

```release-note
NONE
```

```documentation
NONE
```