### PR TITLE
fix: route teardown on disable, unserved GatewayClass signal, e2e harness gaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,9 @@ verify-boilerplate:  ## Run verify-boilerplate code.
 verify-imports:  ## Run verify-imports code.
 	./hack/verify-import-order.sh
 
+verify-e2e-loop-budgets:  ## Verify e2e retry-loop sleep budgets fit inside their step timeouts
+	./hack/verify-e2e-loop-budgets.sh
+
 verify-helm-lock:  ## Verify Helm chart lock files are in sync.
 	./hack/verify-helm-lock.sh
 
@@ -325,7 +328,9 @@ CHAINSAW_CLUSTERS += --cluster standalone=$(KUBECONFIGS_DIR)/standalone.kubeconf
 else
 CHAINSAW_EXCLUDE ?= --exclude-test-regex '.*/.*ing-conversion.*'
 endif
-CHAINSAW_FLAGS ?= --config $(CHAINSAW_CONFIG) --values $(CHAINSAW_VALUES) $(CHAINSAW_CLUSTERS) $(CHAINSAW_EXCLUDE)
+# --fast-namespace-deletion: don't block each test's cleanup on the ephemeral
+# namespace actually finalizing. Slow teardown was failing otherwise-green tests.
+CHAINSAW_FLAGS ?= --config $(CHAINSAW_CONFIG) --values $(CHAINSAW_VALUES) $(CHAINSAW_CLUSTERS) $(CHAINSAW_EXCLUDE) --fast-namespace-deletion
 
 .PHONY: e2e-setup-kind
 e2e-setup-kind: ## Setup Kind clusters for e2e tests (kubelb, tenant1, tenant2; standalone if ENABLE_STANDALONE=true)

--- a/charts/kubelb-ccm/templates/clusterrole.yaml
+++ b/charts/kubelb-ccm/templates/clusterrole.yaml
@@ -73,6 +73,16 @@ rules:
   - get
   - update
   - patch
+# Read-only: used to tell whether an unserved GatewayClass belongs to another
+# controller before warning the tenant about it.
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}
 {{- if not .Values.kubelb.disableGRPCRouteController }}
 - apiGroups:

--- a/config/ccm/rbac/role.yaml
+++ b/config/ccm/rbac/role.yaml
@@ -53,6 +53,14 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - gateways
   - grpcroutes
   - httproutes

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -78,6 +78,7 @@ try "Verify go.mod" make check-dependencies
 try "Verify YAML" yamllint -c .yamllint.conf .
 try "Verify boilerplate" make verify-boilerplate
 try "Verify imports" make verify-imports
+try "Verify e2e loop budgets" make verify-e2e-loop-budgets
 try "Verify shfmt" shfmt -l -sr -i 2 -d hack
 try "Verify licenses" ./hack/verify-licenses.sh
 

--- a/hack/e2e/deploy.sh
+++ b/hack/e2e/deploy.sh
@@ -36,11 +36,16 @@ GIT_COMMIT="${GIT_COMMIT:-$(git rev-parse --short HEAD)}"
 BUILD_DATE="${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
 # Cluster type detection
-USE_KIND="${USE_KIND:-auto}"                    # auto, true, false
-SKIP_BUILD="${SKIP_BUILD:-false}"               # Skip image building (use pre-built images)
-SKIP_IMAGE_LOAD="${SKIP_IMAGE_LOAD:-false}"     # Skip image loading
-METALLB_IP_RANGE="${METALLB_IP_RANGE:-}"        # Override MetalLB IP range for cloud
-CONVERSION_MODE="${CONVERSION_MODE:-false}"     # Deploy CCM in standalone conversion mode
+USE_KIND="${USE_KIND:-auto}"                # auto, true, false
+SKIP_BUILD="${SKIP_BUILD:-false}"           # Skip image building (use pre-built images)
+SKIP_IMAGE_LOAD="${SKIP_IMAGE_LOAD:-false}" # Skip image loading
+METALLB_IP_RANGE="${METALLB_IP_RANGE:-}"    # Override MetalLB IP range for cloud
+CONVERSION_MODE="${CONVERSION_MODE:-false}" # Deploy CCM in standalone conversion mode
+
+# Secret the manager generates per tenant, holding the scoped ServiceAccount
+# kubeconfig the CCM uses to reach the management cluster.
+TENANT_KUBECONFIG_SECRET="kubelb-ccm-kubeconfig"
+TENANT_KUBECONFIG_TIMEOUT="${TENANT_KUBECONFIG_TIMEOUT:-180}"
 ENABLE_STANDALONE="${ENABLE_STANDALONE:-false}" # Enable standalone cluster for conversion tests
 DEV_MODE="${DEV_MODE:-false}"                   # Minimal local-dev setup: kubelb + tenant1 only
 
@@ -375,17 +380,102 @@ setup_tenants() {
 }
 
 #######################################
