### PR TITLE
fix(release): cover restructured docs paths and security page in docs-update

### DIFF
--- a/.github/workflows/release-docs-update.yml
+++ b/.github/workflows/release-docs-update.yml
@@ -213,7 +213,18 @@ jobs:
           # bump together), and multi-line `--version vX.Y.Z` scoped to
           # kubelb-manager/ccm charts only — kubelb-addons has its own
           # version line in the same doc and must not bump with kubelb.
-          FILE_RULES["tutorials/airgap-installation/_index.en.md"]='s{^VERSION=v\d+\.\d+\.\d+$}{VERSION='"${VERSION}"'}gm; s{(kubermatic/(?:helm-charts/)?kubelb-(?:manager|ccm)(?:-ee)?:)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g; s{(oci://[^\s`]+kubelb-(?:manager|ccm)(?:-ee)?\s+\\\s*\n\s*--version[ =])v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
+          # Listed under both paths: docs restructure (kubermatic/docs#2242)
+          # moved the page to installation/air-gap on main (v1.5+ trees),
+          # while v1.3/v1.4 trees keep the old tutorials path. The missing
+          # one warns-and-skips.
+          AIRGAP_RULES='s{^VERSION=v\d+\.\d+\.\d+$}{VERSION='"${VERSION}"'}gm; s{(kubermatic/(?:helm-charts/)?kubelb-(?:manager|ccm)(?:-ee)?:)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g; s{(oci://[^\s`]+kubelb-(?:manager|ccm)(?:-ee)?\s+\\\s*\n\s*--version[ =])v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g'
+          FILE_RULES["tutorials/airgap-installation/_index.en.md"]="$AIRGAP_RULES"
+          FILE_RULES["installation/air-gap/_index.en.md"]="$AIRGAP_RULES"
+          # security: cosign/oras image + chart refs (manager only — the page
+          # has no ccm examples), GitHub release download URLs, and the
+          # versioned SBOM/checksums artifact filename. Anchored so nothing
+          # else on the page (envoy images, tool versions) can match.
+          FILE_RULES["security/_index.en.md"]='s{(kubermatic/(?:helm-charts/)?kubelb-manager(?:-ee)?:)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g; s{(github\.com/kubermatic/kubelb/releases/download/)v\d+\.\d+\.\d+}{${1}'"${VERSION}"'}g; s{(kubelb_)v\d+\.\d+\.\d+(_linux)}{${1}'"${VERSION}"'${2}}g'
 
           UPDATED=0
           for relpath in "${!FILE_RULES[@]}"; do


### PR DESCRIPTION
**What this PR does / why we need it**:

Two coverage gaps in `release-docs-update.yml` FILE_RULES:

1. **Air-gap page moved.** kubermatic/docs#2242 restructured the main docs tree: `tutorials/airgap-installation/` is now `installation/air-gap/`. Rules were keyed on the old path only, and missing files warn-and-skip, so the v1.5 tree (seeded from main) would silently ship stale air-gap versions. Rules now keyed under both paths; v1.3/v1.4 trees keep the old layout, whichever is absent warns.
2. **Security page never covered.** `security/_index.en.md` hardcodes release versions in cosign/oras/trivy examples, `releases/download/` URLs and SBOM/checksums filenames. No rule existed, so the v1.4 tree shipped v1.4.1 refs through the v1.4.2 and v1.4.3 releases. Added three anchored rules: `kubelb-manager(-ee):vX.Y.Z` image/chart refs, `releases/download/vX.Y.Z`, `kubelb_vX.Y.Z_linux` filenames.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

Dry-ran all rules against the current kubermatic/docs `main` and `v1.4` trees with a sentinel version: security pages change exactly their 12 kubelb refs each, air-gap pages their 12; the agentgateway/envoy example versions on the same pages don't match any rule. Backfill of the currently stale pages is in kubermatic/docs#2243.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
NONE
```

**Documentation**:

```documentation
https://github.com/kubermatic/docs/pull/2243
```