### PR TITLE
fix: Gateway name collisions silently overwriting each other

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,9 +76,9 @@ linters:
           - goconst
         path: _test\.go
       - path: (.+)\.go$
-        text: cyclomatic complexity 33 of func `CreateOrUpdateGRPCRoute` is high
+        text: cyclomatic complexity \d+ of func `CreateOrUpdateGRPCRoute` is high
       - path: (.+)\.go$
-        text: cyclomatic complexity 33 of func `CreateOrUpdateHTTPRoute` is high
+        text: cyclomatic complexity \d+ of func `CreateOrUpdateHTTPRoute` is high
       - path: (.+)\.go$
         text: cyclomatic complexity \d+ of func `\(\*LoadBalancerReconciler\)\.Reconcile` is high
       - path: (.+)\.go$

--- a/internal/controllers/kubelb/route_controller.go
+++ b/internal/controllers/kubelb/route_controller.go
@@ -456,10 +456,11 @@ func (r *RouteReconciler) manageRoutes(ctx context.Context, log logr.Logger, rou
 	routeStatus := route.Status.DeepCopy()
 
 	// Determine the type of the resource and call the appropriate method
+	var applyErr error
 	switch v := resource.(type) {
 	case *v1.Ingress: // v1 "k8s.io/api/networking/v1"
-		err = ingressHelpers.CreateOrUpdateIngress(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, config, tenant, annotations)
-		if err == nil {
+		applyErr = ingressHelpers.CreateOrUpdateIngress(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, config, tenant, annotations)
+		if applyErr == nil {
 			// Retrieve updated object to get the status.
 			key := ctrlruntimeclient.ObjectKey{Namespace: v.Namespace, Name: v.Name}
 			res := &v1.Ingress{}
@@ -468,12 +469,12 @@ func (r *RouteReconciler) manageRoutes(ctx context.Context, log logr.Logger, rou
 					return fmt.Errorf("failed to get Ingress: %w", err)
 				}
 			}
-			updateResourceStatus(routeStatus, res, err)
+			updateResourceStatus(routeStatus, res, nil)
 		}
 
 	case *gwapiv1.Gateway: // v1 "sigs.k8s.io/gateway-api/apis/v1"
-		err = gatewayHelpers.CreateOrUpdateGateway(ctx, log, r.Client, v, route.Namespace, config, tenant, annotations)
-		if err == nil {
+		applyErr = gatewayHelpers.CreateOrUpdateGateway(ctx, log, r.Client, v, route.Namespace, config, tenant, annotations)
+		if applyErr == nil {
 			// Retrieve updated object to get the status.
 			key := ctrlruntimeclient.ObjectKey{Namespace: v.Namespace, Name: v.Name}
 			res := &gwapiv1.Gateway{}
@@ -482,12 +483,12 @@ func (r *RouteReconciler) manageRoutes(ctx context.Context, log logr.Logger, rou
 					return fmt.Errorf("failed to get Gateway: %w", err)
 				}
 			}
-			updateResourceStatus(routeStatus, res, err)
+			updateResourceStatus(routeStatus, res, nil)
 		}
 
 	case *gwapiv1.HTTPRoute: // v1 "sigs.k8s.io/gateway-api/apis/v1"
-		err = httprouteHelpers.CreateOrUpdateHTTPRoute(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, tenant, annotations)
-		if err == nil {
+		applyErr = httprouteHelpers.CreateOrUpdateHTTPRoute(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, tenant, annotations)
+		if applyErr == nil {
 			// Retrieve updated object to get the status.
 			key := ctrlruntimeclient.ObjectKey{Namespace: v.Namespace, Name: v.Name}
 			res := &gwapiv1.HTTPRoute{}
@@ -496,12 +497,12 @@ func (r *RouteReconciler) manageRoutes(ctx context.Context, log logr.Logger, rou
 					return fmt.Errorf("failed to get HTTPRoute: %w", err)
 				}
 			}
-			updateResourceStatus(routeStatus, res, err)
+			updateResourceStatus(routeStatus, res, nil)
 		}
 
 	case *gwapiv1.GRPCRoute: // v1 "sigs.k8s.io/gateway-api/apis/v1"
-		err = grpcrouteHelpers.CreateOrUpdateGRPCRoute(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, tenant, annotations)
-		if err == nil {
+		applyErr = grpcrouteHelpers.CreateOrUpdateGRPCRoute(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, tenant, annotations)
+		if applyErr == nil {
 			// Retrieve updated object to get the status.
 			key := ctrlruntimeclient.ObjectKey{Namespace: v.Namespace, Name: v.Name}
 			res := &gwapiv1.GRPCRoute{}
@@ -510,14 +511,25 @@ func (r *RouteReconciler) manageRoutes(ctx context.Context, log logr.Logger, rou
 					return fmt.Errorf("failed to get GRPCRoute: %w", err)
 				}
 			}
-			updateResourceStatus(routeStatus, res, err)
+			updateResourceStatus(routeStatus, res, nil)
 		}
 
 	default:
 		log.V(4).Info("Unsupported resource type")
 	}
 
-	return r.UpdateRouteStatus(ctx, route, *routeStatus)
+	if applyErr != nil {
+		applyErr = fmt.Errorf("failed to create or update %s: %w", resource.GetObjectKind().GroupVersionKind().Kind, applyErr)
+		log.Error(applyErr, "failed to apply route resource")
+		r.Recorder.Eventf(route, nil, corev1.EventTypeWarning, "RouteApplyFailed", "Reconciling", applyErr.Error())
+		updateResourceStatus(routeStatus, resource, applyErr)
+	}
+
+	// Status first so the failure is visible, then the error so the workqueue retries.
+	if err := r.UpdateRouteStatus(ctx, route, *routeStatus); err != nil {
+		return err
+	}
+	return applyErr
 }
 
 func (r *RouteReconciler) shouldReconcile(ctx context.Context, route *kubelbv1alpha1.Route, tenant *kubelbv1alpha1.Tenant, config *kubelbv1alpha1.Config) (bool, bool, error) {

--- a/internal/resources/gatewayapi/gateway/gateway.go
+++ b/internal/resources/gatewayapi/gateway/gateway.go
@@ -43,19 +43,31 @@ func CreateOrUpdateGateway(ctx context.Context, log logr.Logger, client ctrlclie
 		gatewayClassName = config.Spec.GatewayAPI.Class
 	}
 
-	// Check if Gateway with the same name but different namespace already exists. If it does, log an error as we don't support
-	// multiple Gateway objects.
+	// Every tenant-cluster namespace collapses into one namespace here, so two source
+	// objects can claim the same name. Renaming to disambiguate would rotate the load
+	// balancer IP, since Envoy Gateway derives its proxy Service name from the
+	// Gateway's namespace/name. First claimant keeps the name instead.
 	gateways := &gwapiv1.GatewayList{}
 	if err := client.List(ctx, gateways, ctrlclient.InNamespace(namespace)); err != nil {
 		return fmt.Errorf("failed to list Gateways: %w", err)
 	}
 
 	found := false
-	for _, existingGateway := range gateways.Items {
-		if existingGateway.Name == object.Name {
-			found = true
-			break
+	for i := range gateways.Items {
+		existingGateway := &gateways.Items[i]
+		if existingGateway.Name != object.Name {
+			continue
 		}
+		found = true
+		// Match on the full origin: the name alone stops identifying the source object
+		// once an edition derives the management-cluster name from the origin.
+		originName, hasName := existingGateway.Labels[kubelb.LabelOriginName]
+		originNamespace, hasNamespace := existingGateway.Labels[kubelb.LabelOriginNamespace]
+		// Gateways predating these labels are adopted rather than rejected.
+		if hasName && hasNamespace && (originName != object.Name || originNamespace != object.Namespace) {
+			return fmt.Errorf("gateway name %q is already claimed by %s/%s in the tenant cluster; a Gateway name can only be owned by one source object per tenant", object.Name, originNamespace, originName)
+		}
+		break
 	}
 
 	if !found && len(gateways.Items) >= MaxGatewaysPerTenant {

--- a/internal/resources/gatewayapi/gateway/gateway_test.go
+++ b/internal/resources/gatewayapi/gateway/gateway_test.go
@@ -1,0 +1,189 @@
+//go:build !e2e
+
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const tenantNamespace = "tenant-primary"
+
+func gatewayScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := gwapiv1.Install(s); err != nil {
+		t.Fatalf("gateway api scheme: %v", err)
+	}
+	return s
+}
+
+// sourceGateway builds a Gateway as it arrives from the tenant cluster, still
+// carrying its original namespace.
+func sourceGateway(originNamespace string) *gwapiv1.Gateway {
+	return &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ParentGatewayName,
+			Namespace: originNamespace,
+		},
+		Spec: gwapiv1.GatewaySpec{
+			GatewayClassName: GatewayClassName,
+			Listeners: []gwapiv1.Listener{{
+				Name:     "http",
+				Protocol: gwapiv1.HTTPProtocolType,
+				Port:     80,
+			}},
+		},
+	}
+}
+
+func applyGateway(t *testing.T, client ctrlclient.Client, originNamespace string) error {
+	t.Helper()
+	return CreateOrUpdateGateway(context.Background(), logr.Discard(), client, sourceGateway(originNamespace),
+		tenantNamespace, &kubelbv1alpha1.Config{}, &kubelbv1alpha1.Tenant{}, kubelbv1alpha1.AnnotationSettings{})
+}
+
+// Renaming the Gateway would rotate the load balancer IP, so the name must stay
+// stable across reconciles.
+func TestCreateOrUpdateGateway_PreservesName(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(gatewayScheme(t)).Build()
+
+	if err := applyGateway(t, client, "default"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gateway := &gwapiv1.Gateway{}
+	if err := client.Get(context.Background(), types.NamespacedName{Namespace: tenantNamespace, Name: ParentGatewayName}, gateway); err != nil {
+		t.Fatalf("Gateway should be created as %s/%s: %v", tenantNamespace, ParentGatewayName, err)
+	}
+	if got := gateway.Labels[kubelb.LabelOriginNamespace]; got != "default" {
+		t.Errorf("origin namespace label = %q, want %q", got, "default")
+	}
+}
+
+func TestCreateOrUpdateGateway_SameOriginIsIdempotent(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(gatewayScheme(t)).Build()
+
+	if err := applyGateway(t, client, "default"); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if err := applyGateway(t, client, "default"); err != nil {
+		t.Fatalf("second apply from the same origin must not conflict: %v", err)
+	}
+
+	gateways := &gwapiv1.GatewayList{}
+	if err := client.List(context.Background(), gateways); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(gateways.Items) != 1 {
+		t.Errorf("got %d Gateways, want 1", len(gateways.Items))
+	}
+}
+
+// Previously the second claimant overwrote the first, leaving both Routes fighting
+// over one Gateway.
+func TestCreateOrUpdateGateway_RejectsConflictingOrigin(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(gatewayScheme(t)).Build()
+
+	if err := applyGateway(t, client, "team-a"); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	err := applyGateway(t, client, "team-b")
+	if err == nil {
+		t.Fatal("expected a conflict error for a second origin namespace, got nil")
+	}
+	if !strings.Contains(err.Error(), "team-a") {
+		t.Errorf("error should name the owning namespace, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), ParentGatewayName) {
+		t.Errorf("error should name the owning object, got: %v", err)
+	}
+
+	// The winner keeps the object untouched, so its load balancer IP is unaffected.
+	gateway := &gwapiv1.Gateway{}
+	if err := client.Get(context.Background(), types.NamespacedName{Namespace: tenantNamespace, Name: ParentGatewayName}, gateway); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got := gateway.Labels[kubelb.LabelOriginNamespace]; got != "team-a" {
+		t.Errorf("origin namespace label = %q, want the first claimant %q", got, "team-a")
+	}
+}
+
+// Only reachable once an edition derives the management-cluster name from something
+// other than the source name, which is why the guard matches the full origin.
+func TestCreateOrUpdateGateway_RejectsConflictingOriginName(t *testing.T) {
+	existing := &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ParentGatewayName,
+			Namespace: tenantNamespace,
+			Labels: map[string]string{
+				kubelb.LabelOriginName:      "other-gateway",
+				kubelb.LabelOriginNamespace: "default",
+			},
+		},
+		Spec: gwapiv1.GatewaySpec{GatewayClassName: GatewayClassName},
+	}
+	client := fake.NewClientBuilder().WithScheme(gatewayScheme(t)).WithObjects(existing).Build()
+
+	err := applyGateway(t, client, "default")
+	if err == nil {
+		t.Fatal("expected a conflict error for a different origin name, got nil")
+	}
+	if !strings.Contains(err.Error(), "other-gateway") {
+		t.Errorf("error should name the owning object, got: %v", err)
+	}
+}
+
+// Adoption rather than rejection, so upgrades do not break existing tenants.
+func TestCreateOrUpdateGateway_AdoptsUnlabelledGateway(t *testing.T) {
+	existing := &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ParentGatewayName,
+			Namespace: tenantNamespace,
+		},
+		Spec: gwapiv1.GatewaySpec{GatewayClassName: GatewayClassName},
+	}
+	client := fake.NewClientBuilder().WithScheme(gatewayScheme(t)).WithObjects(existing).Build()
+
+	if err := applyGateway(t, client, "default"); err != nil {
+		t.Fatalf("an unlabelled Gateway should be adopted, got: %v", err)
+	}
+
+	gateway := &gwapiv1.Gateway{}
+	if err := client.Get(context.Background(), types.NamespacedName{Namespace: tenantNamespace, Name: ParentGatewayName}, gateway); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got := gateway.Labels[kubelb.LabelOriginNamespace]; got != "default" {
+		t.Errorf("origin namespace label = %q, want %q", got, "default")
+	}
+}