+# Address of the management cluster API server as reachable from inside the
+# Docker network, i.e. from a pod running in one of the tenant kind clusters.
+#######################################
+kind_management_api_server() {
+  local internal_kubeconfig="${KUBECONFIGS_DIR}/kubelb-internal.kubeconfig"
+  local server=""
+
+  if [[ -f "${internal_kubeconfig}" ]]; then
+    server=$(awk '$1 == "server:" { print $2; exit }' "${internal_kubeconfig}")
+  fi
+
+  if [[ -z "${server}" ]]; then
+    local container_ip
+    container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kubelb-control-plane 2> /dev/null || echo "")
+    if [[ -n "${container_ip}" ]]; then
+      server="https://${container_ip}:6443"
+    fi
+  fi
+
+  if [[ -z "${server}" ]]; then
+    return 1
+  fi
+  echo "${server}"
+}
+
+#######################################
+# Write the manager-generated tenant kubeconfig for a tenant to a file.
+#
+# Real installs give the CCM the scoped ServiceAccount kubeconfig that the
+# manager writes into the kubelb-ccm-kubeconfig secret of the tenant-<name>
+# namespace, bound to the tenant Role. Handing e2e the cluster-admin
+# kubeconfig instead meant no test could ever fail on a tenant RBAC gap.
+#
+# Arguments:
+#   $1 - tenant name (Tenant CR name, e.g. "primary")
+#   $2 - output file
+#######################################
+fetch_tenant_kubeconfig() {
+  local tenant="$1"
+  local out_file="$2"
+  local namespace="tenant-${tenant}"
+  local manager_kubeconfig="${KUBECONFIGS_DIR}/kubelb.kubeconfig"
+  local deadline=$(($(date +%s) + TENANT_KUBECONFIG_TIMEOUT))
+  local kubeconfig=""
+
+  # The secret appears only after the manager has reconciled the Tenant CR and
+  # the token controller has populated the ServiceAccount token it is built
+  # from, so this races the helm install that just created the Tenant.
+  echodate "Waiting for ${namespace}/${TENANT_KUBECONFIG_SECRET} (scoped CCM kubeconfig)..."
+  while true; do
+    kubeconfig=$(kubectl --kubeconfig "${manager_kubeconfig}" -n "${namespace}" \
+      get secret "${TENANT_KUBECONFIG_SECRET}" \
+      -o go-template='{{ index .data "kubelb" | base64decode }}' 2> /dev/null || true)
+    if [[ -n "${kubeconfig}" ]]; then
+      break
+    fi
+    if [[ $(date +%s) -ge ${deadline} ]]; then
+      echodate "ERROR: secret ${namespace}/${TENANT_KUBECONFIG_SECRET} did not appear within ${TENANT_KUBECONFIG_TIMEOUT}s"
+      echodate "  The kubelb manager creates it while reconciling Tenant/${tenant}."
+      echodate "  Check: kubectl --kubeconfig ${manager_kubeconfig} get tenant ${tenant} -o yaml"
+      echodate "  and the manager logs in the kubelb namespace."
+      return 1
+    fi
+    sleep 2
+  done
+
+  # The manager fills in the API server address it discovers from inside the
+  # management cluster: the cluster-info ConfigMap, falling back to the
+  # kubernetes EndpointSlice. With kind, cluster-info advertises the
+  # control-plane *container hostname* (https://kubelb-control-plane:6443),
+  # which only resolves from a tenant pod as long as Docker's embedded DNS is
+  # reachable through that cluster's CoreDNS. Pin the address to the
+  # control-plane container IP instead - the same address setup-kind.sh bakes
+  # into kubelb-internal.kubeconfig for the admin credential, and the one the
+  # EndpointSlice fallback would produce. Only the endpoint changes: the
+  # tenant ServiceAccount token and CA, the part under test, are kept as the
+  # manager generated them.
+  if is_kind_cluster; then
+    local server
+    if ! server=$(kind_management_api_server); then
+      echodate "ERROR: could not determine the internal API server address of the kubelb cluster"
+      return 1
+    fi
+    kubeconfig=$(echo "${kubeconfig}" | sed -E "s|^([[:space:]]*server:[[:space:]]*).*|\1${server}|")
+  fi
+
+  echo "${kubeconfig}" > "${out_file}"
+  chmod 600 "${out_file}"
+}
+
+#######################################
 # Deploy CCM to tenant clusters
 #######################################
 deploy_ccms() {
   echodate "Deploying CCMs to tenant clusters..."
   local deploy_start=$(nowms)
-
-  # Prepare kubeconfig for CCM to connect to kubelb management cluster
-  local kubelb_kubeconfig="${KUBECONFIGS_DIR}/kubelb.kubeconfig"
-  if is_kind_cluster; then
-    kubelb_kubeconfig="${KUBECONFIGS_DIR}/kubelb-internal.kubeconfig"
-  fi
 
   # Set pull policy based on cluster type
   local pull_policy="IfNotPresent"
@@ -404,11 +494,16 @@ deploy_ccms() {
       # Create kubelb namespace in tenant cluster
       kubectl create ns kubelb 2> /dev/null || true
 
-      # Skip kubelb-cluster secret in standalone conversion mode
+      # Skip kubelb-cluster secret in standalone conversion mode: that CCM
+      # never talks to a management cluster.
       if [[ "${CONVERSION_MODE}" != "true" ]]; then
-        # Create secret with kubeconfig to kubelb management cluster
+        # Create secret with the scoped tenant kubeconfig to the kubelb
+        # management cluster, mirroring a real tenant-cluster install.
+        local tenant_kubeconfig="${KUBECONFIGS_DIR}/tenant-${tenant}-ccm.kubeconfig"
+        fetch_tenant_kubeconfig "${tenant}" "${tenant_kubeconfig}" || exit 1
+
         kubectl -n kubelb create secret generic kubelb-cluster \
-          --from-file=kubelb="${kubelb_kubeconfig}" \
+          --from-file=kubelb="${tenant_kubeconfig}" \
           --dry-run=client -o yaml | kubectl apply -f -
       fi
 

--- a/hack/e2e/deploy.sh
+++ b/hack/e2e/deploy.sh
@@ -103,6 +103,34 @@ verify_kubeconfigs() {
 }
 
 #######################################
+# Wait on background jobs and fail the deploy if any of them did.
+#
+# A bare `wait` returns 0 no matter how its jobs exited, so readiness checks
+# collected that way were reported as passing even when they timed out, and
+# the deploy went on to announce success over a cluster that had nothing
+# running on it.
+#
+# Arguments:
+#   $1 - message to print when a job failed
+#   $@ - pids to wait on
+#######################################
+wait_all_or_die() {
+  local message="$1"
+  shift
+
+  local any_failed=false
+  local pid
+  for pid in "$@"; do
+    wait "${pid}" || any_failed=true
+  done
+
+  if [[ "${any_failed}" == "true" ]]; then
+    echodate "ERROR: ${message}"
+    exit 1
+  fi
+}
+
+#######################################
 # Build images using centralized make targets
 #######################################
 build_images() {
@@ -140,9 +168,12 @@ build_images() {
     echodate "Pushing images to registry..."
     docker tag kubelb:e2e "${KUBELB_IMAGE}"
     docker tag kubelb-ccm:e2e "${CCM_IMAGE}"
+    local push_pids=()
     docker push "${KUBELB_IMAGE}" &
+    push_pids+=($!)
     docker push "${CCM_IMAGE}" &
-    wait
+    push_pids+=($!)
+    wait_all_or_die "image push to ${IMAGE_REGISTRY} failed" "${push_pids[@]}"
   fi
 
   printElapsed "image_builds" ${build_start}
@@ -169,15 +200,20 @@ load_images() {
   # kubelb cluster: needs kubelb + ccm images
   # tenant clusters: need ccm image (CCM runs there)
   # standalone cluster: needs ccm image (standalone mode)
+  local load_pids=()
   kind load docker-image --name=kubelb "${KUBELB_IMAGE}" "${CCM_IMAGE}" &
+  load_pids+=($!)
   kind load docker-image --name=tenant1 "${CCM_IMAGE}" &
+  load_pids+=($!)
   if [[ "${DEV_MODE}" != "true" ]]; then
     kind load docker-image --name=tenant2 "${CCM_IMAGE}" &
+    load_pids+=($!)
   fi
   if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
     kind load docker-image --name=standalone "${CCM_IMAGE}" &
+    load_pids+=($!)
   fi
-  wait
+  wait_all_or_die "image load into the kind clusters failed" "${load_pids[@]}"
 
   printElapsed "image_loads" ${load_start}
 }
@@ -664,19 +700,22 @@ configure_standalone_metallb_pool() {
 deploy_test_apps() {
   echodate "Deploying shared test apps to all clusters..."
 
+  local apply_pids=()
   for tenant in "${!TENANT_MAP[@]}"; do
     local cluster="${TENANT_MAP[$tenant]}"
     KUBECONFIG="${KUBECONFIGS_DIR}/${cluster}.kubeconfig" \
       kubectl apply -f "${E2E_MANIFESTS_DIR}/test-apps/echo-server.yaml" &
+    apply_pids+=($!)
   done
 
   # Also deploy to standalone cluster if enabled
   if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
     KUBECONFIG="${KUBECONFIGS_DIR}/standalone.kubeconfig" \
       kubectl apply -f "${E2E_MANIFESTS_DIR}/test-apps/echo-server.yaml" &
+    apply_pids+=($!)
   fi
 
-  wait
+  wait_all_or_die "Shared test apps could not be applied" "${apply_pids[@]}"
   echodate "Test apps deployed (pods starting in background)"
 }
 
@@ -754,24 +793,30 @@ if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
 fi
 
 # Wait for all clusters to be ready in parallel
+cluster_ready_pids=()
 wait_for_ready &
+cluster_ready_pids+=($!)
 if [[ "${ENABLE_STANDALONE}" == "true" ]]; then
   wait_for_standalone_ready &
+  cluster_ready_pids+=($!)
 fi
-wait
+wait_all_or_die "cluster readiness checks failed" "${cluster_ready_pids[@]}"
 
 deploy_test_apps
 
 # Wait for KubeLB tenant envoy proxy deployments to be ready
 # These are created dynamically after CCM creates LoadBalancer CRDs, so poll for existence first
 echodate "Waiting for tenant envoy proxies..."
+envoy_pids=()
 KUBECONFIG="${KUBECONFIGS_DIR}/kubelb.kubeconfig" \
   wait_for_deployment_exist_and_ready tenant-primary envoy-tenant-primary 300 &
+envoy_pids+=($!)
 if [[ "${DEV_MODE}" != "true" ]]; then
   KUBECONFIG="${KUBECONFIGS_DIR}/kubelb.kubeconfig" \
     wait_for_deployment_exist_and_ready tenant-secondary envoy-tenant-secondary 300 &
+  envoy_pids+=($!)
 fi
-wait
+wait_all_or_die "tenant envoy proxies never became ready, the CCM is not propagating LoadBalancers" "${envoy_pids[@]}"
 echodate "Tenant envoy proxies ready"
 
 echodate ""

--- a/hack/verify-e2e-loop-budgets.sh
+++ b/hack/verify-e2e-loop-budgets.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The KubeLB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A chainsaw retry loop whose sleep budget exceeds its step timeout is killed
+# mid-wait: the test fails without ever printing the loop's own failure
+# message or diagnostics, and slow-but-converging waits die early (this is
+# how backend-transport-switch and the Aug 2026 airgap flakes bit us).
+#
+# Heuristic per script operation (from one `timeout: Ns` line to the next):
+# max(seq 1 N) * max(sleep S) must not exceed the timeout. Command overhead
+# (kubectl, curl --max-time) is deliberately ignored, so equality passes;
+# only loops that cannot finish even with instant commands are flagged.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+source hack/lib.sh
+
+FAILED=0
+
+while IFS= read -r file; do
+  violations=$(awk '
+    function flush() {
+      if (t > 0 && n > 0 && s > 0 && n * s > t) {
+        printf "  line %d: timeout=%ds but loop sleeps up to %dx%ds=%ds\n", tline, t, n, s, n * s
+      }
+      n = 0
+      s = 0
+    }
+    match($0, /timeout:[ ]*[0-9]+s/) {
+      flush()
+      t = substr($0, RSTART, RLENGTH)
+      gsub(/[^0-9]/, "", t)
+      t += 0
+      tline = NR
+      next
+    }
+    match($0, /seq 1 [0-9]+/) {
+      v = substr($0, RSTART + 6, RLENGTH - 6) + 0
+      if (v > n) n = v
+    }
+    match($0, /sleep [0-9]+/) {
+      v = substr($0, RSTART + 6, RLENGTH - 6) + 0
+      if (v > s) s = v
+    }
+    END { flush() }
+  ' "$file")
+  if [[ -n "$violations" ]]; then
+    echodate "FAIL: ${file}"
+    echo "$violations"
+    FAILED=1
+  fi
+done < <(find test/e2e/tests test/e2e/step-templates -name '*.yaml')
+
+if [[ $FAILED -ne 0 ]]; then
+  echodate "Loop budgets above exceed their step timeout. Either raise the"
+  echodate "step timeout past the loop's worst case or shrink the loop; see"
+  echodate "the pitfalls section in test/e2e/AGENTS.md."
+  exit 1
+fi
+
+echodate "All e2e retry-loop budgets fit inside their step timeouts."

--- a/internal/controllers/ccm/gateway_class_signal_test.go
+++ b/internal/controllers/ccm/gateway_class_signal_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ccm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	gatewayhelper "k8c.io/kubelb/internal/resources/gatewayapi/gateway"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func gatewaySignalScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := gwapiv1.Install(s); err != nil {
+		t.Fatalf("failed to build scheme: %v", err)
+	}
+	return s
+}
+
+func gatewayNamed(class string, finalizers ...string) *gwapiv1.Gateway {
+	return &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       gatewayhelper.ParentGatewayName,
+			Namespace:  "default",
+			Finalizers: finalizers,
+		},
+		Spec: gwapiv1.GatewaySpec{GatewayClassName: gwapiv1.ObjectName(class)},
+	}
+}
+
+func newGatewaySignalReconciler(t *testing.T, useGatewayClass bool, objects ...ctrlruntimeclient.Object) (*GatewayReconciler, *events.FakeRecorder) {
+	t.Helper()
+	scheme := gatewaySignalScheme(t)
+	recorder := events.NewFakeRecorder(16)
+
+	return &GatewayReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objects...).
+			Build(),
+		Log:             logr.Discard(),
+		Scheme:          scheme,
+		Recorder:        recorder,
+		UseGatewayClass: useGatewayClass,
+	}, recorder
+}
+
+func warningFor(t *testing.T, recorder *events.FakeRecorder) string {
+	t.Helper()
+	select {
+	case e := <-recorder.Events:
+		return e
+	default:
+		return ""
+	}
+}
+
+// The tenant otherwise sees the Gateway API default status,
+// Accepted=Unknown/Pending, which is indistinguishable from a dead controller.
+func TestWarnGatewayClassNotAcceptedEmitsWarning(t *testing.T) {
+	gateway := gatewayNamed("nginx")
+	r, recorder := newGatewaySignalReconciler(t, true, gateway)
+
+	r.warnGatewayClassNotAccepted(context.Background(), logr.Discard(), gateway)
+
+	event := warningFor(t, recorder)
+	if !strings.Contains(event, EventReasonGatewayClassNotAccepted) {
+		t.Errorf("expected a %s event, got %q", EventReasonGatewayClassNotAccepted, event)
+	}
+	if !strings.Contains(event, "nginx") {
+		t.Errorf("expected the event to name the class, got %q", event)
+	}
+}
+
+// A GatewayClass object that exists designates another controller, and that
+// controller owns the Gateway's status. Warning there would be wrong.
+func TestWarnGatewayClassNotAcceptedStaysQuietWhenClassIsClaimed(t *testing.T) {
+	gateway := gatewayNamed("nginx")
+	class := &gwapiv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "nginx"}}
+	r, recorder := newGatewaySignalReconciler(t, true, gateway, class)
+
+	r.warnGatewayClassNotAccepted(context.Background(), logr.Discard(), gateway)
+
+	if event := warningFor(t, recorder); event != "" {
+		t.Errorf("expected no event for a claimed class, got %q", event)
+	}
+}
+
+// A Gateway still carrying the finalizer was demonstrably adopted by KubeLB
+// before the class mapping changed, so the warning is KubeLB's to emit even
+// though another controller now owns the class.
+func TestWarnGatewayClassNotAcceptedWarnsOnAdoptedGateway(t *testing.T) {
+	gateway := gatewayNamed("nginx", CleanupFinalizer)
+	class := &gwapiv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "nginx"}}
+	r, recorder := newGatewaySignalReconciler(t, true, gateway, class)
+
+	r.warnGatewayClassNotAccepted(context.Background(), logr.Discard(), gateway)
+
+	event := warningFor(t, recorder)
+	if !strings.Contains(event, "no longer served") {
+		t.Errorf("expected the teardown wording for an adopted Gateway, got %q", event)
+	}
+}
+
+func TestWarnGatewayClassNotAcceptedIgnoresServedAndForeignGateways(t *testing.T) {
+	tests := []struct {
+		name            string
+		gateway         *gwapiv1.Gateway
+		useGatewayClass bool
+	}{
+		{
+			name:            "class is served",
+			gateway:         gatewayNamed(gatewayhelper.GatewayClassName),
+			useGatewayClass: true,
+		},
+		{
+			name:            "class matching is off",
+			gateway:         gatewayNamed("nginx"),
+			useGatewayClass: false,
+		},
+		{
+			name: "another name, not KubeLB's to comment on",
+			gateway: &gwapiv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"},
+				Spec:       gwapiv1.GatewaySpec{GatewayClassName: "nginx"},
+			},
+			useGatewayClass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, recorder := newGatewaySignalReconciler(t, tt.useGatewayClass, tt.gateway)
+
+			r.warnGatewayClassNotAccepted(context.Background(), logr.Discard(), tt.gateway)
+
+			if event := warningFor(t, recorder); event != "" {
+				t.Errorf("expected no event, got %q", event)
+			}
+		})
+	}
+}
+
+// Reconcile has to see an unserved Gateway to warn about it, but a foreign
+// controller rewriting that Gateway's status must not enqueue it.
+func TestShouldObserveAdmitsUnservedGatewayNamedKubelb(t *testing.T) {
+	r, _ := newGatewaySignalReconciler(t, true)
+
+	unserved := gatewayNamed("nginx")
+	if r.shouldReconcile(unserved) {
+		t.Error("expected an unserved class to stay out of the reconcile path")
+	}
+	if !r.shouldObserve(unserved) {
+		t.Error("expected an unserved class to be observed")
+	}
+
+	foreign := &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"},
+		Spec:       gwapiv1.GatewaySpec{GatewayClassName: "nginx"},
+	}
+	if r.shouldObserve(foreign) {
+		t.Error("expected a Gateway with another name to be ignored entirely")
+	}
+}

