### PR TITLE
helm: bump addon charts and fix envoy image pins

### DIFF
--- a/charts/kubelb-addons/Chart.lock
+++ b/charts/kubelb-addons/Chart.lock
@@ -4,16 +4,16 @@ dependencies:
   version: 4.15.1
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: 1.7.2
+  version: 1.8.3
 - name: cert-manager
   repository: oci://quay.io/jetstack/charts
   version: 1.21.0
 - name: external-dns
   repository: https://kubernetes-sigs.github.io/external-dns
-  version: 1.20.0
+  version: 1.21.1
 - name: metallb
   repository: oci://quay.io/metallb/chart
-  version: 0.15.3
+  version: 0.16.1
 - name: agentgateway-crds
   repository: oci://cr.agentgateway.dev/charts
   version: v1.3.1
@@ -26,5 +26,5 @@ dependencies:
 - name: ratelimit
   repository: file://./ratelimit
   version: 0.1.0
-digest: sha256:40c860bc3862e023f3a3b0a032b4feeb30bd9f7a1ff3834f2d2064857904b624
-generated: "2026-07-27T01:13:50.60176932Z"
+digest: sha256:eccc647653bea553545ad740320db0770ba820f629c7f2bd1237d4a1130e88f0
+generated: "2026-07-28T19:12:58.149501+05:00"

--- a/charts/kubelb-addons/Chart.lock
+++ b/charts/kubelb-addons/Chart.lock
@@ -16,15 +16,15 @@ dependencies:
   version: 0.16.1
 - name: agentgateway-crds
   repository: oci://cr.agentgateway.dev/charts
-  version: v1.3.1
+  version: 1.4.0
 - name: agentgateway
   repository: oci://cr.agentgateway.dev/charts
-  version: v1.3.1
+  version: 1.4.0
 - name: valkey
   repository: oci://ghcr.io/valkey-io/valkey-helm
   version: 0.11.0
 - name: ratelimit
   repository: file://./ratelimit
   version: 0.1.0
-digest: sha256:eccc647653bea553545ad740320db0770ba820f629c7f2bd1237d4a1130e88f0
-generated: "2026-07-28T19:12:58.149501+05:00"
+digest: sha256:5cb0ba8edb3104300f286a120e5687f6a2e88d1251cf1cf32c29c2343f5acab6
+generated: "2026-07-28T19:19:58.042666+05:00"

--- a/charts/kubelb-addons/Chart.yaml
+++ b/charts/kubelb-addons/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   - name: gateway-helm
     repository: oci://docker.io/envoyproxy
     condition: envoy-gateway.enabled
-    version: 1.7.2
+    version: 1.8.3
     alias: envoy-gateway
   - name: cert-manager
     repository: oci://quay.io/jetstack/charts
@@ -26,11 +26,11 @@ dependencies:
   - name: external-dns
     repository: https://kubernetes-sigs.github.io/external-dns
     condition: external-dns.enabled
-    version: 1.20.0
+    version: 1.21.1
   - name: metallb
     repository: oci://quay.io/metallb/chart
     condition: metallb.enabled
-    version: 0.15.3
+    version: 0.16.1
   - name: agentgateway-crds
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway-crds.enabled

--- a/charts/kubelb-addons/Chart.yaml
+++ b/charts/kubelb-addons/Chart.yaml
@@ -34,11 +34,11 @@ dependencies:
   - name: agentgateway-crds
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway-crds.enabled
-    version: v1.3.1
+    version: 1.4.0
   - name: agentgateway
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway.enabled
-    version: v1.3.1
+    version: 1.4.0
   - name: valkey
     repository: oci://ghcr.io/valkey-io/valkey-helm
     condition: valkey.enabled

--- a/charts/kubelb-addons/templates/gateway-class.yaml
+++ b/charts/kubelb-addons/templates/gateway-class.yaml
@@ -2,7 +2,8 @@
 {{- $egValues := index .Values "envoy-gateway" -}}
 {{- $envoyProxyImage := "" -}}
 {{- if .Values.global.imageRegistry -}}
