### PR TITLE
docs: add dependency-update skill

### DIFF
--- a/.claude/skills/kubelb-dependency-updates/REFERENCE.md
+++ b/.claude/skills/kubelb-dependency-updates/REFERENCE.md
@@ -1,0 +1,106 @@
+# Pitfalls
+
+Each of these cost real time. Ordered by how badly they bite.
+
+## Stacked PRs lose commits
+
+`kubermatic-bot` deletes the head branch immediately on merge. Two consequences:
+
+1. **Auto-close.** GitHub closes any PR whose *base* branch is deleted. A stacked PR dies the moment its parent merges, and it cannot be recovered in place: closed PRs cannot be retargeted, and reopening fails because the base is gone. You must rebase the branch onto the squashed `main` and open a fresh PR.
+2. **Silent loss.** If a parent and its child merge in the same second, the parent's squash snapshots the branch *before* the child's commit lands. The child reports **Merged** while its content reached nothing. This happened to the agentgateway bump — GitHub said merged, `Chart.yaml` still said `v1.3.1`.
+
+Prefer one flat PR against `main`. If you must stack, verify afterwards by reading the tree:
+
+```bash
+git show upstream/<base-branch>:charts/kubelb-addons/Chart.yaml | grep -A2 "name: agentgateway"
+```
+
+Never conclude "it landed" from PR status. Audit a whole batch with:
+
+```bash
+git diff --name-only <pre-work-sha> upstream/main > /tmp/inmain.txt
+git diff --name-only <pre-work-sha> upstream/<open-branch> > /tmp/inpr.txt
+# every file touched by the PRs must appear in one of those two
+```
+
+## `test -s` tool guards never reinstall
+
+Makefile install targets guard on file existence:
+
+```make
+test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install ...@$(CONTROLLER_TOOLS_VERSION)
+```
+
+Bumping the version variable does nothing when a binary is already there. `make manifests` runs the **old** tool and produces no diff, so the bump looks complete and is not. Guard on version output instead:
+
+```make
+@$(LOCALBIN)/controller-gen --version 2>/dev/null | grep -q "$(CONTROLLER_TOOLS_VERSION)$$" || \
+    GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+```
+
+Version output formats differ: `controller-gen --version` → `Version: v0.21.0` (with `v`); `chainsaw version` → `Version: 0.2.15` (no `v`, use `$(subst v,,...)`). `setup-envtest` has no version flag at all. After changing a guard, `rm -f bin/<tool>` and confirm the reinstall actually happens.
+
+## Version skew between surfaces
+
+The same upstream version is pinned in several places that drift apart. Check these pairs every time:
+
+| Must match | Found via |
+|---|---|
+| `GATEWAY_API_VERSION` (Makefile) | `sigs.k8s.io/gateway-api` in `go.mod` |
+| `gateway-class.yaml` envoy image | `DefaultEnvoyProxyImage` for the pinned envoy-gateway chart |
+| `hack/e2e/images*.yaml` envoy | `envoyImage` const in `loadbalancer_controller.go` |
+| `hack/e2e/images*.yaml` charts | versions in `charts/kubelb-addons/Chart.yaml` |
+
+Read the envoy-gateway default straight from the module cache rather than guessing:
+
+```bash
+grep -n "DefaultEnvoyProxyImage" \
+  "$(go env GOMODCACHE)/github.com/envoyproxy/gateway@v1.8.3/api/v1alpha1/shared_types.go"
+```
+
+The `gateway-class.yaml` pin only applies when `global.imageRegistry` is set, so a skew here means air-gapped installs silently run a different dataplane version than everyone else. Bumping the envoy-gateway chart *always* means updating this pin too.
+
+## Chart minors delete what patches target
+
+`hack/patches/*.patch` are context diffs against upstream addon charts. A minor bump can make hunks **obsolete** rather than merely drifted — metallb 0.16 removed the kube-rbac-proxy sidecar entirely, invalidating 6 hunks. Blindly re-fuzzing would have reintroduced dead config.
+
+Regenerate:
+
+```bash
+helm pull oci://quay.io/metallb/chart/metallb --version <new> -d "$W"
+tar -xzf "$W"/metallb-<new>.tgz -C "$W/a" && cp -R "$W/a/metallb" "$W/b/"
+cd "$W/b" && patch -p1 --fuzz=3 < hack/patches/metallb.patch   # collect .rej
+# decide per reject: obsolete (drop) or drifted (re-apply by hand)
+find "$W/b" -name '*.rej' -delete
+cd "$W" && diff -ruN --exclude=README.md --exclude=README.md.gotmpl a b > metallb.patch
+```
+
+Watch for helpers whose anchor moved — the `metallb.imageRepository` define failed to apply while its *callers* applied fine, which would have shipped a chart calling an undefined template. Then confirm the patch's actual purpose still works:
+
+```bash
+helm template t charts/kubelb-addons --set global.imageRegistry=mirror.example.com ... | grep "image:"
+```
+
+## Dependabot blind spots
+
+- **docker** ecosystem only scans Dockerfiles at the repo root — `.prow/` images are invisible.
+- Action **version inputs** (`with: version: v2.11.4`) are not `uses:` refs and are never proposed.
+- **agentgateway** is explicitly ignored: the dead pre-v1.0 lineage semver-sorts above the current 1.x line, so dependabot "upgrades" into an obsolete lineage. Bump manually and check the CRD API versions — 1.4.0 stayed on `v1alpha1` and only added a CRD, so it was safe despite the ignore rule's breaking-minor warning.
+- `github/codeql-action` looks perpetually behind against `releases/latest`; it tags releases `codeql-bundle-*`. False positive, leave it.
+
+## Environment gotchas
+
+- A stale gitignored `vendor/` breaks `go list -m -u` with "inconsistent vendoring". Prefix with `GOFLAGS=-mod=mod`.
+- A stale `charts/kubelb-addons/charts/` makes `helm-lint` fail with "missing these dependencies" for charts that are not in `Chart.yaml`. Run `make helm-dependency-update` first; do not chase it as a real failure.
+- `Chart.lock` digests are **identical** between helm 3 and helm 4, and helm does not rewrite the file when deps are unchanged. So a lock generated locally on helm 4 is safe for CI on helm 3, and `verify-helm-lock` will not thrash on the `generated:` timestamp.
+- `azure/setup-helm` has no `version:` input in this repo, so it floats to `latest`. Workflows are therefore on helm 4 regardless of what `hack/ci/verify.sh` pins.
+
+## Known-deferred items
+
+Do not treat these as oversights; they need an explicit decision and an e2e run:
+
+- Managed envoy dataplane (`envoyImage` in `loadbalancer_controller.go`) lags latest envoy by several minors.
+- `kindest/node` trails the `k8s.io/*` minor that envtest derives from `k8s.io/api`.
+- `grpcbin:latest` floats in two chainsaw tests while the preload lists pin it by digest.
+- `test/e2e/values.yaml` is passed via `--values` but has zero `$values.` references — dead config, including a very stale envoy pin.
+- Bumping the prow `golangci-lint` image is blocked on cleaning up the goconst/noctx findings it surfaces in the cli module.