--- a/internal/controllers/ccm/gateway_controller.go
+++ b/internal/controllers/ccm/gateway_controller.go
@@ -31,6 +31,7 @@ import (
 	ccmmetrics "k8c.io/kubelb/internal/metricsutil/ccm"
 	gatewayhelper "k8c.io/kubelb/internal/resources/gatewayapi/gateway"
 
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -51,6 +52,12 @@ import (
 
 const (
 	GatewayControllerName = "gateway-controller"
+
+	// EventReasonGatewayClassNotAccepted is the Event reason used to tell a
+	// tenant that their Gateway names a GatewayClass KubeLB does not serve.
+	// Gateway API defines no condition reason for "no controller claims this
+	// class", so the signal is an Event rather than a status write.
+	EventReasonGatewayClassNotAccepted = "GatewayClassNotAccepted"
 )
 
 // GatewayReconciler reconciles a Gateway Object
@@ -72,6 +79,7 @@ type GatewayReconciler struct {
 // +kubebuilder:rbac:groups=kubelb.k8c.io,resources=routes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 
 func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("name", req.NamespacedName)
@@ -103,6 +111,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if !r.shouldReconcile(resource) {
+		r.warnGatewayClassNotAccepted(ctx, log, resource)
 		ccmmetrics.GatewayReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSkipped).Inc()
 		return reconcile.Result{}, nil
 	}
@@ -217,15 +226,23 @@ func (r *GatewayReconciler) resourceFilter() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			if obj, ok := e.Object.(*gwapiv1.Gateway); ok {
-				return r.shouldReconcile(obj)
+				return r.shouldObserve(obj)
 			}
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if obj, ok := e.ObjectNew.(*gwapiv1.Gateway); ok {
-				return r.shouldReconcile(obj)
+			oldObj, okOld := e.ObjectOld.(*gwapiv1.Gateway)
+			newObj, okNew := e.ObjectNew.(*gwapiv1.Gateway)
+			if !okOld || !okNew {
+				return false
 			}
-			return false
+			if r.shouldReconcile(newObj) {
+				return true
+			}
+			// Gateways of a foreign controller are only admitted when their spec
+			// moved. Those controllers rewrite Gateway status continuously and
+			// none of that can change whether KubeLB serves the class.
+			return r.shouldObserve(newObj) && oldObj.Generation != newObj.Generation
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			if obj, ok := e.Object.(*gwapiv1.Gateway); ok {
@@ -246,6 +263,74 @@ func (r *GatewayReconciler) resourceFilter() predicate.Predicate {
 // In Community Edition, only a single Gateway with the name "kubelb" is reconciled.
 func (r *GatewayReconciler) shouldReconcile(gateway *gwapiv1.Gateway) bool {
 	return gatewayhelper.ShouldReconcileResource(gateway, r.UseGatewayClass)
+}
+
+// shouldObserve widens shouldReconcile to the Gateways that carry KubeLB's own
+// name but a GatewayClass it does not serve. Reconcile has to see them to warn
+// their owner, and only Reconcile can afford the GatewayClass lookup that
+// decides whether the warning is KubeLB's to emit.
+func (r *GatewayReconciler) shouldObserve(gateway *gwapiv1.Gateway) bool {
+	return r.shouldReconcile(gateway) || r.droppedOnGatewayClass(gateway)
+}
+
+// droppedOnGatewayClass reports whether the only thing keeping this Gateway out
+// of the reconcile path is its GatewayClass. A Gateway with a different name is
+// not KubeLB's to comment on, whatever class it names.
+func (r *GatewayReconciler) droppedOnGatewayClass(gateway *gwapiv1.Gateway) bool {
+	return r.UseGatewayClass &&
+		gateway.Name == gatewayhelper.ParentGatewayName &&
+		string(gateway.Spec.GatewayClassName) != gatewayhelper.GatewayClassName
+}
+
+// warnGatewayClassNotAccepted tells the tenant why their Gateway is being
+// ignored, instead of leaving it at the Gateway API default status of
+// "Accepted: Unknown, Pending" that is indistinguishable from a dead
+// controller.
+//
+// The signal is an Event and never a status write: Gateway API reserves the
+// status of a Gateway for the controller named by its GatewayClass, and KubeLB
+// registers no GatewayClass and no controllerName in the tenant cluster, so it
+// can never be that controller for a class it does not serve. An Event is
+// additive and cannot fight whichever controller does own the class.
+//
+// A Gateway KubeLB never adopted stays untouched while a GatewayClass object of
+// that name exists, because that object hands the Gateway to another controller
+// and the warning would be both wrong and confusing there.
+func (r *GatewayReconciler) warnGatewayClassNotAccepted(ctx context.Context, log logr.Logger, gateway *gwapiv1.Gateway) {
+	if r.Recorder == nil || !r.droppedOnGatewayClass(gateway) {
+		return
+	}
+
+	class := string(gateway.Spec.GatewayClassName)
+	adopted := controllerutil.ContainsFinalizer(gateway, CleanupFinalizer)
+	if !adopted && gatewayClassClaimed(ctx, r.Client, class) {
+		return
+	}
+
+	log.Info("Gateway names a GatewayClass that KubeLB does not serve", "gatewayClass", class, "adopted", adopted)
+
+	note := "GatewayClass %q is not served by KubeLB, this Gateway is ignored and no load balancer is provisioned for it. Served GatewayClass: %s"
+	if adopted {
+		note = "GatewayClass %q is no longer served by KubeLB, the load balancer configuration for this Gateway is being removed. Served GatewayClass: %s"
+	}
+	r.Recorder.Eventf(gateway, nil, corev1.EventTypeWarning, EventReasonGatewayClassNotAccepted, "Reconciling", note, class, gatewayhelper.GatewayClassName)
+}
+
+// gatewayClassClaimed reports whether a GatewayClass object of that name exists
+// in the tenant cluster. KubeLB registers no GatewayClass and no controllerName
+// there, it matches on the class name alone, so a GatewayClass that does exist
+// always designates a different controller and its Gateways are that
+// controller's to accept or reject. A failed lookup counts as claimed so that
+// KubeLB never warns on a Gateway it cannot prove is unserved.
+func gatewayClassClaimed(ctx context.Context, reader ctrlclient.Reader, name string) bool {
+	if name == "" {
+		return false
+	}
+	class := &gwapiv1.GatewayClass{}
+	if err := reader.Get(ctx, ctrlclient.ObjectKey{Name: name}, class); err != nil {
+		return !kerrors.IsNotFound(err)
+	}
+	return true
 }
 
 func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controllers/kubelb/route_controller.go
+++ b/internal/controllers/kubelb/route_controller.go
@@ -43,6 +43,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	unstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -128,7 +129,7 @@ func (r *RouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// Resource is marked for deletion
 	if resource.DeletionTimestamp != nil {
 		if controllerutil.ContainsFinalizer(resource, CleanupFinalizer) {
-			return r.cleanup(ctx, resource)
+			return r.cleanup(ctx, resource, false)
 		}
 		// Finalizer doesn't exist so clean up is already done
 		return reconcile.Result{}, nil
@@ -141,9 +142,12 @@ func (r *RouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return reconcile.Result{}, err
 	}
 
-	// If the resource is disabled, we need to clean up the resources
+	// The resource type was disabled at the tenant or global level. Tear down
+	// whatever was generated while it was enabled, otherwise the management
+	// cluster keeps serving a configuration that is supposed to be off.
 	if controllerutil.ContainsFinalizer(resource, CleanupFinalizer) && disabled {
-		return r.cleanup(ctx, resource)
+		managermetrics.RouteReconcileTotal.WithLabelValues(req.Namespace, routeType, metricsutil.ResultSkipped).Inc()
+		return r.cleanup(ctx, resource, true)
 	}
 
 	if !shouldReconcile {
@@ -205,9 +209,20 @@ func (r *RouteReconciler) reconcile(ctx context.Context, log logr.Logger, route 
 	return nil
 }
 
-func (r *RouteReconciler) cleanup(ctx context.Context, route *kubelbv1alpha1.Route) (ctrl.Result, error) {
-	// Route will be removed automatically because of owner reference. We need to take care of removing
-	// the services while ensuring that the services are not being used by other routes.
+// cleanup removes everything the Route generated in the management cluster and
+// drops the finalizer. resetStatus must be true whenever the Route object
+// itself survives the teardown, so the status stops advertising sub-resources
+// that no longer exist; the CCM mirrors that status back onto the tenant's
+// object.
+func (r *RouteReconciler) cleanup(ctx context.Context, route *kubelbv1alpha1.Route, resetStatus bool) (ctrl.Result, error) {
+	// The generated route resource is garbage collected via its owner reference
+	// only when the Route itself is deleted. On the teardown paths the Route
+	// survives, so it has to be deleted explicitly.
+	if err := r.deleteGeneratedRoute(ctx, route); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Remove the services while ensuring that they are not being used by other routes.
 	for _, value := range route.Status.Resources.Services {
 		log := r.Log.WithValues("name", value.Name, "namespace", value.Namespace)
 		svc := corev1.Service{
@@ -231,12 +246,64 @@ func (r *RouteReconciler) cleanup(ctx context.Context, route *kubelbv1alpha1.Rou
 		return reconcile.Result{}, fmt.Errorf("failed to deallocate ports: %w", err)
 	}
 
+	if resetStatus {
+		if err := r.resetGeneratedResourcesStatus(ctx, route); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	controllerutil.RemoveFinalizer(route, CleanupFinalizer)
 	if err := r.Update(ctx, route); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// deleteGeneratedRoute deletes the resource that was generated in the
+// management cluster for this Route. The kind comes from the embedded source
+// object and the name from the status, which is the only record of what was
+// actually created.
+func (r *RouteReconciler) deleteGeneratedRoute(ctx context.Context, route *kubelbv1alpha1.Route) error {
+	generatedName := route.Status.Resources.Route.GeneratedName
+	if generatedName == "" || route.Spec.Source.Kubernetes == nil {
+		return nil
+	}
+
+	gvk := route.Spec.Source.Kubernetes.Route.GroupVersionKind()
+	if gvk.Empty() {
+		return nil
+	}
+
+	generated := &unstructuredv1.Unstructured{}
+	generated.SetGroupVersionKind(gvk)
+	generated.SetName(generatedName)
+	generated.SetNamespace(route.Namespace)
+
+	r.Log.V(1).Info("Deleting generated route resource", "name", generatedName, "namespace", route.Namespace, "kind", gvk.Kind)
+
+	// A kind that the cluster no longer serves cannot have a leftover resource.
+	if err := r.Delete(ctx, generated); err != nil && !kerrors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
+		return fmt.Errorf("failed to delete generated %s: %w", gvk.Kind, err)
+	}
+	return nil
+}
+
+// resetGeneratedResourcesStatus clears the sub-resource status of a Route whose
+// generated resources were torn down, while keeping the conditions that explain
+// why. Leaving the old entries in place would keep the CCM mirroring an address
+// for a route that is no longer served.
+func (r *RouteReconciler) resetGeneratedResourcesStatus(ctx context.Context, route *kubelbv1alpha1.Route) error {
+	routeStatus := route.Status.DeepCopy()
+	routeStatus.Resources.Services = nil
+	routeStatus.Resources.Route = kubelbv1alpha1.ResourceState{
+		Conditions: routeStatus.Resources.Route.Conditions,
+	}
+
+	if err := r.UpdateRouteStatus(ctx, route, *routeStatus); err != nil {
+		return fmt.Errorf("failed to reset route status: %w", err)
+	}
+	return nil
 }
 
 func (r *RouteReconciler) manageServices(ctx context.Context, log logr.Logger, route *kubelbv1alpha1.Route, annotations kubelbv1alpha1.AnnotationSettings) error {
@@ -412,6 +479,33 @@ func (r *RouteReconciler) UpdateRouteStatus(ctx context.Context, route *kubelbv1
 	})
 }
 
+// recordAppliedResource records the just-applied object in the Route status.
+//
+// The live object is preferred because it carries the sub-resource status, but
+// the read-after-write goes through the informer cache, which can still miss an
+// object that was created moments ago. The desired object is then the only
+// record of what was applied: recording an empty ResourceState instead would
+// strand the generated resource, because both cleanup and the CCM's status
+// projection key off GeneratedName.
+func recordAppliedResource[T any, PT interface {
+	*T
+	ctrlruntimeclient.Object
+}](ctx context.Context, client ctrlruntimeclient.Client, routeStatus *kubelbv1alpha1.RouteStatus, desired PT) error {
+	applied := ctrlruntimeclient.Object(desired)
+
+	live := PT(new(T))
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(desired), live); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get %T: %w", desired, err)
+		}
+	} else {
+		applied = live
+	}
+
+	updateResourceStatus(routeStatus, applied, nil)
+	return nil
+}
+
 func (r *RouteReconciler) manageRoutes(ctx context.Context, log logr.Logger, route *kubelbv1alpha1.Route, config *kubelbv1alpha1.Config, tenant *kubelbv1alpha1.Tenant, annotations kubelbv1alpha1.AnnotationSettings) error {
 	if route.Spec.Source.Kubernetes == nil {
 		return nil
@@ -461,57 +555,33 @@ func (r *RouteReconciler) manageRoutes(ctx context.Context, log logr.Logger, rou
 	case *v1.Ingress: // v1 "k8s.io/api/networking/v1"
 		applyErr = ingressHelpers.CreateOrUpdateIngress(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, config, tenant, annotations)
 		if applyErr == nil {
-			// Retrieve updated object to get the status.
-			key := ctrlruntimeclient.ObjectKey{Namespace: v.Namespace, Name: v.Name}
-			res := &v1.Ingress{}
-			if err := r.Get(ctx, key, res); err != nil {
-				if !kerrors.IsNotFound(err) {
-					return fmt.Errorf("failed to get Ingress: %w", err)
-				}
+			if err := recordAppliedResource(ctx, r.Client, routeStatus, v); err != nil {
+				return err
 			}
-			updateResourceStatus(routeStatus, res, nil)
 		}
 
 	case *gwapiv1.Gateway: // v1 "sigs.k8s.io/gateway-api/apis/v1"
 		applyErr = gatewayHelpers.CreateOrUpdateGateway(ctx, log, r.Client, v, route.Namespace, config, tenant, annotations)
 		if applyErr == nil {
-			// Retrieve updated object to get the status.
-			key := ctrlruntimeclient.ObjectKey{Namespace: v.Namespace, Name: v.Name}
-			res := &gwapiv1.Gateway{}
-			if err := r.Get(ctx, key, res); err != nil {
-				if !kerrors.IsNotFound(err) {
-					return fmt.Errorf("failed to get Gateway: %w", err)
-				}
+			if err := recordAppliedResource(ctx, r.Client, routeStatus, v); err != nil {
+				return err
 			}
-			updateResourceStatus(routeStatus, res, nil)
 		}
 
 	case *gwapiv1.HTTPRoute: // v1 "sigs.k8s.io/gateway-api/apis/v1"
 		applyErr = httprouteHelpers.CreateOrUpdateHTTPRoute(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, tenant, annotations)
 		if applyErr == nil {
-			// Retrieve updated object to get the status.
-			key := ctrlruntimeclient.ObjectKey{Namespace: v.Namespace, Name: v.Name}
-			res := &gwapiv1.HTTPRoute{}
-			if err := r.Get(ctx, key, res); err != nil {
-				if !kerrors.IsNotFound(err) {
-					return fmt.Errorf("failed to get HTTPRoute: %w", err)
-				}
+			if err := recordAppliedResource(ctx, r.Client, routeStatus, v); err != nil {
+				return err
 			}
-			updateResourceStatus(routeStatus, res, nil)
 		}
 
 	case *gwapiv1.GRPCRoute: // v1 "sigs.k8s.io/gateway-api/apis/v1"
 		applyErr = grpcrouteHelpers.CreateOrUpdateGRPCRoute(ctx, log, r.Client, v, referencedServices, route.Namespace, originalRouteName, tenant, annotations)
 		if applyErr == nil {
-			// Retrieve updated object to get the status.
-			key := ctrlruntimeclient.ObjectKey{Namespace: v.Namespace, Name: v.Name}
-			res := &gwapiv1.GRPCRoute{}
-			if err := r.Get(ctx, key, res); err != nil {
-				if !kerrors.IsNotFound(err) {
-					return fmt.Errorf("failed to get GRPCRoute: %w", err)
-				}
+			if err := recordAppliedResource(ctx, r.Client, routeStatus, v); err != nil {
+				return err
 			}
-			updateResourceStatus(routeStatus, res, nil)
 		}
 
 	default:

--- a/internal/controllers/kubelb/route_teardown_test.go
+++ b/internal/controllers/kubelb/route_teardown_test.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelb
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	portlookup "k8c.io/kubelb/internal/port-lookup"
+	"k8c.io/kubelb/internal/resources/unstructured"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	teardownTenant          = "primary"
+	teardownNamespace       = "tenant-primary"
+	teardownConfigNamespace = "kubelb"
+	teardownIngressName     = "default-echo"
+	teardownServiceName     = "default-echo-svc"
+	seededLoadBalancerIP    = "203.0.113.10"
+)
+
+func teardownScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		kubelbv1alpha1.AddToScheme,
+		gwapiv1.Install,
+	} {
+		if err := add(s); err != nil {
+			t.Fatalf("failed to build scheme: %v", err)
+		}
+	}
+	return s
+}
+
+func teardownIngressSource(t *testing.T) kubelbv1alpha1.RouteSource {
+	t.Helper()
+	ingress := &networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: networkingv1.SchemeGroupVersion.String(),
+			Kind:       "Ingress",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "echo", Namespace: "default"},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{
+				Host: "app.example.com",
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     "/",
+							PathType: ptr.To(networkingv1.PathTypePrefix),
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: "echo",
+									Port: networkingv1.ServiceBackendPort{Number: 80},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	unstruct, err := unstructured.ConvertObjectToUnstructured(ingress)
+	if err != nil {
+		t.Fatalf("failed to convert source to unstructured: %v", err)
+	}
+	return kubelbv1alpha1.RouteSource{
+		Kubernetes: &kubelbv1alpha1.KubernetesSource{Route: *unstruct},
+	}
+}
+
+// admittedRoute is a Route that was accepted on a previous reconcile: it carries
+// the cleanup finalizer and a status pointing at the resources it generated.
+func admittedRoute(t *testing.T) *kubelbv1alpha1.Route {
+	t.Helper()
+	return &kubelbv1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "route-uid",
+			Namespace:  teardownNamespace,
+			Finalizers: []string{CleanupFinalizer},
+		},
+		Spec: kubelbv1alpha1.RouteSpec{Source: teardownIngressSource(t)},
+		Status: kubelbv1alpha1.RouteStatus{
+			Resources: kubelbv1alpha1.RouteResourcesStatus{
+				Route: kubelbv1alpha1.ResourceState{
+					Name:          "echo",
+					Namespace:     "default",
+					GeneratedName: teardownIngressName,
+					Conditions: []metav1.Condition{{
+						Type:               kubelbv1alpha1.ConditionResourceAppliedSuccessfully.String(),
+						Status:             metav1.ConditionTrue,
+						Reason:             conditionReasonSuccessful,
+						LastTransitionTime: metav1.Now(),
+					}},
+				},
+				Services: map[string]kubelbv1alpha1.RouteServiceStatus{
+					"default/echo": {
+						ResourceState: kubelbv1alpha1.ResourceState{
+							Name:          "echo",
+							Namespace:     "default",
+							GeneratedName: teardownServiceName,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// pendingRoute has never been reconciled: no status, nothing generated yet.
+func pendingRoute(t *testing.T) *kubelbv1alpha1.Route {
+	t.Helper()
+	return &kubelbv1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "route-uid",
+			Namespace:  teardownNamespace,
+			Finalizers: []string{CleanupFinalizer},
+		},
+		Spec: kubelbv1alpha1.RouteSpec{Source: teardownIngressSource(t)},
+	}
+}
+
+func generatedIngress() *networkingv1.Ingress {
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: teardownIngressName, Namespace: teardownNamespace},
+	}
+}
+
+func generatedService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: teardownServiceName, Namespace: teardownNamespace},
+	}
+}
+
+func newTeardownReconciler(t *testing.T, objects ...ctrlruntimeclient.Object) *RouteReconciler {
+	t.Helper()
+	scheme := teardownScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(&kubelbv1alpha1.Route{}).
+		Build()
+
+	return &RouteReconciler{
+		Client:        client,
+		Log:           logr.Discard(),
+		Scheme:        scheme,
+		Recorder:      events.NewFakeRecorder(16),
+		Namespace:     teardownConfigNamespace,
+		PortAllocator: portlookup.NewPortAllocator(),
+	}
+}
+
+// newCacheMissReconciler makes every Ingress read miss, which is what an
+// informer cache does for an object that was created moments ago. Flipping the
+// returned toggle restores normal reads so assertions can observe the cluster.
+func newCacheMissReconciler(t *testing.T, objects ...ctrlruntimeclient.Object) (*RouteReconciler, *bool) {
+	t.Helper()
+	blocked := true
+
+	scheme := teardownScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(&kubelbv1alpha1.Route{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c ctrlruntimeclient.WithWatch, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+				if _, ok := obj.(*networkingv1.Ingress); ok && blocked {
+					return kerrors.NewNotFound(schema.GroupResource{Group: networkingv1.GroupName, Resource: "ingresses"}, key.Name)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	return &RouteReconciler{
+		Client:        client,
+		Log:           logr.Discard(),
+		Scheme:        scheme,
+		Recorder:      events.NewFakeRecorder(16),
+		Namespace:     teardownConfigNamespace,
+		PortAllocator: portlookup.NewPortAllocator(),
+	}, &blocked
+}
+
+func manageIngressRoute(t *testing.T, r *RouteReconciler, route *kubelbv1alpha1.Route) {
+	t.Helper()
+	err := r.manageRoutes(context.Background(), logr.Discard(), route, &kubelbv1alpha1.Config{}, &kubelbv1alpha1.Tenant{}, kubelbv1alpha1.AnnotationSettings{})
+	if err != nil {
+		t.Fatalf("manageRoutes returned an error: %v", err)
+	}
+}
+
+func recordedResource(t *testing.T, r *RouteReconciler, route *kubelbv1alpha1.Route) kubelbv1alpha1.ResourceState {
+	t.Helper()
+	updated := &kubelbv1alpha1.Route{}
+	if err := r.Get(context.Background(), ctrlruntimeclient.ObjectKeyFromObject(route), updated); err != nil {
+		t.Fatalf("failed to get the Route: %v", err)
+	}
+	return updated.Status.Resources.Route
+}
+
+// The owner reference only collects the generated resource when the Route
+// itself is deleted. On the disable path the Route survives, so it has to be
+// deleted explicitly or it keeps serving.
+func TestCleanupDeletesGeneratedRouteResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		resetStatus bool
+	}{
+		{name: "teardown resets the status", resetStatus: true},
+		{name: "deletion keeps the status", resetStatus: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := admittedRoute(t)
+			r := newTeardownReconciler(t, route, generatedIngress(), generatedService())
+
+			ctx := context.Background()
+			if _, err := r.cleanup(ctx, route, tt.resetStatus); err != nil {
+				t.Fatalf("cleanup returned an error: %v", err)
+			}
+
+			if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: teardownIngressName, Namespace: teardownNamespace}, &networkingv1.Ingress{}); !kerrors.IsNotFound(err) {
+				t.Errorf("expected the generated Ingress to be deleted, got %v", err)
+			}
+			if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: teardownServiceName, Namespace: teardownNamespace}, &corev1.Service{}); !kerrors.IsNotFound(err) {
+				t.Errorf("expected the generated Service to be deleted, got %v", err)
+			}
+
+			updated := &kubelbv1alpha1.Route{}
+			if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(route), updated); err != nil {
+				t.Fatalf("failed to get the Route: %v", err)
+			}
+
+			generatedName := updated.Status.Resources.Route.GeneratedName
+			if tt.resetStatus && generatedName != "" {
+				t.Errorf("expected the status to be reset, got generatedName %q", generatedName)
+			}
+			if !tt.resetStatus && generatedName != teardownIngressName {
+				t.Errorf("expected the status to be kept, got generatedName %q", generatedName)
+			}
+			if apimeta.FindStatusCondition(updated.Status.Resources.Route.Conditions, kubelbv1alpha1.ConditionResourceAppliedSuccessfully.String()) == nil {
+				t.Error("expected the applied condition to survive cleanup")
+			}
+		})
+	}
+}
+
+// A Route with nothing recorded in its status generated nothing, so there is
+// no name to delete and no kind to resolve.
+func TestCleanupSkipsRouteWithoutGeneratedResource(t *testing.T) {
+	route := pendingRoute(t)
+	r := newTeardownReconciler(t, route)
+
+	if _, err := r.cleanup(context.Background(), route, true); err != nil {
+		t.Fatalf("cleanup returned an error: %v", err)
+	}
+}
+
+// Disabling Ingress for the tenant used to leave the mirrored Ingress live
+// while the Route was told the feature was off.
+func TestReconcileTearsDownRouteWhenIngressIsDisabled(t *testing.T) {
+	route := admittedRoute(t)
+	tenant := &kubelbv1alpha1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: teardownTenant}}
+	tenant.Spec.Ingress.Disable = true
+
+	r := newTeardownReconciler(t, route, tenant, generatedIngress(), generatedService())
+
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: route.Name, Namespace: route.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile returned an error: %v", err)
+	}
+
+	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: teardownIngressName, Namespace: teardownNamespace}, &networkingv1.Ingress{}); !kerrors.IsNotFound(err) {
+		t.Errorf("expected the generated Ingress to be deleted, got %v", err)
+	}
+
+	updated := &kubelbv1alpha1.Route{}
+	if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(route), updated); err != nil {
+		t.Fatalf("failed to get the Route: %v", err)
+	}
+	if updated.Status.Resources.Route.GeneratedName != "" {
+		t.Errorf("expected the status to be reset, got generatedName %q", updated.Status.Resources.Route.GeneratedName)
+	}
+	if len(updated.Finalizers) != 0 {
+		t.Errorf("expected the finalizer to be removed, got %v", updated.Finalizers)
+	}
+}
+
+// A read-after-write that misses must not wipe the record of what was applied:
+// cleanup and the CCM's status projection both key off GeneratedName.
+func TestManageRoutesRecordsResourceWhenReadAfterWriteMissesCache(t *testing.T) {
+	route := pendingRoute(t)
+	r, _ := newCacheMissReconciler(t, route)
+
+	manageIngressRoute(t, r, route)
+
+	applied := recordedResource(t, r, route)
+	if applied.GeneratedName != teardownIngressName {
+		t.Errorf("expected generatedName %q, got %q", teardownIngressName, applied.GeneratedName)
+	}
+	if applied.Name != "echo" || applied.Namespace != "default" {
+		t.Errorf("expected the origin to be recorded as default/echo, got %s/%s", applied.Namespace, applied.Name)
+	}
+}
+
+// The live object is what carries the sub-resource status, so it must win
+// whenever the cache does have it.
+func TestManageRoutesPrefersLiveResource(t *testing.T) {
+	route := pendingRoute(t)
+	existing := generatedIngress()
+	existing.Status.LoadBalancer.Ingress = []networkingv1.IngressLoadBalancerIngress{{IP: seededLoadBalancerIP}}
+
+	scheme := teardownScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(route, existing).
+		WithStatusSubresource(&kubelbv1alpha1.Route{}, &networkingv1.Ingress{}).
+		Build()
+
+	r := &RouteReconciler{
+		Client:        client,
+		Log:           logr.Discard(),
+		Scheme:        scheme,
+		Recorder:      events.NewFakeRecorder(16),
+		Namespace:     teardownConfigNamespace,
+		PortAllocator: portlookup.NewPortAllocator(),
+	}
+
+	manageIngressRoute(t, r, route)
+
+	applied := recordedResource(t, r, route)
+	if applied.GeneratedName != teardownIngressName {
+		t.Errorf("expected generatedName %q, got %q", teardownIngressName, applied.GeneratedName)
+	}
+	if !strings.Contains(string(applied.Status.Raw), seededLoadBalancerIP) {
+		t.Errorf("expected the live Ingress status to be recorded, got %s", applied.Status.Raw)
+	}
+}
+
+// A teardown landing right after the first create must still find the mirrored
+// resource: the wiped status was what left it orphaned and serving traffic.
+func TestTeardownFindsResourceRecordedFromCacheMiss(t *testing.T) {
+	route := pendingRoute(t)
+	r, blocked := newCacheMissReconciler(t, route)
+
+	manageIngressRoute(t, r, route)
+	*blocked = false
+
+	ctx := context.Background()
+	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: teardownIngressName, Namespace: teardownNamespace}, &networkingv1.Ingress{}); err != nil {
+		t.Fatalf("expected the Ingress to have been created: %v", err)
+	}
+
+	if _, err := r.cleanup(ctx, route, true); err != nil {
+		t.Fatalf("cleanup returned an error: %v", err)
+	}
+
+	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: teardownIngressName, Namespace: teardownNamespace}, &networkingv1.Ingress{}); !kerrors.IsNotFound(err) {
+		t.Errorf("expected the generated Ingress to be deleted, got %v", err)
+	}
+}

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -277,6 +277,20 @@ spec:
 | `isolated/patch-config.yaml` | Patch Config CRD | `patch_json` |
 | `isolated/patch-tenant.yaml` | Patch Tenant CRD | `tenant_name`, `patch_json` |
 