-  {{- $defaultImage := "docker.io/envoyproxy/envoy:distroless-v1.37.1" -}}
+  {{- /* Keep in sync with DefaultEnvoyProxyImage for the envoy-gateway chart version in Chart.yaml. */ -}}
+  {{- $defaultImage := "docker.io/envoyproxy/envoy:distroless-v1.37.2" -}}
   {{- $imageParts := splitn "/" 2 $defaultImage -}}
   {{- $repositoryTag := $imageParts._1 -}}
   {{- $envoyProxyImage = printf "%s/%s" (trimSuffix "/" .Values.global.imageRegistry) $repositoryTag -}}

--- a/charts/kubelb-addons/templates/gateway-class.yaml
+++ b/charts/kubelb-addons/templates/gateway-class.yaml
@@ -3,7 +3,7 @@
 {{- $envoyProxyImage := "" -}}
 {{- if .Values.global.imageRegistry -}}
   {{- /* Keep in sync with DefaultEnvoyProxyImage for the envoy-gateway chart version in Chart.yaml. */ -}}
-  {{- $defaultImage := "docker.io/envoyproxy/envoy:distroless-v1.37.2" -}}
+  {{- $defaultImage := "docker.io/envoyproxy/envoy:distroless-v1.38.3" -}}
   {{- $imageParts := splitn "/" 2 $defaultImage -}}
   {{- $repositoryTag := $imageParts._1 -}}
   {{- $envoyProxyImage = printf "%s/%s" (trimSuffix "/" .Values.global.imageRegistry) $repositoryTag -}}

--- a/hack/e2e/images-standalone.yaml
+++ b/hack/e2e/images-standalone.yaml
@@ -14,9 +14,8 @@
 
 # Container images pre-pulled into conversion Kind cluster
 images:
-  - docker.io/envoyproxy/gateway:v1.3.0
-  - docker.io/envoyproxy/gateway:v1.6.2
-  - docker.io/envoyproxy/envoy:distroless-v1.36.3
+  - docker.io/envoyproxy/gateway:v1.7.2
+  - docker.io/envoyproxy/envoy:distroless-v1.36.4
   - quay.io/metallb/speaker:v0.15.3
   - quay.io/frrouting/frr:10.4.1
   - registry.k8s.io/ingress-nginx/controller:v1.13.0

--- a/hack/e2e/images-standalone.yaml
+++ b/hack/e2e/images-standalone.yaml
@@ -14,10 +14,10 @@
 
 # Container images pre-pulled into conversion Kind cluster
 images:
-  - docker.io/envoyproxy/gateway:v1.7.2
+  - docker.io/envoyproxy/gateway:v1.8.3
   - docker.io/envoyproxy/envoy:distroless-v1.36.4
-  - quay.io/metallb/speaker:v0.15.3
-  - quay.io/frrouting/frr:10.4.1
+  - quay.io/metallb/speaker:v0.16.1
+  - quay.io/frrouting/frr:10.4.3
   - registry.k8s.io/ingress-nginx/controller:v1.13.0
   - quay.io/brancz/kube-rbac-proxy:v0.20.1
   - hashicorp/http-echo:1.0

--- a/hack/e2e/images.yaml
+++ b/hack/e2e/images.yaml
@@ -16,9 +16,9 @@
 # Test workload images (http-echo, echoserver-udp) pull on-demand during tests
 images:
   - quay.io/brancz/kube-rbac-proxy:v0.20.1
-  - docker.io/envoyproxy/gateway:v1.7.2
+  - docker.io/envoyproxy/gateway:v1.8.3
   - envoyproxy/envoy:distroless-v1.36.4
