### PR TITLE
ci: bump helm and yq in verify.sh

### DIFF
--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -27,8 +27,8 @@ SUMMARY=
 echodate "Installing tools..."
 
 apt-get update -qq && apt-get install -y -qq yamllint > /dev/null 2>&1 &
-curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.17.0 bash > /dev/null 2>&1 &
-curl -fsSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 && chmod +x /usr/local/bin/yq &
+curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | DESIRED_VERSION=v4.2.3 bash > /dev/null 2>&1 &
+curl -fsSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64 && chmod +x /usr/local/bin/yq &
 go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 &
 go install go.xrstf.de/gimps@v0.6.2 &
 go install github.com/kubermatic-labs/boilerplate@v0.3.0 &


### PR DESCRIPTION
**What this PR does / why we need it**:

- helm: v3.17.0 -> v4.2.3 (installer switches from `get-helm-3` to `get-helm-4`)
- yq: v4.45.1 -> v4.53.3

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

```release-note
NONE
```

```documentation
NONE
```