--- a/internal/resources/gatewayapi/grpcroute/grpcroute.go
+++ b/internal/resources/gatewayapi/grpcroute/grpcroute.go
@@ -70,18 +70,16 @@ func CreateOrUpdateGRPCRoute(ctx context.Context, log logr.Logger, client ctrlcl
 				}
 			}
 			// Collect services from the filters.
-			if ref.Filters != nil {
-				for _, filter := range ref.Filters {
-					if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
-						ref := filter.RequestMirror.BackendRef
-						for _, service := range referencedServices {
-							if string(ref.Name) == service.Name {
-								ns := ref.Namespace
-								// Corresponding service found, update the name.
-								if ns == nil || string(*ns) == service.Namespace {
-									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace)) // Set the namespace to nil since all the services are created in the same namespace as the Route.
-									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Namespace = nil
-								}
+			for k, filter := range ref.Filters {
+				if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
+					mirrorRef := filter.RequestMirror.BackendRef
+					for _, service := range referencedServices {
+						if string(mirrorRef.Name) == service.Name {
+							ns := mirrorRef.Namespace
+							// Corresponding service found, update the name.
+							if ns == nil || string(*ns) == service.Namespace {
+								object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace)) // Set the namespace to nil since all the services are created in the same namespace as the Route.
+								object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef.Namespace = nil
 							}
 						}
 					}

--- a/internal/resources/gatewayapi/grpcroute/grpcroute_test.go
+++ b/internal/resources/gatewayapi/grpcroute/grpcroute_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcroute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	tenantNamespace = "tenant-primary"
+	originNamespace = "default"
+	routeName       = "demo"
+	backendName     = "backend"
+	mirrorName      = "mirror"
+)
+
+// The old code indexed the rule-level filter slice with the backendRef index, so it
+// missed this rewrite and panicked when the rule itself had no filters.
+func TestCreateOrUpdateGRPCRoute_RewritesBackendRefFilterMirror(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := gwapiv1.Install(s); err != nil {
+		t.Fatalf("gateway api scheme: %v", err)
+	}
+	client := fake.NewClientBuilder().WithScheme(s).Build()
+
+	object := &gwapiv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: routeName, Namespace: originNamespace},
+		Spec: gwapiv1.GRPCRouteSpec{
+			Rules: []gwapiv1.GRPCRouteRule{{
+				BackendRefs: []gwapiv1.GRPCBackendRef{{
+					BackendRef: gwapiv1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{Name: backendName},
+					},
+					Filters: []gwapiv1.GRPCRouteFilter{{
+						Type: gwapiv1.GRPCRouteFilterRequestMirror,
+						RequestMirror: &gwapiv1.HTTPRequestMirrorFilter{
+							BackendRef: gwapiv1.BackendObjectReference{Name: mirrorName},
+						},
+					}},
+				}},
+			}},
+		},
+	}
+
+	referencedServices := []metav1.ObjectMeta{
+		{Name: backendName, Namespace: originNamespace},
+		{Name: mirrorName, Namespace: originNamespace},
+	}
+
+	if err := CreateOrUpdateGRPCRoute(context.Background(), logr.Discard(), client, object,
+		referencedServices, tenantNamespace, routeName, &kubelbv1alpha1.Tenant{}, kubelbv1alpha1.AnnotationSettings{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	applied := &gwapiv1.GRPCRoute{}
+	key := types.NamespacedName{Namespace: tenantNamespace, Name: kubelb.GenerateName(routeName, originNamespace)}
+	if err := client.Get(context.Background(), key, applied); err != nil {
+		t.Fatalf("get %s: %v", key, err)
+	}
+
+	gotMirror := applied.Spec.Rules[0].BackendRefs[0].Filters[0].RequestMirror.BackendRef
+	wantMirror := gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, mirrorName, originNamespace))
+	if gotMirror.Name != wantMirror {
+		t.Errorf("mirror backendRef name = %q, want %q", gotMirror.Name, wantMirror)
+	}
+	if gotMirror.Namespace != nil {
+		t.Errorf("mirror backendRef namespace = %q, want nil", *gotMirror.Namespace)
+	}
+}