-  - quay.io/metallb/speaker:v0.15.3
-  - quay.io/frrouting/frr:10.4.1
+  - quay.io/metallb/speaker:v0.16.1
+  - quay.io/frrouting/frr:10.4.3
   - registry.k8s.io/ingress-nginx/controller:v1.13.0
   - docker.io/kong/grpcbin@sha256:6535251b38b0be84c9ba26b1eb00921f5c78a25052b06a117677d302bbc861ce

--- a/hack/e2e/images.yaml
+++ b/hack/e2e/images.yaml
@@ -16,8 +16,7 @@
 # Test workload images (http-echo, echoserver-udp) pull on-demand during tests
 images:
   - quay.io/brancz/kube-rbac-proxy:v0.20.1
-  - docker.io/envoyproxy/gateway:v1.3.0
-  - docker.io/envoyproxy/gateway:v1.6.2
+  - docker.io/envoyproxy/gateway:v1.7.2
   - envoyproxy/envoy:distroless-v1.36.4
   - quay.io/metallb/speaker:v0.15.3
   - quay.io/frrouting/frr:10.4.1

--- a/hack/patches/metallb.patch
+++ b/hack/patches/metallb.patch
@@ -1,6 +1,6 @@
 diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8s/templates/_helpers.tpl b/metallb/charts/frr-k8s/templates/_helpers.tpl
---- a/metallb/charts/frr-k8s/templates/_helpers.tpl	2025-12-04 20:20:55
-+++ b/metallb/charts/frr-k8s/templates/_helpers.tpl	2026-04-14 12:05:23
+--- a/metallb/charts/frr-k8s/templates/_helpers.tpl	2026-05-28 02:12:45
++++ b/metallb/charts/frr-k8s/templates/_helpers.tpl	2026-07-28 19:14:32
 @@ -61,3 +61,18 @@
  {{- default "default" .Values.frrk8s.serviceAccount.name }}
  {{- end }}
@@ -21,8 +21,8 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
 +{{- $repository -}}
 +{{- end }}
 diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8s/templates/controller.yaml b/metallb/charts/frr-k8s/templates/controller.yaml
---- a/metallb/charts/frr-k8s/templates/controller.yaml	2025-12-04 20:20:55
-+++ b/metallb/charts/frr-k8s/templates/controller.yaml	2026-04-14 12:05:23
+--- a/metallb/charts/frr-k8s/templates/controller.yaml	2026-05-28 02:12:45
++++ b/metallb/charts/frr-k8s/templates/controller.yaml	2026-07-28 19:14:32
 @@ -132,7 +132,7 @@
        {{- if .Values.frrk8s.runtimeClassName }}
        runtimeClassName: {{ .Values.frrk8s.runtimeClassName }}
@@ -32,7 +32,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
        imagePullSecrets:
          {{- toYaml . | nindent 8 }}
        {{- end }}
-@@ -161,7 +161,7 @@
+@@ -165,7 +165,7 @@
        initContainers:
          # Copies the initial config files with the right permissions to the shared volume.
          - name: cp-frr-files
@@ -41,7 +41,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
            securityContext:
              runAsUser: 100
              runAsGroup: 101
-@@ -173,20 +173,20 @@
+@@ -177,20 +177,20 @@
                mountPath: /etc/frr
          # Copies the reloader to the shared volume between the speaker and reloader.
          - name: cp-reloader
@@ -65,7 +65,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
            command: ["/bin/sh", "-c", "cp -f /frr-status /etc/frr_status/"]
            volumeMounts:
              - name: frr-status
-@@ -194,7 +194,7 @@
+@@ -198,7 +198,7 @@
        shareProcessNamespace: true
        containers:
        - name: controller
@@ -74,7 +74,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
          {{- if .Values.frrk8s.image.pullPolicy }}
          imagePullPolicy: {{ .Values.frrk8s.image.pullPolicy }}
          {{- end }}
-@@ -273,7 +273,7 @@
+@@ -299,7 +299,7 @@
              - NET_RAW
              - SYS_ADMIN
              - NET_BIND_SERVICE
