### PR TITLE
chore: prune stale Gateway API CRDs on download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,13 +512,23 @@ update-gateway-api-crds:
 .PHONY: download-gateway-api-crds
 download-gateway-api-crds: ## Download Gateway API CRDs
 	@echo "Downloading Gateway API CRDs..."
-	@curl -s -k "https://api.github.com/repos/kubernetes-sigs/gateway-api/contents/config/crd/$(GATEWAY_RELEASE_CHANNEL)?ref=$(GATEWAY_API_VERSION)" | \
-		jq -r '.[] | select(.name != "kustomization.yaml") | .name' | \
-		while read filename; do \
-			echo "Downloading $$filename..."; \
-			curl -k -sLo "internal/resources/crds/gatewayapi/$(GATEWAY_RELEASE_CHANNEL)/$$filename" \
-				"https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GATEWAY_API_VERSION)/config/crd/$(GATEWAY_RELEASE_CHANNEL)/$$filename"; \
-		done
+	@dir="internal/resources/crds/gatewayapi/$(GATEWAY_RELEASE_CHANNEL)"; \
+	tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	files="$$(curl -sf -k "https://api.github.com/repos/kubernetes-sigs/gateway-api/contents/config/crd/$(GATEWAY_RELEASE_CHANNEL)?ref=$(GATEWAY_API_VERSION)" | \
+		jq -r '.[] | select(.name != "kustomization.yaml") | .name')"; \
+	if [ -z "$$files" ]; then \
+		echo "No CRDs listed for $(GATEWAY_API_VERSION)/$(GATEWAY_RELEASE_CHANNEL)"; \
+		exit 1; \
+	fi; \
+	for filename in $$files; do \
+		echo "Downloading $$filename..."; \
+		curl -k -sfLo "$$tmp/$$filename" \
+			"https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GATEWAY_API_VERSION)/config/crd/$(GATEWAY_RELEASE_CHANNEL)/$$filename" || exit 1; \
+	done; \
+	rm -rf "$$dir"; \
+	mkdir -p "$$dir"; \
+	mv "$$tmp"/* "$$dir/"
 	@echo "Gateway API CRDs downloaded successfully to internal/resources/crds/gatewayapi/$(GATEWAY_RELEASE_CHANNEL)/"
 
 .PHONY: reconciler-gen


### PR DESCRIPTION
**What this PR does / why we need it**:

`download-gateway-api-crds` wrote each upstream file into `internal/resources/crds/gatewayapi/<channel>/` in place. Files that disappear upstream between Gateway API versions were never removed, so they stayed pinned at whatever bundle-version last shipped them and kept getting installed into tenant clusters. That is how `gateway.networking.x-k8s.io_xlistenersets.yaml` sat at v1.4.1 while the other 25 CRDs moved to v1.6.1 (deleted in #565).

Downloads now stage into a temp dir and replace the channel dir only once every file has landed, so the tree always matches the upstream listing for `GATEWAY_API_VERSION`. An empty listing or a failed fetch aborts before the swap and leaves the existing CRDs in place.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```