### PR TITLE
chore(envoy-cp): thread Config through instead of storing on receiver

### DIFF
--- a/cmd/kubelb/main.go
+++ b/cmd/kubelb/main.go
@@ -137,13 +137,15 @@ func main() {
 	// setup signal handler
 	ctx := ctrl.SetupSignalHandler()
 
-	conf, err := config.GetConfig(ctx, mgr.GetAPIReader(), opt.namespace)
-	if err != nil {
+	// Controllers now read the Config per reconcile rather than caching it here,
+	// but keep the startup read so a missing or unreadable Config still fails the
+	// manager fast instead of surfacing on the first reconcile.
+	if _, err := config.GetConfig(ctx, mgr.GetAPIReader(), opt.namespace); err != nil {
 		setupLog.Error(err, "unable to load controller config")
 		os.Exit(1)
 	}
 
-	envoyServer, err := envoy.NewServer(&conf, opt.envoyListenAddress, opt.enableDebugMode)
+	envoyServer, err := envoy.NewServer(opt.envoyListenAddress, opt.enableDebugMode)
 	if err != nil {
 		setupLog.Error(err, "unable to create envoy server")
 		os.Exit(1)

--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -67,7 +67,6 @@ type EnvoyCPReconciler struct {
 	Namespace         string
 	EnvoyServer       *envoycp.Server
 	DisableGatewayAPI bool
-	Config            *kubelbv1alpha1.Config
 }
 
 // +kubebuilder:rbac:groups=kubelb.k8c.io,resources=loadbalancers,verbs=get;list;watch
@@ -88,10 +87,7 @@ func (r *EnvoyCPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		managermetrics.EnvoyCPReconcileTotal.WithLabelValues(metricsutil.ResultError).Inc()
 		return ctrl.Result{}, fmt.Errorf("failed to retrieve config: %w", err)
 	}
-	r.Config = config
-	r.EnvoyServer.UpdateConfig(config)
-
-	if err := r.reconcile(ctx, req); err != nil {
+	if err := r.reconcile(ctx, req, config); err != nil {
 		managermetrics.EnvoyCPReconcileTotal.WithLabelValues(metricsutil.ResultError).Inc()
 		return ctrl.Result{}, err
 	}
@@ -100,7 +96,7 @@ func (r *EnvoyCPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{}, nil
 }
 
-func (r *EnvoyCPReconciler) reconcile(ctx context.Context, req ctrl.Request) error {
+func (r *EnvoyCPReconciler) reconcile(ctx context.Context, req ctrl.Request, config *kubelbv1alpha1.Config) error {
 	snapshotName, appName := req.Namespace, req.Namespace
 
 	lbs, routes, err := r.ListLoadBalancersAndRoutes(ctx, req)
@@ -113,7 +109,7 @@ func (r *EnvoyCPReconciler) reconcile(ctx context.Context, req ctrl.Request) err
 	if len(lbs) == 0 && len(routes) == 0 {
 		r.EnvoyCache.ClearSnapshot(snapshotName)
 		envoycpmetrics.CacheClearsTotal.WithLabelValues(snapshotName).Inc()
-		return r.cleanupEnvoyProxy(ctx, appName, namespace)
+		return r.cleanupEnvoyProxy(ctx, config, appName, namespace)
 	}
 
 	tenant, err := GetTenant(ctx, r.Client, RemoveTenantPrefix(namespace))
@@ -121,7 +117,7 @@ func (r *EnvoyCPReconciler) reconcile(ctx context.Context, req ctrl.Request) err
 		return fmt.Errorf("failed to retrieve tenant: %w", err)
 	}
 
-	if err := r.ensureEnvoyProxy(ctx, namespace, appName, snapshotName, tenant); err != nil {
+	if err := r.ensureEnvoyProxy(ctx, config, namespace, appName, snapshotName, tenant); err != nil {
 		return fmt.Errorf("failed to update Envoy proxy: %w", err)
 	}
 	managermetrics.EnvoyProxiesTotal.WithLabelValues(namespace, "shared").Set(1)
@@ -138,13 +134,13 @@ func (r *EnvoyCPReconciler) reconcile(ctx context.Context, req ctrl.Request) err
 		return err
 	}
 
-	return r.updateCache(ctx, snapshotName, lbs, routes)
+	return r.updateCache(ctx, config, snapshotName, lbs, routes)
 }
 
-func (r *EnvoyCPReconciler) updateCache(ctx context.Context, snapshotName string, lbs []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route) error {
+func (r *EnvoyCPReconciler) updateCache(ctx context.Context, config *kubelbv1alpha1.Config, snapshotName string, lbs []kubelbv1alpha1.LoadBalancer, routes []kubelbv1alpha1.Route) error {
 	log := ctrl.LoggerFrom(ctx)
 	snapshotStart := time.Now()
-	desiredSnapshot, err := envoycp.MapSnapshot(ctx, r.Client, lbs, routes, r.PortAllocator, snapshotName, envoycp.ResolveHeaderLimits(r.Config))
+	desiredSnapshot, err := envoycp.MapSnapshot(ctx, r.Client, lbs, routes, r.PortAllocator, snapshotName, envoycp.ResolveHeaderLimits(config))
 	envoycpmetrics.SnapshotGenerationDuration.WithLabelValues(snapshotName).Observe(time.Since(snapshotStart).Seconds())
 	if err != nil {
 		return err
@@ -233,7 +229,7 @@ func (r *EnvoyCPReconciler) ListLoadBalancersAndRoutes(ctx context.Context, req 
 	return lbs, routeList, nil
 }
 
-func (r *EnvoyCPReconciler) cleanupEnvoyProxy(ctx context.Context, appName string, namespace string) error {
+func (r *EnvoyCPReconciler) cleanupEnvoyProxy(ctx context.Context, config *kubelbv1alpha1.Config, appName string, namespace string) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("reconcile", "envoy-proxy")
 	log.V(2).Info("cleanup envoy-proxy")
 
@@ -242,7 +238,7 @@ func (r *EnvoyCPReconciler) cleanupEnvoyProxy(ctx context.Context, appName strin
 		Namespace: namespace,
 	}
 	var envoyProxy ctrlruntimeclient.Object
-	if r.Config.Spec.EnvoyProxy.UseDaemonset {
+	if config.Spec.EnvoyProxy.UseDaemonset {
 		envoyProxy = &appsv1.DaemonSet{
 			ObjectMeta: objMeta,
 		}
@@ -260,7 +256,7 @@ func (r *EnvoyCPReconciler) cleanupEnvoyProxy(ctx context.Context, appName strin
 	return nil
 }
 
-func (r *EnvoyCPReconciler) ensureEnvoyProxy(ctx context.Context, namespace, appName, snapshotName string, tenant *kubelbv1alpha1.Tenant) error {
+func (r *EnvoyCPReconciler) ensureEnvoyProxy(ctx context.Context, config *kubelbv1alpha1.Config, namespace, appName, snapshotName string, tenant *kubelbv1alpha1.Tenant) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("reconcile", "envoy-proxy")
 	log.V(2).Info("verify envoy-proxy")
 
@@ -274,7 +270,7 @@ func (r *EnvoyCPReconciler) ensureEnvoyProxy(ctx context.Context, namespace, app
 			kubelb.LabelAppKubernetesManagedBy: envoyProxyManagedByVal,
 		},
 	}
-	if r.Config.Spec.EnvoyProxy.UseDaemonset {
+	if config.Spec.EnvoyProxy.UseDaemonset {
 		envoyProxy = &appsv1.DaemonSet{
 			ObjectMeta: objMeta,
 		}
@@ -293,10 +289,10 @@ func (r *EnvoyCPReconciler) ensureEnvoyProxy(ctx context.Context, namespace, app
 		return err
 	}
 
-	desiredTemplate := r.getEnvoyProxyPodSpec(namespace, appName, snapshotName, tenant)
+	desiredTemplate := r.getEnvoyProxyPodSpec(config, namespace, appName, snapshotName, tenant)
 	var originalTemplate corev1.PodTemplateSpec
 	var originalReplicas, desiredReplicas *int32
-	if r.Config.Spec.EnvoyProxy.UseDaemonset {
+	if config.Spec.EnvoyProxy.UseDaemonset {
 		daemonset := envoyProxy.(*appsv1.DaemonSet)
 		originalTemplate = daemonset.Spec.Template
 		daemonset.Spec.Selector = &metav1.LabelSelector{
@@ -308,7 +304,7 @@ func (r *EnvoyCPReconciler) ensureEnvoyProxy(ctx context.Context, namespace, app
 		deployment := envoyProxy.(*appsv1.Deployment)
 		originalTemplate = deployment.Spec.Template
 		originalReplicas = deployment.Spec.Replicas
-		replicas := r.Config.Spec.EnvoyProxy.Replicas
+		replicas := config.Spec.EnvoyProxy.Replicas
 		if tenant.Spec.EnvoyProxy != nil && tenant.Spec.EnvoyProxy.Replicas != nil {
 			replicas = *tenant.Spec.EnvoyProxy.Replicas
 		}
@@ -334,8 +330,8 @@ func (r *EnvoyCPReconciler) ensureEnvoyProxy(ctx context.Context, namespace, app
 	return nil
 }
 
-func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(namespace, appName, snapshotName string, tenant *kubelbv1alpha1.Tenant) corev1.PodTemplateSpec {
-	envoyProxy := r.Config.Spec.EnvoyProxy
+func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(config *kubelbv1alpha1.Config, namespace, appName, snapshotName string, tenant *kubelbv1alpha1.Tenant) corev1.PodTemplateSpec {
+	envoyProxy := config.Spec.EnvoyProxy
 
 	// Extract graceful shutdown configuration
 	gracefulShutdownEnabled := true
@@ -359,7 +355,7 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(namespace, appName, snapshotNam
 		Name:  envoyProxyContainerName,
 		Image: envoyImage,
 		Args: []string{
-			"--config-yaml", r.EnvoyServer.GenerateBootstrap(),
+			"--config-yaml", r.EnvoyServer.GenerateBootstrap(config),
 			"--service-node", snapshotName,
 			"--service-cluster", namespace,
 		},
@@ -509,7 +505,7 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(namespace, appName, snapshotNam
 				kubelb.LabelAppKubernetesName:      appName,
 				kubelb.LabelAppKubernetesManagedBy: "kubelb",
 			},
-			Annotations: r.envoyProxyAnnotations(),
+			Annotations: r.envoyProxyAnnotations(config),
 		},
 		Spec: corev1.PodSpec{
 			TerminationGracePeriodSeconds: ptr.To(terminationGracePeriod),
@@ -550,8 +546,8 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(namespace, appName, snapshotNam
 	return template
 }
 
-func (r *EnvoyCPReconciler) envoyProxyAnnotations() map[string]string {
-	if r.Config.Spec.EnvoyProxy.PodMonitor != nil && r.Config.Spec.EnvoyProxy.PodMonitor.Enabled {
+func (r *EnvoyCPReconciler) envoyProxyAnnotations(config *kubelbv1alpha1.Config) map[string]string {
+	if config.Spec.EnvoyProxy.PodMonitor != nil && config.Spec.EnvoyProxy.PodMonitor.Enabled {
 		return nil
 	}
 	return map[string]string{

--- a/internal/controllers/kubelb/loadbalancer_controller_test.go
+++ b/internal/controllers/kubelb/loadbalancer_controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Lb deployment and service creation", func() {
 					return k8sClient.Get(ctx, deploymentLookupKey, createdDeployment)
 				}, timeout, interval).Should(Succeed())
 
-				Expect(createdDeployment.Spec.Template.Spec.Containers[0].Args[1]).Should(Equal(envoyServer.GenerateBootstrap()))
+				Expect(createdDeployment.Spec.Template.Spec.Containers[0].Args[1]).Should(Equal(envoyServer.GenerateBootstrap(&kubelbv1alpha1.Config{})))
 
 				By("creating a corresponding service")
 

--- a/internal/controllers/kubelb/suite_test.go
+++ b/internal/controllers/kubelb/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	sigCtx := ctrl.SetupSignalHandler()
 	ctx, cancel = context.WithCancel(sigCtx)
 
-	envoyServer, err = envoy.NewServer(&v1alpha1.Config{}, ":8001", true)
+	envoyServer, err = envoy.NewServer(":8001", true)
 
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -38,6 +38,8 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 )
 
 const xdsClusterName = "xds_cluster"
@@ -85,7 +87,7 @@ const (
 // potential security issues while keeping it available for the stats and probe listeners.
 var EnvoyAdminListenerAddress = "127.0.0.1"
 
-func (s *Server) GenerateBootstrap() string {
+func (s *Server) GenerateBootstrap(config *v1alpha1.Config) string {
 	// If debug is enabled, allow external access to the admin interface
 	if s.enableAdmin {
 		EnvoyAdminListenerAddress = wildcardBindAddress
@@ -254,8 +256,8 @@ func (s *Server) GenerateBootstrap() string {
 			},
 		},
 	}
-	if s.config.Spec.EnvoyProxy.OverloadManager != nil && s.config.Spec.EnvoyProxy.OverloadManager.Enabled {
-		cfg.OverloadManager = s.buildOverloadManager()
+	if config.Spec.EnvoyProxy.OverloadManager != nil && config.Spec.EnvoyProxy.OverloadManager.Enabled {
+		cfg.OverloadManager = s.buildOverloadManager(config)
 	}
 
 	jsonBytes, err := protojson.Marshal(cfg)
@@ -469,12 +471,12 @@ func marshalAny(pb proto.Message) *anypb.Any {
 	return marshalledPB
 }
 
-func (s *Server) buildOverloadManager() *envoyConfigOverloadV3.OverloadManager {
+func (s *Server) buildOverloadManager(config *v1alpha1.Config) *envoyConfigOverloadV3.OverloadManager {
 	om := &envoyConfigOverloadV3.OverloadManager{
 		RefreshInterval: durationpb.New(250 * time.Millisecond),
 	}
 
-	cfg := s.config.Spec.EnvoyProxy.OverloadManager
+	cfg := config.Spec.EnvoyProxy.OverloadManager
 
 	// Configure fixed heap monitoring if max heap size is specified
 	if cfg.MaxHeapSizeBytes > 0 {

--- a/internal/envoy/server.go
+++ b/internal/envoy/server.go
@@ -37,7 +37,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 
-	"k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 	envoycpmetrics "k8c.io/kubelb/internal/metricsutil/envoycp"
 )
 
@@ -77,14 +76,13 @@ func registerServer(grpcServer *grpc.Server, server serverv3.Server) {
 }
 
 type Server struct {
-	config        *v1alpha1.Config
 	Cache         cachev3.SnapshotCache
 	listenAddress string
 	listenPort    uint32
 	enableAdmin   bool
 }
 
-func NewServer(config *v1alpha1.Config, listenAddress string, enableAdmin bool) (*Server, error) {
+func NewServer(listenAddress string, enableAdmin bool) (*Server, error) {
 	portString := strings.Split(listenAddress, ":")[1]
 	port, err := strconv.ParseUint(portString, 10, 32)
 	if err != nil {
@@ -92,17 +90,11 @@ func NewServer(config *v1alpha1.Config, listenAddress string, enableAdmin bool) 
 	}
 
 	return &Server{
-		config:        config,
 		listenAddress: listenAddress,
 		listenPort:    uint32(port),
 		enableAdmin:   enableAdmin,
 		Cache:         cachev3.NewSnapshotCache(false, cachev3.IDHash{}, Logger{enableAdmin}),
 	}, nil
-}
-
-// UpdateConfig updates the server's config reference.
-func (s *Server) UpdateConfig(config *v1alpha1.Config) {
-	s.config = config
 }
 
 // Start the Envoy control plane server.

--- a/internal/envoy/server_test.go
+++ b/internal/envoy/server_test.go
@@ -20,15 +20,13 @@ import (
 	"context"
 	"testing"
 	"time"
-
-	"k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
 )
 
 // On shutdown the xDS server must drain its streams. Without it the process
 // exits with every ADS stream still open, so each connected proxy sees a reset
 // mid-response and the whole fleet reconnects at once.
 func TestServerStartDrainsOnContextCancellation(t *testing.T) {
-	server, err := NewServer(&v1alpha1.Config{}, "127.0.0.1:0", false)
+	server, err := NewServer("127.0.0.1:0", false)
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`EnvoyCPReconciler` read the Config once per reconcile and stashed it on itself (`r.Config = config`), then pushed the same pointer into the xDS server via `EnvoyServer.UpdateConfig`. Both are shared mutable state written on every reconcile and read from about ten other call sites, including `GenerateBootstrap` on a different goroutine.

Config is now a parameter threaded down `reconcile` to `updateCache`, `ensureEnvoyProxy`, `cleanupEnvoyProxy`, `getEnvoyProxyPodSpec` and `envoyProxyAnnotations`. `Server.config` and `UpdateConfig` are gone; `GenerateBootstrap` and `buildOverloadManager` take it explicitly.

`cmd/kubelb` keeps the startup `config.GetConfig` read so a missing or unreadable Config still fails the manager fast rather than surfacing on the first reconcile. The value is discarded.

No behavioural change. Every read resolves to the same Config the reconcile already fetched.

**What type of PR is this?**
/kind cleanup

```release-note
NONE
```

```documentation
NONE
```