### PR TITLE
fix(envoy): tcp keepalive on proxied connections

### DIFF
--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -91,6 +91,53 @@ const (
 	defaultMaxResponseHeadersKb   uint32 = 8192
 )
 
+// Upstreams are tenant NodePorts, so every flow is tracked by kube-proxy. In
+// IPVS mode it drops idle entries at 900s without signalling either end,
+// leaving Envoy to reuse a socket the node has forgotten. Probe well before.
+const (
+	tcpKeepaliveIdleSeconds     = 180
+	tcpKeepaliveIntervalSeconds = 30
+	tcpKeepaliveProbes          = 3
+)
+
+// Hardcoded because the syscall package resolves these differently on Darwin.
+const (
+	sockOptLevelSocket   = 0x1 // SOL_SOCKET
+	sockOptNameKeepalive = 0x9 // SO_KEEPALIVE
+	sockOptLevelTCP      = 0x6 // SOL_TCP
+	sockOptNameKeepIdle  = 0x4 // TCP_KEEPIDLE
+	sockOptNameKeepIntvl = 0x5 // TCP_KEEPINTVL
+	sockOptNameKeepCnt   = 0x6 // TCP_KEEPCNT
+)
+
+func upstreamTCPKeepalive() *envoyCluster.UpstreamConnectionOptions {
+	return &envoyCluster.UpstreamConnectionOptions{
+		TcpKeepalive: &envoyCore.TcpKeepalive{
+			KeepaliveTime:     wrapperspb.UInt32(tcpKeepaliveIdleSeconds),
+			KeepaliveInterval: wrapperspb.UInt32(tcpKeepaliveIntervalSeconds),
+			KeepaliveProbes:   wrapperspb.UInt32(tcpKeepaliveProbes),
+		},
+	}
+}
+
+// Set on the listening socket; accepted connections inherit them.
+func downstreamTCPKeepalive() []*envoyCore.SocketOption {
+	option := func(level, name, value int64) *envoyCore.SocketOption {
+		return &envoyCore.SocketOption{
+			Level: level,
+			Name:  name,
+			Value: &envoyCore.SocketOption_IntValue{IntValue: value},
+			State: envoyCore.SocketOption_STATE_PREBIND,
+		}
+	}
+	return []*envoyCore.SocketOption{
+		option(sockOptLevelSocket, sockOptNameKeepalive, 1),
+		option(sockOptLevelTCP, sockOptNameKeepIdle, tcpKeepaliveIdleSeconds),
+		option(sockOptLevelTCP, sockOptNameKeepIntvl, tcpKeepaliveIntervalSeconds),
+		option(sockOptLevelTCP, sockOptNameKeepCnt, tcpKeepaliveProbes),
+	}
+}
+
 // HeaderLimits holds the resolved client header limits applied to the managed Envoy.
 type HeaderLimits struct {
 	MaxRequestHeadersKb    uint32
@@ -307,6 +354,10 @@ func makeCluster(clusterName string, protocol corev1.Protocol, routeKind string,
 		CommonLbConfig: &envoyCluster.Cluster_CommonLbConfig{
 			HealthyPanicThreshold: &envoyType.Percent{Value: 0},
 		},
+	}
+
+	if protocol != corev1.ProtocolUDP {
+		cluster.UpstreamConnectionOptions = upstreamTCPKeepalive()
 	}
 
 	switch discoveryType {
@@ -527,6 +578,7 @@ func makeTCPListener(clusterName string, listenerName string, listenerPort uint3
 				},
 			}},
 		}},
+		SocketOptions: downstreamTCPKeepalive(),
 	}
 }
 
@@ -701,6 +753,7 @@ func makeHTTPListener(listenerName string, clusterName string, listenerPort uint
 				},
 			}},
 		}},
+		SocketOptions: downstreamTCPKeepalive(),
 	}
 }
 