--- a/.claude/skills/kubelb-dependency-updates/REFERENCE.md
+++ b/.claude/skills/kubelb-dependency-updates/REFERENCE.md
@@ -1,3 +1,58 @@
+# Reference
+
+## Discovering a repo's security posture
+
+Do not hardcode scanners. Read them out of CI so this works unchanged in `kubelb-ee` or any sibling repo, and so local runs match what will gate the PR.
+
+```bash
+# which scanners run, and where
+grep -rn "govulncheck\|trivy\|osv-scanner\|grype\|snyk\|dependency-review\|codeql\|scorecard" \
+  .github/ .prow/ hack/ Makefile 2>/dev/null | grep -v Binary
+
+# pinned scanner versions and thresholds
+grep -rnE "govulncheck@|trivy .*-b /usr/local/bin|severity|fail-on-severity|ignore-unfixed|exit-code" \
+  .github/workflows/ .prow/
+
+# suppression configs
+git ls-files | grep -iE "osv|trivy|grype|vuln|\.snyk"
+```
+
+Then mirror what you find: same tool, same pinned version, same severity threshold. Three things to extract:
+
+- **What runs where.** Blocking on PRs vs release-only changes how urgent a finding is.
+- **Thresholds.** `--severity HIGH,CRITICAL` plus `--ignore-unfixed` means MEDIUM findings and unfixable ones are deliberately out of scope. Do not "fix" what the repo has chosen not to gate on.
+- **Suppression file and its convention** (see below).
+
+### kubelb's posture as of writing
+
+| Scanner | Version | Where | Gate |
+|---|---|---|---|
+| govulncheck | v1.1.4 | `pr.yml`, both modules | blocking on every PR |
+| trivy (image + rootfs) | v0.69.2 | `pr.yml`, `release.yml`, `release-vuln-scan.yml` | blocking, `HIGH,CRITICAL`, `--ignore-unfixed` |
+| dependency-review-action | v5.0.0 | `pr.yml` | `fail-on-severity: high`, scopes runtime + development |
+| CodeQL | — | `codeql-analysis.yml` | SARIF to code scanning |
+| OpenSSF Scorecard | — | `scorecard.yml` | SARIF to code scanning |
+
+Note `osv-scanner.toml` exists in the repo root but **nothing in-repo invokes osv-scanner** — it is consumed by an external scanner. Edits to it are therefore untestable locally; do not assume a local run validates them.
+
+## Suppressing a finding
+
+Suppress only when a bump genuinely cannot fix it: no fixed version exists, or the vulnerable package is not reachable from the binaries. Prove the second claim before claiming it:
+
+```bash
+go mod why golang.org/x/crypto/openpgp        # run in both modules
+```
+
+Record the id and the reasoning in the repo's suppression file. The existing entry is the format to copy:
+
+```toml
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "golang.org/x/crypto/openpgp is deprecated with no fixed version; kubelb does not import any openpgp package (verified with `go mod why golang.org/x/crypto/openpgp` in both modules), x/crypto is only an indirect dependency"
+```
+
+A reason that does not say *why it is unreachable or unfixable* is not a reason.
+
 # Pitfalls
 
 Each of these cost real time. Ordered by how badly they bite.

