### PR TITLE
chore(addons): bump addons to v0.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ RECONCILE_HELPER_PATH = "internal/resources/reconciling/zz_generated_reconcile.g
 
 GATEWAY_RELEASE_CHANNEL ?= standard
 GATEWAY_API_VERSION ?= v1.6.1
-KUBELB_ADDONS_CHART_VERSION ?= v0.4.0
+KUBELB_ADDONS_CHART_VERSION ?= v0.5.0
 
 export GOPATH?=$(shell go env GOPATH)
 export CGO_ENABLED=0

--- a/charts/kubelb-addons/Chart.lock
+++ b/charts/kubelb-addons/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 0.16.1
 - name: agentgateway-crds
   repository: oci://cr.agentgateway.dev/charts
-  version: 1.4.0
+  version: 1.4.1
 - name: agentgateway
   repository: oci://cr.agentgateway.dev/charts
-  version: 1.4.0
-digest: sha256:e5c060196ed5d2a85772a4872445810e78d21dfa9cd84b0424591d909e750d29
-generated: "2026-08-10T11:01:00.828333+05:00"
+  version: 1.4.1
+digest: sha256:0b8e77887c98cfa5f6621ef4a8565ead77acde90e98854f5ddd52e18bb6b7430
+generated: "2026-08-11T12:01:41.983222+05:00"

--- a/charts/kubelb-addons/Chart.yaml
+++ b/charts/kubelb-addons/Chart.yaml
@@ -7,8 +7,8 @@ maintainers:
   - name: Kubermatic
     email: support@kubermatic.com
     url: https://kubermatic.com
-version: v0.4.0
-appVersion: v0.4.0
+version: v0.5.0
+appVersion: v0.5.0
 dependencies:
   - name: ingress-nginx
     repository: https://kubernetes.github.io/ingress-nginx

--- a/charts/kubelb-addons/Chart.yaml
+++ b/charts/kubelb-addons/Chart.yaml
@@ -34,8 +34,8 @@ dependencies:
   - name: agentgateway-crds
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway-crds.enabled
-    version: 1.4.0
+    version: 1.4.1
   - name: agentgateway
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway.enabled
-    version: 1.4.0
+    version: 1.4.1

--- a/charts/kubelb-addons/README.md
+++ b/charts/kubelb-addons/README.md
@@ -89,8 +89,8 @@ These are the default values to use when Gateway API is disabled for KubeLB in f
 |------------|------|---------|
 | https://kubernetes-sigs.github.io/external-dns | external-dns | 1.21.1 |
 | https://kubernetes.github.io/ingress-nginx | ingress-nginx | 4.15.1 |
-| oci://cr.agentgateway.dev/charts | agentgateway | 1.4.0 |
-| oci://cr.agentgateway.dev/charts | agentgateway-crds | 1.4.0 |
+| oci://cr.agentgateway.dev/charts | agentgateway | 1.4.1 |
+| oci://cr.agentgateway.dev/charts | agentgateway-crds | 1.4.1 |
 | oci://docker.io/envoyproxy | envoy-gateway(gateway-helm) | 1.8.3 |
 | oci://quay.io/jetstack/charts | cert-manager | 1.21.1 |
 | oci://quay.io/metallb/chart | metallb | 0.16.1 |

--- a/charts/kubelb-addons/README.md
+++ b/charts/kubelb-addons/README.md
@@ -2,12 +2,12 @@
 
 Helm chart for deploying optional addons to enhance KubeLB functionality.
 
-![Version: v0.4.0](https://img.shields.io/badge/Version-v0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square)
+![Version: v0.5.0](https://img.shields.io/badge/Version-v0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
 
 ## Installing the chart
 
 ```sh
-helm pull oci://quay.io/kubermatic/helm-charts/kubelb-addons --version=v0.4.0 --untardir "." --untar
+helm pull oci://quay.io/kubermatic/helm-charts/kubelb-addons --version=v0.5.0 --untardir "." --untar
 ## Create and update values.yaml with the required values.
 helm install kubelb-addons kubelb-addons --namespace kubelb -f values.yaml --create-namespace
 ```
@@ -21,7 +21,7 @@ All Helm charts are cryptographically signed using [Sigstore Cosign](https://git
 ### Verify Chart Signature
 
 ```bash
-cosign verify quay.io/kubermatic/helm-charts/kubelb-addons:v0.4.0 \
+cosign verify quay.io/kubermatic/helm-charts/kubelb-addons:v0.5.0 \
   --certificate-identity-regexp="^https://github.com/kubermatic/kubelb/.github/workflows/release.yml@refs/tags/addons-v.*" \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
- Bumps the addon chart to v0.5.0
- Bumps the `agentgateway` and `agentgateway-crds` subcharts from 1.4.0 to 1.4.1. 


**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Bump addons to v0.5.0
- Bump agentgateway and agentgateway-crds addon charts to 1.4.1
```

**Documentation**:
```documentation
NONE
```