--- a/internal/envoy/resource_test.go
+++ b/internal/envoy/resource_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	envoyCluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoyCore "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyListener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoyHttpManager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoyTcpProxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
@@ -800,5 +801,84 @@ func TestMapSnapshot_VersionStableAcrossReorder(t *testing.T) {
 		if v1, v2 := snap1.GetVersion(rt), snap2.GetVersion(rt); v1 != v2 {
 			t.Errorf("version changed for %s despite ignored-field mutation: %q != %q", rt, v1, v2)
 		}
+	}
+}
+
+func TestMakeCluster_TCPKeepalive(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol corev1.Protocol
+		want     bool
+	}{
+		{name: "tcp cluster keeps the conntrack entry warm", protocol: corev1.ProtocolTCP, want: true},
+		{name: "udp cluster has no tcp keepalive", protocol: corev1.ProtocolUDP},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := makeCluster("test-cluster", tt.protocol, "", false, nil, envoyCluster.Cluster_EDS, nil, ResolveHeaderLimits(nil))
+			keepalive := cluster.GetUpstreamConnectionOptions().GetTcpKeepalive()
+			if got := keepalive != nil; got != tt.want {
+				t.Fatalf("tcp_keepalive present = %v, want %v", got, tt.want)
+			}
+			if !tt.want {
+				return
+			}
+			if got := keepalive.GetKeepaliveTime().GetValue(); got != tcpKeepaliveIdleSeconds {
+				t.Errorf("keepalive_time = %d, want %d", got, tcpKeepaliveIdleSeconds)
+			}
+			if got := keepalive.GetKeepaliveInterval().GetValue(); got != tcpKeepaliveIntervalSeconds {
+				t.Errorf("keepalive_interval = %d, want %d", got, tcpKeepaliveIntervalSeconds)
+			}
+			if got := keepalive.GetKeepaliveProbes().GetValue(); got != tcpKeepaliveProbes {
+				t.Errorf("keepalive_probes = %d, want %d", got, tcpKeepaliveProbes)
+			}
+		})
+	}
+}
+
+func socketOptionValue(t *testing.T, options []*envoyCore.SocketOption, level, name int64) int64 {
+	t.Helper()
+	for _, option := range options {
+		if option.GetLevel() == level && option.GetName() == name {
+			if option.GetState() != envoyCore.SocketOption_STATE_PREBIND {
+				t.Errorf("socket option level %d name %d state = %v, want STATE_PREBIND", level, name, option.GetState())
+			}
+			return option.GetIntValue()
+		}
+	}
+	t.Fatalf("socket option level %d name %d not found", level, name)
+	return 0
+}
+
+func TestListeners_TCPKeepalive(t *testing.T) {
+	tests := []struct {
+		name     string
+		listener *envoyListener.Listener
+	}{
+		{name: "tcp", listener: makeTCPListener("test-cluster", "test-listener", 10001, nil)},
+		{name: "http", listener: makeHTTPListener("test-listener", "test-cluster", 10001, ResolveHeaderLimits(nil))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := tt.listener.GetSocketOptions()
+			if got := socketOptionValue(t, options, sockOptLevelSocket, sockOptNameKeepalive); got != 1 {
+				t.Errorf("SO_KEEPALIVE = %d, want 1", got)
+			}
+			if got := socketOptionValue(t, options, sockOptLevelTCP, sockOptNameKeepIdle); got != tcpKeepaliveIdleSeconds {
+				t.Errorf("TCP_KEEPIDLE = %d, want %d", got, tcpKeepaliveIdleSeconds)
+			}
+			if got := socketOptionValue(t, options, sockOptLevelTCP, sockOptNameKeepIntvl); got != tcpKeepaliveIntervalSeconds {
+				t.Errorf("TCP_KEEPINTVL = %d, want %d", got, tcpKeepaliveIntervalSeconds)
+			}
+			if got := socketOptionValue(t, options, sockOptLevelTCP, sockOptNameKeepCnt); got != tcpKeepaliveProbes {
+				t.Errorf("TCP_KEEPCNT = %d, want %d", got, tcpKeepaliveProbes)
+			}
+		})
+	}
+}
+
+func TestMakeUDPListener_NoTCPKeepalive(t *testing.T) {
+	if options := makeUDPListener("test-cluster", "test-listener", 10001, nil).GetSocketOptions(); len(options) != 0 {
+		t.Fatalf("udp listener socket options = %v, want none", options)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets TCP keepalive on both sides of the managed Envoy proxy. Full write-up in #539.

Short version: upstreams are `tenantNodeIP:NodePort`, so every flow is tracked by kube-proxy on the tenant node. IPVS expires idle entries at 900s and signals nothing, so Envoy keeps reusing a socket the node already forgot. First request after a quiet period fails, retry works.

Values are the same on both sides: `keepalive_time` 180s, `keepalive_interval` 30s, `keepalive_probes` 3. Only `keepalive_time` matters for the IPVS problem, it's the idle time before the first probe, and 180s leaves room under 900s even if `--ipvs-tcp-timeout` was lowered. Interval and probes just govern dead peer detection.

**Which issue(s) this PR fixes**:

Fixes #539

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:


```release-note
Enable TCP keepalive on connections through the KubeLB-managed Envoy proxy so idle connections are not silently dropped by kube-proxy in IPVS mode. Existing connections are drained once when the updated listener config is pushed.
```

```documentation
NONE
```