@@ -83,7 +83,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
          {{- if .Values.frrk8s.frr.image.pullPolicy }}
          imagePullPolicy: {{ .Values.frrk8s.frr.image.pullPolicy }}
          {{- end }}
-@@ -322,7 +322,7 @@
+@@ -342,7 +342,7 @@
            periodSeconds: {{ .Values.frrk8s.startupProbe.periodSeconds }}
          {{- end }}
        - name: reloader
@@ -92,7 +92,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
          {{- if .Values.frrk8s.frr.image.pullPolicy }}
          imagePullPolicy: {{ .Values.frrk8s.frr.image.pullPolicy }}
          {{- end }}
-@@ -339,7 +339,7 @@
+@@ -359,7 +359,7 @@
            {{- toYaml . | nindent 12 }}
          {{- end }}
        - name: frr-metrics
@@ -100,8 +100,8 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
 +        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.frrk8s.frr.image.repository "context" .) }}:{{ .Values.frrk8s.frr.image.tag | default .Chart.AppVersion }}
          command: ["/etc/frr_metrics/frr-metrics"]
          args:
-           - --metrics-port={{ .Values.frrk8s.frr.metricsPort }}
-@@ -381,7 +381,7 @@
+           - --metrics-port={{ .Values.frrk8s.frr.secureMetricsPort }}
+@@ -422,7 +422,7 @@
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
@@ -110,27 +110,9 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
          volumeMounts:
            - mountPath: /var/run/frr
              name: frr-sockets
