### PR TITLE
fix: stop repo-root-walking checks from descending into worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,10 @@ helm-lint:
 	helm lint charts/*
 
 generate-helm-docs: helm-docs
-	$(LOCALBIN)/helm-docs charts/
+	@# helm-docs takes no positional arguments, so a bare "charts/" was ignored
+	@# and it searched from the repo root, rewriting README.md in any git
+	@# worktree checked out under the repo.
+	$(LOCALBIN)/helm-docs --chart-search-root charts
 
 .PHONY: bump-chart
 bump-chart:

--- a/charts/kubelb-addons/README.md
+++ b/charts/kubelb-addons/README.md
@@ -88,14 +88,14 @@ These are the default values to use when Gateway API is disabled for KubeLB in f
 | Repository | Name | Version |
 |------------|------|---------|
 | file://./ratelimit | ratelimit | 0.1.0 |
-| https://kubernetes-sigs.github.io/external-dns | external-dns | 1.20.0 |
+| https://kubernetes-sigs.github.io/external-dns | external-dns | 1.21.1 |
 | https://kubernetes.github.io/ingress-nginx | ingress-nginx | 4.15.1 |
-| oci://cr.agentgateway.dev/charts | agentgateway | v1.3.1 |
-| oci://cr.agentgateway.dev/charts | agentgateway-crds | v1.3.1 |
-| oci://docker.io/envoyproxy | envoy-gateway(gateway-helm) | 1.7.2 |
-| oci://ghcr.io/valkey-io/valkey-helm | valkey | 0.10.0 |
+| oci://cr.agentgateway.dev/charts | agentgateway | 1.4.0 |
+| oci://cr.agentgateway.dev/charts | agentgateway-crds | 1.4.0 |
+| oci://docker.io/envoyproxy | envoy-gateway(gateway-helm) | 1.8.3 |
+| oci://ghcr.io/valkey-io/valkey-helm | valkey | 0.11.0 |
 | oci://quay.io/jetstack/charts | cert-manager | 1.21.0 |
-| oci://quay.io/metallb/chart | metallb | 0.15.3 |
+| oci://quay.io/metallb/chart | metallb | 0.16.1 |
 
 ## Values
 

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -24,4 +24,6 @@ boilerplate \
   -exclude Makefile \
   -exclude api/ee \
   -exclude internal/resources/crds \
-  -exclude .github
+  -exclude .github \
+  -exclude .worktrees \
+  -exclude .claude


### PR DESCRIPTION
**What this PR does / why we need it**:

Two checks walked the repo root and descended into git worktrees checked out under it (`.worktrees/`, `.claude/worktrees/`).

| Check | Problem | Fix |
|---|---|---|
| `generate-helm-docs` | `helm-docs charts/` passes a positional argument, which helm-docs does not accept, so it fell back to `--chart-search-root .` and rewrote chart READMEs in every worktree | pass `--chart-search-root charts` |
| `verify-boilerplate` | checked 3999 files instead of 368, failing on worktrees' own vendored CRDs | `-exclude .worktrees`, `-exclude .claude` |

Also regenerates `charts/kubelb-addons/README.md`. Its dependency table still listed external-dns 1.20.0, metallb 0.15.3, envoy-gateway 1.7.2, agentgateway v1.3.1 and valkey 0.10.0, so it had drifted from Chart.yaml since #542 and #550.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```