+## Retry Loop Budgets
+
+Keep every retry loop's budget **under** its step `timeout`. A loop budgeted
+past its timeout is killed mid-loop, so its failure message and diagnostic
+dumps never run, and a slow-but-converging wait dies early. Put dumps in
+`catch:` — that survives a step timeout, whereas a trailing `kubectl get ...`
+inside the script does not. `make verify-e2e-loop-budgets` enforces this in CI
+(worst-case sleep budget vs the step timeout).
+
+Cleanup `finally` scripts must not block on slow finalization: pass
+`--wait=false` when deleting namespaces and Gateways. Namespace finalization
+and per-Gateway Envoy teardown routinely outlast a 60s script timeout on
+loaded CI nodes, and a killed `finally` fails an otherwise-green test.
+
 ## Debugging Failures
 
 Run a failing test in isolation:

--- a/test/e2e/tests/isolated/config/lb-class/chainsaw-test.yaml
+++ b/test/e2e/tests/isolated/config/lb-class/chainsaw-test.yaml
@@ -89,7 +89,9 @@ spec:
       cluster: kubelb
       try:
         - script:
-            timeout: 60s
+            # Covers the loop's full 20x5s budget plus kubectl overhead; a
+            # shorter timeout kills the loop mid-wait.
+            timeout: 150s
             content: |
               set -e
               NAMESPACE="tenant-primary"