--- a/.claude/skills/kubelb-dependency-updates/SKILL.md
+++ b/.claude/skills/kubelb-dependency-updates/SKILL.md
@@ -10,6 +10,24 @@ description: Sweep and update every dependency surface in the kubelb repo (go.mo
 1. **A surface gets missed.** Dependabot covers less than it looks like. Work the inventory below, do not assume.
 2. **A bump silently no-ops or silently gets lost.** Verify by reading the resulting tree, never by trusting a "merged" badge or a clean `make` run.
 
+## Scan for CVEs first
+
+Vulnerabilities decide what to bump and in what order. Run the scanners **before** touching any version, and land security-driven bumps as their own PR ahead of routine ones — a CVE fix should be reviewable and backportable without a pile of cosmetic bumps around it.
+
+Discover what this repo already runs rather than assuming; see [REFERENCE.md](REFERENCE.md#discovering-a-repos-security-posture) for the discovery commands. Reuse its pinned scanner versions and thresholds so local results match CI. For kubelb today that is:
+
+```bash
+go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+govulncheck ./... && (cd cli && govulncheck ./...)
+
+make build build-cli
+docker build -t kubelb-manager:scan -f kubelb.goreleaser.dockerfile .
+trivy image --severity HIGH,CRITICAL --ignore-unfixed kubelb-manager:scan
+trivy rootfs --severity HIGH,CRITICAL --ignore-unfixed cli/bin/kubelb
+```
+
+Then triage: a finding that a bump fixes drives that bump. A finding with no fixed version, or in a package the binaries never import, gets suppressed **with a reason** rather than chased — see [REFERENCE.md](REFERENCE.md#suppressing-a-finding).
+
 ## Inventory
 
 Run every row. `auto` = dependabot proposes it weekly; still confirm it is current.
@@ -34,6 +52,7 @@ Go deps: direct deps are usually already current. Use `go get -u ./...` in **bot
 
 Split on **user-facing vs internal**, not one-PR-per-bump.
 
+- **Security fixes → first, on their own.** Anything closing a CVE goes ahead of routine bumps so it can be reviewed and backported cleanly.
 - **User-facing → its own PR, one per concern.** Addon charts (they deploy into tenant clusters), the managed envoy dataplane image, anything with a real `release-note`, CRD/API changes. Each needs its own e2e signal and its own revert story.
 - **Internal → bundle freely into one PR.** Makefile tools, prow images, action SHAs, `hack/ci` pins, go.mod. Nobody downstream sees these.
 

--- a/.claude/skills/kubelb-dependency-updates/SKILL.md
+++ b/.claude/skills/kubelb-dependency-updates/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: kubelb-dependency-updates
+description: Sweep and update every dependency surface in the kubelb repo (go.mod, Makefile tool versions, prow images, GitHub Actions, hack/ci pins, addon Helm charts, pinned container images) and split the work into PRs. Use when asked to update or bump dependencies, tooling, chart versions, addon versions, or image pins in kubelb/kubelb-ce/kubelb-ee.
+---
+
+# KubeLB Dependency Updates
+
+## The two things that go wrong
+
+1. **A surface gets missed.** Dependabot covers less than it looks like. Work the inventory below, do not assume.
+2. **A bump silently no-ops or silently gets lost.** Verify by reading the resulting tree, never by trusting a "merged" badge or a clean `make` run.
+
+## Inventory
+
+Run every row. `auto` = dependabot proposes it weekly; still confirm it is current.
+
+| Surface | Where | Auto? |
+|---|---|---|
+| Go modules (root + cli) | `go.mod`, `cli/go.mod` | direct only |
+| Makefile tools | `CONTROLLER_TOOLS_VERSION`, `CHAINSAW_VERSION`, `KUSTOMIZE_VERSION`, `HELM_DOCS_VERSION`, `CRD_REF_DOCS_VERSION`, `SETUP_ENVTEST_VERSION`, `GO_VERSION`, `GATEWAY_API_VERSION` | no |
+| CI tool pins | `hack/ci/verify.sh` (helm, yq, shfmt, gimps, boilerplate, wwhrd) | no |
+| Prow images | `.prow/verify.yaml`, `.prow/postsubmits.yaml` | **no** |
+| Action SHAs | `.github/workflows/*.yml` `uses:` | yes |
+| Action version *inputs* | same files, `with: version:` | **no** |
+| Addon charts | `charts/kubelb-addons/Chart.yaml` + `Chart.lock` | yes, except agentgateway |
+| agentgateway / -crds | same | **no** (ignored, see `dependabot.yml`) |
+| Envoy dataplane pins | `internal/controllers/kubelb/loadbalancer_controller.go`, `charts/kubelb-addons/templates/gateway-class.yaml`, `hack/e2e/images*.yaml` | no |
+| Base images | `*.dockerfile` | yes |
+| Kind node | `hack/e2e/setup-kind.sh`, `.prow/verify.yaml` | no |
+
+Go deps: direct deps are usually already current. Use `go get -u ./...` in **both** modules to catch indirect ones. Drop the `k8c.io/kubelb` bump it makes in `cli/go.mod` — inert (`replace` points at `../`) and pure noise.
+
+## PR grouping
+
+Split on **user-facing vs internal**, not one-PR-per-bump.
+
+- **User-facing → its own PR, one per concern.** Addon charts (they deploy into tenant clusters), the managed envoy dataplane image, anything with a real `release-note`, CRD/API changes. Each needs its own e2e signal and its own revert story.
+- **Internal → bundle freely into one PR.** Makefile tools, prow images, action SHAs, `hack/ci` pins, go.mod. Nobody downstream sees these.
+
+Keep addon-chart bumps that carry CRD changes (envoy-gateway, agentgateway, metallb minors) separate from each other so a red e2e run stays bisectable.
+
+**Avoid stacked PRs.** See [REFERENCE.md](REFERENCE.md#stacked-prs-lose-commits) — `kubermatic-bot` deletes branches on merge, which auto-closes dependent PRs and can silently drop a merged commit. Prefer one flat PR against `main`.
+
+## Verification gate
+
+```bash
+make lint && make test && make build
+make verify-helm-lock verify-addons-patches helm-lint   # any chart change
+make lint-cli test-cli                                  # any go.mod change
+```
+
+Chart changes: commit `Chart.lock` before running `verify-helm-lock` — it compares via `git diff` against HEAD, so an uncommitted lock always reports out-of-sync.
+
+Before bumping the prow `golangci-lint` image, run `make lint` **and** `make lint-cli` with that exact version locally. A newer linter surfaces new findings and turns the `pull-kubelb-lint-cli` job red.
+
+## Pitfalls
+
+Read [REFERENCE.md](REFERENCE.md) before starting. The ones that have actually bitten: silent no-op tool installs, version skew between go.mod and the Makefile/chart pins, chart minors that delete what a `hack/patches/*.patch` targets, and stacked PRs losing commits.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `.claude/skills/kubelb-dependency-updates/`, capturing what a full dependency sweep of this repo actually involves.

- Scan for CVEs first: govulncheck and trivy run before any version changes, and security-driven bumps land as their own PR ahead of routine ones
- Inventory of every surface, with which ones dependabot covers and which it does not (`.prow/` images, action `with: version:` inputs and agentgateway are blind spots)
- PR grouping rule: security fixes first, then user-facing changes (addon charts, managed envoy image, anything with a release-note) one per PR; internal tooling bumps can be bundled
- Verification gate per change type
- `REFERENCE.md` with the pitfalls: Makefile tool guards that never reinstall on a version bump, version skew between go.mod and the Makefile/chart pins, addon chart minors that invalidate `hack/patches/*.patch`, and stacked PRs silently losing commits

Scanners are discovered from CI rather than hardcoded, so the skill carries over to kubelb-ee or any sibling repo: it reads whatever that repo runs, at its pinned versions and severity thresholds, and follows its suppression convention. Current kubelb posture is recorded as the worked example.

Force-added because `.claude` is gitignored. Both files are now tracked, so edits to them show up in `git status` normally; only *new* files added under that directory would need another `git add -f`.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

```release-note
NONE
```

```documentation
NONE
```