### PR TITLE
chore(charts): pin kubelb-addons v0.5.0 in manager chart

### DIFF
--- a/charts/kubelb-manager/Chart.lock
+++ b/charts/kubelb-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubelb-addons
   repository: oci://quay.io/kubermatic/helm-charts
-  version: v0.4.0
-digest: sha256:6373216e2dd01b1022ff0cae17c95e30f1dd8d1ec9953e98e3fa9a8051572e25
-generated: "2026-04-27T15:40:45.897268+05:00"
+  version: v0.5.0
+digest: sha256:a430a9539eb8bfd7dfa3f36ee93f5b9fecb9ba3ab5fbbdc3e0aadba672d8beba
+generated: "2026-08-11T14:12:25.810278+05:00"

--- a/charts/kubelb-manager/Chart.yaml
+++ b/charts/kubelb-manager/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
   - name: kubelb-addons
     repository: oci://quay.io/kubermatic/helm-charts
     condition: kubelb-addons.enabled
-    version: v0.4.0
+    version: v0.5.0

--- a/charts/kubelb-manager/README.md
+++ b/charts/kubelb-manager/README.md
@@ -47,7 +47,7 @@ cosign verify quay.io/kubermatic/kubelb-manager:v1.3.5 \
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://quay.io/kubermatic/helm-charts | kubelb-addons | v0.4.0 |
+| oci://quay.io/kubermatic/helm-charts | kubelb-addons | v0.5.0 |
 
 ## Values
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #564. The manager chart carries `kubelb-addons` as a dependency and still pinned v0.4.0, so a manager install would keep pulling the old addons chart.

Bumps the pin to v0.5.0, now that the chart is published to `oci://quay.io/kubermatic/helm-charts`, and syncs `Chart.lock` and the generated dependency table in the chart README.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

`make verify-helm-lock helm-lint` pass. Rebased on main after #564 merged and `addons-v0.5.0` was released. The manager chart's own `version`/`appVersion` are untouched.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```