--- a/internal/resources/gatewayapi/httproute/httproute.go
+++ b/internal/resources/gatewayapi/httproute/httproute.go
@@ -73,19 +73,17 @@ func CreateOrUpdateHTTPRoute(ctx context.Context, log logr.Logger, client ctrlcl
 				}
 			}
 			// Collect services from the filters.
-			if ref.Filters != nil {
-				for _, filter := range ref.Filters {
-					if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
-						ref := filter.RequestMirror.BackendRef
-						for _, service := range referencedServices {
-							if string(ref.Name) == service.Name {
-								ns := ref.Namespace
-								// Corresponding service found, update the name.
-								if ns == nil || string(*ns) == service.Namespace {
-									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace))
-									// Set the namespace to nil since all the services are created in the same namespace as the Route.
-									object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Namespace = nil
-								}
+			for k, filter := range ref.Filters {
+				if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
+					mirrorRef := filter.RequestMirror.BackendRef
+					for _, service := range referencedServices {
+						if string(mirrorRef.Name) == service.Name {
+							ns := mirrorRef.Namespace
+							// Corresponding service found, update the name.
+							if ns == nil || string(*ns) == service.Namespace {
+								object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace))
+								// Set the namespace to nil since all the services are created in the same namespace as the Route.
+								object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef.Namespace = nil
 							}
 						}
 					}

--- a/internal/resources/gatewayapi/httproute/httproute_test.go
+++ b/internal/resources/gatewayapi/httproute/httproute_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httproute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	tenantNamespace = "tenant-primary"
+	originNamespace = "default"
+	routeName       = "demo"
+	backendName     = "backend"
+	mirrorName      = "mirror"
+)
+
+func scheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := gwapiv1.Install(s); err != nil {
+		t.Fatalf("gateway api scheme: %v", err)
+	}
+	return s
+}
+
+func referencedServices() []metav1.ObjectMeta {
+	return []metav1.ObjectMeta{
+		{Name: backendName, Namespace: originNamespace},
+		{Name: mirrorName, Namespace: originNamespace},
+	}
+}
+
+// routeWithBackendRefFilter hangs the RequestMirror filter off the backendRef and
+// leaves the rule itself without filters, which is what made the old code index a
+// zero-length slice.
+func routeWithBackendRefFilter() *gwapiv1.HTTPRoute {
+	return &gwapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: routeName, Namespace: originNamespace},
+		Spec: gwapiv1.HTTPRouteSpec{
+			Rules: []gwapiv1.HTTPRouteRule{{
+				BackendRefs: []gwapiv1.HTTPBackendRef{{
+					BackendRef: gwapiv1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{Name: backendName},
+					},
+					Filters: []gwapiv1.HTTPRouteFilter{{
+						Type: gwapiv1.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gwapiv1.HTTPRequestMirrorFilter{
+							BackendRef: gwapiv1.BackendObjectReference{Name: mirrorName},
+						},
+					}},
+				}},
+			}},
+		},
+	}
+}
+
+// The old code indexed the rule-level filter slice with the backendRef index, so it
+// missed this rewrite and panicked when the rule had fewer filters than backendRefs.
+func TestCreateOrUpdateHTTPRoute_RewritesBackendRefFilterMirror(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(scheme(t)).Build()
+	object := routeWithBackendRefFilter()
+
+	if err := CreateOrUpdateHTTPRoute(context.Background(), logr.Discard(), client, object,
+		referencedServices(), tenantNamespace, routeName, &kubelbv1alpha1.Tenant{}, kubelbv1alpha1.AnnotationSettings{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	applied := &gwapiv1.HTTPRoute{}
+	key := types.NamespacedName{Namespace: tenantNamespace, Name: kubelb.GenerateName(routeName, originNamespace)}
+	if err := client.Get(context.Background(), key, applied); err != nil {
+		t.Fatalf("get %s: %v", key, err)
+	}
+
+	backendRef := applied.Spec.Rules[0].BackendRefs[0]
+	wantBackend := gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, backendName, originNamespace))
+	if backendRef.Name != wantBackend {
+		t.Errorf("backendRef name = %q, want %q", backendRef.Name, wantBackend)
+	}
+
+	gotMirror := backendRef.Filters[0].RequestMirror.BackendRef
+	wantMirror := gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, mirrorName, originNamespace))
+	if gotMirror.Name != wantMirror {
+		t.Errorf("mirror backendRef name = %q, want %q", gotMirror.Name, wantMirror)
+	}
+	if gotMirror.Namespace != nil {
+		t.Errorf("mirror backendRef namespace = %q, want nil", *gotMirror.Namespace)
+	}
+}
+
+// Guards against the backendRef-level rewrite clobbering this one.
+func TestCreateOrUpdateHTTPRoute_RewritesRuleLevelMirror(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(scheme(t)).Build()
+	object := &gwapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: routeName, Namespace: originNamespace},
+		Spec: gwapiv1.HTTPRouteSpec{
+			Rules: []gwapiv1.HTTPRouteRule{{
+				Filters: []gwapiv1.HTTPRouteFilter{{
+					Type: gwapiv1.HTTPRouteFilterRequestMirror,
+					RequestMirror: &gwapiv1.HTTPRequestMirrorFilter{
+						BackendRef: gwapiv1.BackendObjectReference{Name: mirrorName},
+					},
+				}},
+				BackendRefs: []gwapiv1.HTTPBackendRef{{
+					BackendRef: gwapiv1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{Name: backendName},
+					},
+				}},
+			}},
+		},
+	}
+
+	if err := CreateOrUpdateHTTPRoute(context.Background(), logr.Discard(), client, object,
+		referencedServices(), tenantNamespace, routeName, &kubelbv1alpha1.Tenant{}, kubelbv1alpha1.AnnotationSettings{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	applied := &gwapiv1.HTTPRoute{}
+	key := types.NamespacedName{Namespace: tenantNamespace, Name: kubelb.GenerateName(routeName, originNamespace)}
+	if err := client.Get(context.Background(), key, applied); err != nil {
+		t.Fatalf("get %s: %v", key, err)
+	}
+
+	got := applied.Spec.Rules[0].Filters[0].RequestMirror.BackendRef
+	want := gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, mirrorName, originNamespace))
+	if got.Name != want {
+		t.Errorf("rule filter mirror name = %q, want %q", got.Name, want)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Gateway duplicate guard compared names only, so two tenant-cluster namespaces claiming the same Gateway name landed on one management-cluster object and overwrote each other. Both Routes stamp themselves controller owner and the reconciler `Owns` the Gateway, so it flaps indefinitely rather than clobbering once. Guard now compares the origin labels: first claimant keeps the name, later ones rejected. Gateways without those labels are adopted, so upgrades don't break existing tenants.

Deliberately no rename to disambiguate. Envoy Gateway hashes `<namespace>/<name>` into its proxy Service name, so renaming provisions a new Service and rotates the LB IP for every L7 tenant at once.

Two bugs found in the same path:

- `manageRoutes` assigned every helper error to `err`, then returned `UpdateRouteStatus(...)`, so it was never read again. No condition, no event, no requeue, reconcile counted as `result="success"`. `MaxGatewaysPerTenant` rejections have always been invisible this way. Now recorded and returned, matching `manageServices`.
- backendRef-level `RequestMirror` rewrite indexed the rule-level `Filters` slice with the backendRef index, writing `Rules[i].Filters[j]` instead of `Rules[i].BackendRefs[j].Filters[k]`. Mirror name never rewritten, a correct rule-level filter could be clobbered, and a rule with fewer rule-level filters than backendRefs panicked on index out of range. Reachable from tenant-supplied content.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:


```release-note
Fixed Gateway objects from different tenant cluster namespaces silently overwriting each other in the management cluster. The first namespace to claim a Gateway name keeps it and later claimants get an error on the Route. Errors from applying Ingress, Gateway, HTTPRoute and GRPCRoute objects are now reported as a condition and event on the Route and retried, instead of being discarded.
```

```documentation
NONE
```