--- a/test/e2e/tests/isolated/config/overload-manager/chainsaw-test.yaml
+++ b/test/e2e/tests/isolated/config/overload-manager/chainsaw-test.yaml
@@ -99,7 +99,9 @@ spec:
       cluster: kubelb
       try:
         - script:
-            timeout: 90s
+            # Covers the loop's full 24x5s budget; a shorter timeout kills the
+            # loop mid-wait and eats its failure diagnostics.
+            timeout: 180s
             content: |
               set -e
               NAMESPACE="tenant-primary"

--- a/test/e2e/tests/layer7/httproute/basic/chainsaw-test.yaml
+++ b/test/e2e/tests/layer7/httproute/basic/chainsaw-test.yaml
@@ -203,7 +203,9 @@ spec:
       try:
         - script:
             skipCommandOutput: true
-            timeout: 90s
+            # Covers the 5s settle plus the loop's 30x(5s curl + 2s sleep)
+            # worst case; 90s could kill the loop mid-wait.
+            timeout: 240s
             content: |
               set -e
               IP=$(kubectl get gateway basic-gw -n default \

--- a/test/e2e/tests/layer7/httproute/reconcile-stability/chainsaw-test.yaml
+++ b/test/e2e/tests/layer7/httproute/reconcile-stability/chainsaw-test.yaml
@@ -237,7 +237,9 @@ spec:
       cluster: kubelb
       try:
         - script:
-            timeout: 30s
+            # Covers the 5x2s poll plus the fixed 10s settle and trailing
+            # kubectl calls; 30s cut the script off mid-check under load.
+            timeout: 60s
             content: |
               set -e
               NAMESPACE="tenant-primary"

--- a/test/e2e/tests/layer7/ingress/cross-tenant/chainsaw-test.yaml
+++ b/test/e2e/tests/layer7/ingress/cross-tenant/chainsaw-test.yaml
@@ -136,7 +136,9 @@ spec:
       cluster: kubelb
       try:
         - script:
-            timeout: 120s
+            # Covers the loop's full 60x3s budget; a shorter timeout kills the
+            # loop mid-wait and eats its failure diagnostics.
+            timeout: 240s
             content: |
               set -e
               NS_PRIMARY="tenant-primary"


### PR DESCRIPTION
**What this PR does / why we need it**:

Two controller bugs and three e2e harness gaps.

1. **Disabling Ingress or Gateway API leaked the mirrored resource.** `cleanup` deleted only the generated Services and left the rest to owner-reference GC, but the owner is the Route CR, which survives every teardown path except its own deletion.
2. **Read-after-write in `manageRoutes` recorded an empty status.** All four branches swallowed `NotFound` and passed the zero-valued object to `updateResourceStatus`, so `GeneratedName` landed empty and cleanup had nothing to key off.
3. **Gateways naming an unserved GatewayClass were silently dropped.** No event, no log, no finalizer, so the tenant saw only `Accepted=Unknown/Pending`. Now a Warning event, never a status write, since KubeLB owns no GatewayClass in the tenant cluster.
4. **e2e reported failed background checks as passing.** Five bare `wait` calls in `deploy.sh` return 0 regardless of how their jobs exited.
5. **e2e ran the CCM as cluster-admin.** It now gets the scoped ServiceAccount kubeconfig the manager writes to `kubelb-ccm-kubeconfig`, so a tenant RBAC gap can actually fail a test.

Plus five chainsaw retry loops budgeted past their step timeout, and `make verify-e2e-loop-budgets` to keep new ones out.

**Which issue(s) this PR fixes**:

None, found by inspection.

**What type of PR is this?**
/kind bug
/kind flake

```release-note
- Fix generated Ingress/Gateway/HTTPRoute/GRPCRoute not being removed when Ingress or Gateway API is disabled for a tenant or globally
- Gateways naming a GatewayClass that KubeLB does not serve now get a Warning event instead of being silently ignored
```

```documentation
https://github.com/kubermatic/docs/pull/2259
```