-@@ -394,7 +394,7 @@
-           {{- toYaml . | nindent 12 }}
-         {{- end }}
-       - name: kube-rbac-proxy
--        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
-+        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag }}
-         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
-         args:
-           - --logtostderr
-@@ -420,7 +420,7 @@
-             readOnly: true
-         {{- end }}
-       - name: kube-rbac-proxy-frr
--        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
-+        image: {{ include "frrk8s.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
-         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
-         args:
-           - --logtostderr
 diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8s/templates/status-cleaner.yaml b/metallb/charts/frr-k8s/templates/status-cleaner.yaml
---- a/metallb/charts/frr-k8s/templates/status-cleaner.yaml	2025-12-04 20:20:55
-+++ b/metallb/charts/frr-k8s/templates/status-cleaner.yaml	2026-04-14 12:05:23
+--- a/metallb/charts/frr-k8s/templates/status-cleaner.yaml	2026-05-28 02:12:45
++++ b/metallb/charts/frr-k8s/templates/status-cleaner.yaml	2026-07-28 19:14:32
 @@ -23,7 +23,7 @@
        {{- if .Values.frrk8s.runtimeClassName }}
        runtimeClassName: {{ .Values.frrk8s.runtimeClassName }}
@@ -140,7 +122,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
        imagePullSecrets:
          {{- toYaml . | nindent 8 }}
        {{- end }}
-@@ -47,7 +47,7 @@
+@@ -56,7 +56,7 @@
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
@@ -150,11 +132,11 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8
          imagePullPolicy: {{ .Values.frrk8s.image.pullPolicy }}
          {{- end }}
 diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/_helpers.tpl b/metallb/templates/_helpers.tpl
---- a/metallb/templates/_helpers.tpl	2025-12-04 20:20:55
-+++ b/metallb/templates/_helpers.tpl	2026-04-14 12:05:23
-@@ -112,3 +112,17 @@
+--- a/metallb/templates/_helpers.tpl	2026-05-28 02:12:45
++++ b/metallb/templates/_helpers.tpl	2026-07-28 19:15:34
+@@ -97,3 +97,17 @@
  {{- end }}
- {{- end }}
+ 
  
 +{{/*
 +Rewrite a repository to the configured global mirror registry.
@@ -171,9 +153,9 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/_he
 +{{- $repository -}}
 +{{- end }}
 diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/controller.yaml b/metallb/templates/controller.yaml
---- a/metallb/templates/controller.yaml	2025-12-04 20:20:55
-+++ b/metallb/templates/controller.yaml	2026-04-14 12:05:23
-@@ -40,7 +40,7 @@
+--- a/metallb/templates/controller.yaml	2026-05-28 02:12:45
++++ b/metallb/templates/controller.yaml	2026-07-28 19:14:32
+@@ -41,7 +41,7 @@
        {{- with .Values.controller.runtimeClassName }}
        runtimeClassName: {{ . | quote }}
        {{- end }}
@@ -182,7 +164,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/con
        imagePullSecrets:
          {{- toYaml . | nindent 8 }}
        {{- end }}
-@@ -52,7 +52,7 @@
+@@ -53,7 +53,7 @@
  {{- end }}
        containers:
        - name: controller
@@ -191,19 +173,10 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/con
          {{- if .Values.controller.image.pullPolicy }}
          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
          {{- end }}
-@@ -138,7 +138,7 @@
-             - ALL
-       {{- if .Values.prometheus.secureMetricsPort }}
-       - name: kube-rbac-proxy
--        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
-+        image: {{ include "metallb.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag }}
-         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
-         securityContext:
-           readOnlyRootFilesystem: true
 diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/speaker.yaml b/metallb/templates/speaker.yaml
---- a/metallb/templates/speaker.yaml	2025-12-04 20:20:55
-+++ b/metallb/templates/speaker.yaml	2026-04-14 12:05:23
-@@ -162,7 +162,7 @@
+--- a/metallb/templates/speaker.yaml	2026-05-28 02:12:45
++++ b/metallb/templates/speaker.yaml	2026-07-28 19:14:32
+@@ -163,7 +163,7 @@
        {{- if .Values.speaker.runtimeClassName }}
        runtimeClassName: {{ .Values.speaker.runtimeClassName }}
        {{- end }}
@@ -212,7 +185,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
        imagePullSecrets:
          {{- toYaml . | nindent 8 }}
        {{- end }}
-@@ -212,7 +212,7 @@
+@@ -217,7 +217,7 @@
        initContainers:
          # Copies the initial config files with the right permissions to the shared volume.
          - name: cp-frr-files
@@ -221,7 +194,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
            securityContext:
              runAsUser: 100
              runAsGroup: 101
-@@ -228,7 +228,7 @@
+@@ -233,7 +233,7 @@
            {{- end }}
          # Copies the reloader to the shared volume between the speaker and reloader.
          - name: cp-reloader
@@ -230,7 +203,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
            command: ["/cp-tool","/frr-reloader.sh","/etc/frr_reloader/frr-reloader.sh"]
            volumeMounts:
              - name: reloader
-@@ -239,7 +239,7 @@
+@@ -244,7 +244,7 @@
            {{- end }}
          # Copies the metrics exporter
          - name: cp-metrics
@@ -239,7 +212,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
            command: ["/cp-tool","/frr-metrics","/etc/frr_metrics/frr-metrics"]
            volumeMounts:
              - name: metrics
-@@ -252,7 +252,7 @@
+@@ -257,7 +257,7 @@
        {{- end }}
        containers:
        - name: speaker
@@ -248,7 +221,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
          {{- if .Values.speaker.image.pullPolicy }}
          imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
          {{- end }}
-@@ -399,7 +399,7 @@
+@@ -420,7 +420,7 @@
              - NET_RAW
              - SYS_ADMIN
              - NET_BIND_SERVICE
@@ -257,7 +230,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
          {{- if .Values.speaker.frr.image.pullPolicy }}
          imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
          {{- end }}
-@@ -459,7 +459,7 @@
+@@ -466,7 +466,7 @@
            periodSeconds: {{ .Values.speaker.startupProbe.periodSeconds }}
          {{- end }}
        - name: reloader
@@ -266,7 +239,7 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
          {{- if .Values.speaker.frr.image.pullPolicy }}
          imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
          {{- end }}
-@@ -481,7 +481,7 @@
+@@ -488,7 +488,7 @@
            {{- toYaml . | nindent 12 }}
          {{- end }}
        - name: frr-metrics
@@ -275,49 +248,3 @@ diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/templates/spe
          securityContext:
            readOnlyRootFilesystem: true
            allowPrivilegeEscalation: false
-@@ -511,7 +511,7 @@
-       {{- end }}
-       {{- if .Values.prometheus.secureMetricsPort }}
-       - name: kube-rbac-proxy
--        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
-+        image: {{ include "metallb.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag }}
-         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
-         securityContext:
-           readOnlyRootFilesystem: true
-@@ -543,7 +543,7 @@
-       {{- if .Values.speaker.frr.enabled }}
-       {{- if .Values.speaker.frr.secureMetricsPort }}
-       - name: kube-rbac-proxy-frr
--        image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
-+        image: {{ include "metallb.imageRepository" (dict "repository" .Values.prometheus.rbacProxy.repository "context" .) }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
-         imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
-         securityContext:
-           readOnlyRootFilesystem: true
-diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/charts/frr-k8s/values.yaml b/metallb/charts/frr-k8s/values.yaml
---- a/metallb/charts/frr-k8s/values.yaml	2025-12-04 20:20:55
-+++ b/metallb/charts/frr-k8s/values.yaml	2026-04-22 12:35:00
-@@ -48,8 +48,8 @@
- 
-   # the image to be used for the kuberbacproxy container
-   rbacProxy:
--    repository: gcr.io/kubebuilder/kube-rbac-proxy
--    tag: v0.12.0
-+    repository: quay.io/brancz/kube-rbac-proxy
-+    tag: v0.20.1
-     pullPolicy:
- 
-   # Prometheus Operator ServiceMonitors.
-diff -ruN --exclude=README.md --exclude=README.md.gotmpl a/metallb/values.yaml b/metallb/values.yaml
---- a/metallb/values.yaml	2025-12-04 20:20:55
-+++ b/metallb/values.yaml	2026-04-22 12:35:00
-@@ -55,8 +55,8 @@
- 
-   # the image to be used for the kuberbacproxy container
-   rbacProxy:
--    repository: gcr.io/kubebuilder/kube-rbac-proxy
--    tag: v0.12.0
-+    repository: quay.io/brancz/kube-rbac-proxy
-+    tag: v0.20.1
-     pullPolicy:
- 
-   # Prometheus Operator PodMonitors


### PR DESCRIPTION
**What this PR does / why we need it**:

Combines the addon chart bumps and the envoy pin fixes. Supersedes the earlier stack (#543, #550).

Chart deps:

- envoy-gateway (gateway-helm): 1.7.2 -> 1.8.3
- metallb: 0.15.3 -> 0.16.1
- external-dns: 1.20.0 -> 1.21.1
- agentgateway / agentgateway-crds: v1.3.1 -> 1.4.0

ingress-nginx (4.15.1), cert-manager (1.21.0) and valkey (0.11.0) are already at latest.

Image pins:

- `gateway-class.yaml`: distroless-v1.37.1 -> v1.38.3 (mirrors `DefaultEnvoyProxyImage`; was already a patch behind envoy-gateway 1.7.2)
- `hack/e2e/images-standalone.yaml`: distroless-v1.36.3 -> v1.36.4, matching the controller's `envoyImage`
- e2e preloads: gateway v1.3.0 + v1.6.2 -> v1.8.3, metallb speaker v0.16.1, frr 10.4.3

`hack/patches/metallb.patch` regenerated against 0.16.1, which drops the kube-rbac-proxy sidecar.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

```release-note
- Bump addon charts: envoy-gateway 1.8.3, metallb 0.16.1, external-dns 1.21.1, agentgateway 1.4.0
- metallb no longer deploys a kube-rbac-proxy sidecar
```

```documentation
NONE
```