### PR TITLE
ci: bump goreleaser prow image

### DIFF
--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -213,7 +213,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: goreleaser/goreleaser:v2.15.3
+        - image: goreleaser/goreleaser:v2.17.1
           env:
             - name: GOTOOLCHAIN
               value: auto


### PR DESCRIPTION
**What this PR does / why we need it**:

- goreleaser (`.prow/verify.yaml`): v2.15.3 -> v2.17.1

Dependabot's docker ecosystem only scans Dockerfiles at the repo root, so `.prow/` images are never proposed automatically.

golangci-lint stays at v2.10.1 here. v2.12.2 surfaces 19 new goconst/noctx findings in the cli module, which the `pull-kubelb-lint-cli` job would fail on, so that bump needs the cleanup first.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

```release-note
NONE
```

```documentation
NONE
```