### PR TITLE
fix: drop Service UID from xDS resource names, reap orphaned mirrors, propagate annotation removals

### DIFF
--- a/charts/kubelb-manager/README.md
+++ b/charts/kubelb-manager/README.md
@@ -79,7 +79,7 @@ cosign verify quay.io/kubermatic/kubelb-manager:v1.3.5 \
 | kubelb.envoyProxy.nodeSelector | object | `{}` |  |
 | kubelb.envoyProxy.podMonitor.enabled | bool | `false` | Create PodMonitor resources for Envoy Proxy pods to enable Prometheus Operator scraping. |
 | kubelb.envoyProxy.replicas | int | `2` | The number of replicas for the Envoy Proxy deployment. |
-| kubelb.envoyProxy.resources | object | `{}` |  |
+| kubelb.envoyProxy.resources | object | `{}` | Resource requests/limits for the Envoy Proxy container. If empty, defaults to requests 200m CPU / 256Mi memory and limits 2 CPU / 1Gi memory. |
 | kubelb.envoyProxy.singlePodPerNode | bool | `true` | Deploy single pod per node. |
 | kubelb.envoyProxy.tolerations | list | `[]` |  |
 | kubelb.envoyProxy.topology | string | `"shared"` | Topology defines the deployment topology for Envoy Proxy. Only "shared" is supported. "dedicated" and "global" are deprecated and will default to shared. |

--- a/charts/kubelb-manager/values.yaml
+++ b/charts/kubelb-manager/values.yaml
@@ -33,6 +33,7 @@ kubelb:
     useDaemonset: false
     nodeSelector: {}
     tolerations: []
+    # -- Resource requests/limits for the Envoy Proxy container. If empty, defaults to requests 200m CPU / 256Mi memory and limits 2 CPU / 1Gi memory.
     resources: {}
     affinity: {}
     gracefulShutdown:

--- a/internal/controllers/ccm/service_controller.go
+++ b/internal/controllers/ccm/service_controller.go
@@ -79,18 +79,12 @@ func (r *KubeLBServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	err := r.Get(ctx, req.NamespacedName, &service)
 	if err != nil {
-		if ctrlclient.IgnoreNotFound(err) != nil {
-			log.Error(err, "unable to fetch service")
-			ccmmetrics.ServiceReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-		}
-		log.V(3).Info("service not found")
-
-		return ctrl.Result{}, nil
+		return r.handleMissingService(ctx, log, req, err)
 	}
 
 	// Resource is marked for deletion
 	if service.DeletionTimestamp != nil {
-		if controllerutil.ContainsFinalizer(&service, CleanupFinalizer) || controllerutil.ContainsFinalizer(&service, LBFinalizerName) {
+		if hasCleanupFinalizer(&service) {
 			return r.cleanupService(ctx, log, &service)
 		}
 		// Finalizer doesn't exist so clean up is already done
@@ -98,24 +92,28 @@ func (r *KubeLBServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if !r.shouldReconcile(service) {
+		// The Service dropped out of scope - downgraded from LoadBalancer, or its
+		// loadBalancerClass changed. It is not being deleted, so only this branch can
+		// tear the mirror down.
+		if hasCleanupFinalizer(&service) {
+			return r.cleanupService(ctx, log, &service)
+		}
 		ccmmetrics.ServiceReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultSkipped).Inc()
 		return ctrl.Result{}, nil
 	}
 
-	// Add finalizer if it doesn't exist
-	if !controllerutil.ContainsFinalizer(&service, CleanupFinalizer) {
-		if ok := controllerutil.AddFinalizer(&service, CleanupFinalizer); !ok {
-			log.Error(nil, "Failed to add finalizer for the LB Service")
-			return ctrl.Result{Requeue: true}, nil
-		}
+	if requeue, err := r.ensureFinalizer(ctx, log, &service); err != nil {
+		ccmmetrics.ServiceReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+		return reconcile.Result{}, err
+	} else if requeue {
+		return ctrl.Result{Requeue: true}, nil
+	}
 
-		// Remove old finalizer since it is not used anymore.
-		controllerutil.RemoveFinalizer(&service, LBFinalizerName)
-
-		if err := r.Update(ctx, &service); err != nil {
-			ccmmetrics.ServiceReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
-			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
-		}
+	// The Service may have been recreated under the same name with a fresh UID while
+	// the CCM was down; the mirrors of its previous incarnations are orphans.
+	if err := r.reapStaleLoadBalancers(ctx, log, service.Name, service.Namespace, string(service.UID)); err != nil {
+		ccmmetrics.ServiceReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+		return ctrl.Result{}, err
 	}
 
 	clusterEndpoints, useAddressesReference := r.getEndpoints(&service)
@@ -211,6 +209,52 @@ func (r *KubeLBServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return ctrl.Result{}, nil
 }
 
+// handleMissingService covers the paths where the Service could not be read. When it
+// is gone its mirror has to be reaped: the origin vanished without the finalizer
+// having run, so nothing else will ever tear the mirror - and the cloud LoadBalancer
+// behind it - down.
+func (r *KubeLBServiceReconciler) handleMissingService(ctx context.Context, log logr.Logger, req ctrl.Request, err error) (ctrl.Result, error) {
+	if getErr := ctrlclient.IgnoreNotFound(err); getErr != nil {
+		// A transient read failure says nothing about the Service's existence:
+		// requeue instead of reaping, otherwise a live mirror and its cloud LB
+		// could be deleted on an API hiccup.
+		log.Error(getErr, "unable to fetch service")
+		ccmmetrics.ServiceReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+		return ctrl.Result{}, getErr
+	}
+	log.V(3).Info("service not found")
+
+	if err := r.reapStaleLoadBalancers(ctx, log, req.Name, req.Namespace, ""); err != nil {
+		ccmmetrics.ServiceReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func hasCleanupFinalizer(service *corev1.Service) bool {
+	return controllerutil.ContainsFinalizer(service, CleanupFinalizer) || controllerutil.ContainsFinalizer(service, LBFinalizerName)
+}
+
+// ensureFinalizer adds the cleanup finalizer to the Service, reporting whether the
+// reconciliation has to be requeued instead.
+func (r *KubeLBServiceReconciler) ensureFinalizer(ctx context.Context, log logr.Logger, service *corev1.Service) (bool, error) {
+	if controllerutil.ContainsFinalizer(service, CleanupFinalizer) {
+		return false, nil
+	}
+	if ok := controllerutil.AddFinalizer(service, CleanupFinalizer); !ok {
+		log.Error(nil, "Failed to add finalizer for the LB Service")
+		return true, nil
+	}
+
+	// Remove old finalizer since it is not used anymore.
+	controllerutil.RemoveFinalizer(service, LBFinalizerName)
+
+	if err := r.Update(ctx, service); err != nil {
+		return false, fmt.Errorf("failed to add finalizer: %w", err)
+	}
+	return false, nil
+}
+
 func (r *KubeLBServiceReconciler) updateManagedServicesGauge(ctx context.Context, namespace string) {
 	serviceList := &corev1.ServiceList{}
 	if err := r.List(ctx, serviceList, ctrlclient.InNamespace(namespace)); err == nil {
@@ -248,6 +292,38 @@ func (r *KubeLBServiceReconciler) cleanupService(ctx context.Context, log logr.L
 	log.V(4).Info("removed finalizer")
 
 	return ctrl.Result{}, nil
+}
+
+// reapStaleLoadBalancers deletes the LoadBalancers in the tenant's
+// management-cluster namespace that were generated from name/namespace but not from
+// the Service currently living under liveUID. The finalizer path only covers
+// Services that still exist and still carry the finalizer; everything else (tenant
+// cluster rebuilt, etcd restore, finalizers force-removed, namespace deleted while
+// the CCM was down) leaves the mirror - and the billed cloud LoadBalancer it
+// fronts - behind forever.
+func (r *KubeLBServiceReconciler) reapStaleLoadBalancers(ctx context.Context, log logr.Logger, name, namespace, liveUID string) error {
+	kubelbClient := r.KubeLBManager.GetClient()
+	stale, err := staleMirrorNames(ctx, kubelbClient, &kubelbv1alpha1.LoadBalancerList{}, r.ClusterName, liveUID, ctrlclient.MatchingLabels{
+		kubelb.LabelOriginName:      name,
+		kubelb.LabelOriginNamespace: namespace,
+	})
+	if err != nil || len(stale) == 0 {
+		return err
+	}
+
+	for _, lbName := range stale {
+		log.V(1).Info("deleting orphaned LoadBalancer", "name", lbName, "namespace", r.ClusterName)
+		lb := &kubelbv1alpha1.LoadBalancer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lbName,
+				Namespace: r.ClusterName,
+			},
+		}
+		if err := recordKubeLBOperation("delete", func() error { return kubelbClient.Delete(ctx, lb) }); err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("deleting orphaned LoadBalancer: %w", err)
+		}
+	}
+	return nil
 }
 
 func (r *KubeLBServiceReconciler) enqueueLoadBalancer() handler.TypedMapFunc[*kubelbv1alpha1.LoadBalancer, reconcile.Request] {

--- a/internal/controllers/ccm/service_controller_test.go
+++ b/internal/controllers/ccm/service_controller_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ccm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	testServiceName = "app"
+	testServiceUID  = "svc-uid-1"
+)
+
+// fakeLBManager satisfies ctrl.Manager for reconcile() calls that only need
+// its client.
+type fakeLBManager struct {
+	ctrl.Manager
+	client ctrlclient.Client
+}
+
+func (m *fakeLBManager) GetClient() ctrlclient.Client {
+	return m.client
+}
+
+func newTenantService(opts ...func(*corev1.Service)) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testServiceName,
+			Namespace:  testNS,
+			UID:        testServiceUID,
+			Finalizers: []string{CleanupFinalizer},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Name: "http", Port: 80, NodePort: 30080, Protocol: corev1.ProtocolTCP}},
+		},
+	}
+	for _, o := range opts {
+		o(svc)
+	}
+	return svc
+}
+
+func newLoadBalancerMirror(name string) *kubelbv1alpha1.LoadBalancer {
+	return &kubelbv1alpha1.LoadBalancer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testCluster,
+			Labels: map[string]string{
+				kubelb.LabelOriginName:      testServiceName,
+				kubelb.LabelOriginNamespace: testNS,
+				kubelb.LabelTenantName:      testCluster,
+			},
+		},
+		Spec: kubelbv1alpha1.LoadBalancerSpec{Type: corev1.ServiceTypeLoadBalancer},
+	}
+}
+
+func newServiceReconciler(t *testing.T, svc *corev1.Service, mirrors ...*kubelbv1alpha1.LoadBalancer) (*KubeLBServiceReconciler, ctrlclient.Client, ctrlclient.Client) {
+	t.Helper()
+	s := newScheme(t)
+	srcBuilder := fake.NewClientBuilder().WithScheme(s)
+	if svc != nil {
+		srcBuilder = srcBuilder.WithObjects(svc)
+	}
+	src := srcBuilder.Build()
+
+	lbObjects := make([]ctrlclient.Object, 0, len(mirrors))
+	for _, m := range mirrors {
+		lbObjects = append(lbObjects, m)
+	}
+	lb := fake.NewClientBuilder().WithScheme(s).WithObjects(lbObjects...).Build()
+
+	return &KubeLBServiceReconciler{
+		Client:        src,
+		KubeLBManager: &fakeLBManager{client: lb},
+		Log:           logr.Discard(),
+		ClusterName:   testCluster,
+	}, src, lb
+}
+
+func serviceRequest() ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Name: testServiceName, Namespace: testNS}}
+}
+
+func assertMirrorGone(t *testing.T, lb ctrlclient.Client, name, msg string) {
+	t.Helper()
+	err := lb.Get(context.Background(), types.NamespacedName{Name: name, Namespace: testCluster}, &kubelbv1alpha1.LoadBalancer{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("%s: got err=%v", msg, err)
+	}
+}
+
+// A tenant Service downgraded from LoadBalancer to ClusterIP no longer qualifies
+// for KubeLB, so its management-cluster mirror (and the billed cloud LB behind it)
+// must be torn down; leaving it behind leaks provider quota and keeps a public IP
+// pointed at a NodePort that can later be reassigned to an unrelated Service.
+func TestServiceReconcile_TypeDowngradeTearsDownMirror(t *testing.T) {
+	svc := newTenantService(func(s *corev1.Service) { s.Spec.Type = corev1.ServiceTypeClusterIP })
+	r, src, lb := newServiceReconciler(t, svc, newLoadBalancerMirror(testServiceUID))
+
+	if _, err := r.Reconcile(context.Background(), serviceRequest()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	assertMirrorGone(t, lb, testServiceUID, "expected LoadBalancer mirror deleted after type downgrade")
+
+	got := &corev1.Service{}
+	if err := src.Get(context.Background(), serviceRequest().NamespacedName, got); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, CleanupFinalizer) {
+		t.Fatalf("cleanup finalizer not removed: %+v", got.Finalizers)
+	}
+}
+
+// The origin Service vanished without the finalizer ever running (tenant cluster
+// rebuilt, etcd restore, finalizers force-removed). Nothing else reaps the mirror.
+func TestServiceReconcile_OriginGoneReapsMirror(t *testing.T) {
+	r, _, lb := newServiceReconciler(t, nil, newLoadBalancerMirror(testServiceUID))
+
+	if _, err := r.Reconcile(context.Background(), serviceRequest()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	assertMirrorGone(t, lb, testServiceUID, "expected orphaned LoadBalancer mirror deleted")
+}
+
+// Tenant cluster rebuilt: the Service comes back under the same name/namespace with
+// a fresh UID, so the CCM creates a second mirror while the old one keeps its own
+// billed cloud LB alive forever.
+func TestServiceReconcile_RecreatedOriginReapsStaleUIDMirror(t *testing.T) {
+	svc := newTenantService(func(s *corev1.Service) { s.UID = "svc-uid-2" })
+	r, _, lb := newServiceReconciler(t, svc, newLoadBalancerMirror(testServiceUID), newLoadBalancerMirror("svc-uid-2"))
+
+	if _, err := r.Reconcile(context.Background(), serviceRequest()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	assertMirrorGone(t, lb, testServiceUID, "expected stale-UID LoadBalancer mirror deleted")
+	if err := lb.Get(context.Background(), types.NamespacedName{Name: "svc-uid-2", Namespace: testCluster}, &kubelbv1alpha1.LoadBalancer{}); err != nil {
+		t.Fatalf("live mirror must be kept: %v", err)
+	}
+}
+
+// A transient read failure says nothing about the Service's existence. It must be
+// requeued via a returned error, and it must NOT reap the mirror - deleting a live
+// mirror (and the cloud LB behind it) on an API hiccup would be far worse than the
+// orphan the reap exists to prevent.
+func TestServiceReconcile_TransientGetErrorDoesNotReap(t *testing.T) {
+	s := newScheme(t)
+	failing := interceptor.NewClient(
+		fake.NewClientBuilder().WithScheme(s).Build(),
+		interceptor.Funcs{
+			Get: func(ctx context.Context, client ctrlclient.WithWatch, key ctrlclient.ObjectKey, obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+				return apierrors.NewInternalError(errors.New("etcdserver: leader changed"))
+			},
+		},
+	)
+	lb := fake.NewClientBuilder().WithScheme(s).WithObjects(newLoadBalancerMirror(testServiceUID)).Build()
+	r := &KubeLBServiceReconciler{
+		Client:        failing,
+		KubeLBManager: &fakeLBManager{client: lb},
+		Log:           logr.Discard(),
+		ClusterName:   testCluster,
+	}
+
+	if _, err := r.Reconcile(context.Background(), serviceRequest()); err == nil {
+		t.Fatal("expected the transient Get error to be returned for requeue, got nil")
+	}
+
+	if err := lb.Get(context.Background(), types.NamespacedName{Name: testServiceUID, Namespace: testCluster}, &kubelbv1alpha1.LoadBalancer{}); err != nil {
+		t.Fatalf("mirror must survive a transient Get error, got: %v", err)
+	}
+}

--- a/internal/controllers/ccm/shared.go
+++ b/internal/controllers/ccm/shared.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubelb/internal/resources/unstructured"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -81,6 +82,35 @@ func cleanupRoute(ctx context.Context, client ctrlclient.Client, resourceUID str
 		}
 	}
 	return nil
+}
+
+// staleMirrorNames returns the names of the management-cluster mirrors in
+// tenantNamespace that were generated from the origin selected by selector but no
+// longer belong to it. Mirrors are named after the origin's UID, so any match whose
+// name is not liveUID is a leftover: the origin was deleted while the CCM could not
+// run its finalizer, or it was recreated with a fresh UID (tenant cluster rebuilt,
+// etcd restore). An empty liveUID means the origin is gone entirely, so every match
+// is stale.
+func staleMirrorNames(ctx context.Context, lbClient ctrlclient.Client, list ctrlclient.ObjectList, tenantNamespace, liveUID string, selector ctrlclient.MatchingLabels) ([]string, error) {
+	if err := lbClient.List(ctx, list, ctrlclient.InNamespace(tenantNamespace), selector); err != nil {
+		return nil, fmt.Errorf("failed to list mirrors in %s: %w", tenantNamespace, err)
+	}
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract mirror list: %w", err)
+	}
+
+	var stale []string
+	for _, item := range items {
+		obj, ok := item.(ctrlclient.Object)
+		if !ok {
+			continue
+		}
+		if obj.GetName() != liveUID {
+			stale = append(stale, obj.GetName())
+		}
+	}
+	return stale, nil
 }
 
 func enqueueRoutes(gvk, clusterNamespace string) handler.TypedMapFunc[*kubelbv1alpha1.Route, reconcile.Request] {

--- a/internal/controllers/ccm/source_reconciler.go
+++ b/internal/controllers/ccm/source_reconciler.go
@@ -89,6 +89,12 @@ func (r *SourceReconciler[T]) Reconcile(ctx context.Context, req ctrl.Request) (
 	resource := r.Adapter.NewObject()
 	if err := r.Client.Get(ctx, req.NamespacedName, resource); err != nil {
 		if kerrors.IsNotFound(err) {
+			// The origin is gone without the finalizer having run, so nothing else
+			// will ever tear its mirror down.
+			if err := r.reapStaleRoutes(ctx, log, req.Name, req.Namespace, ""); err != nil {
+				m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+				return reconcile.Result{}, err
+			}
 			return reconcile.Result{}, nil
 		}
 		m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
@@ -113,6 +119,13 @@ func (r *SourceReconciler[T]) Reconcile(ctx context.Context, req ctrl.Request) (
 			m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
+	}
+
+	// The origin may have been recreated under the same name with a fresh UID while
+	// the CCM was down; the mirrors of its previous incarnations are orphans.
+	if err := r.reapStaleRoutes(ctx, log, resource.GetName(), resource.GetNamespace(), string(resource.GetUID())); err != nil {
+		m.ReconcileTotal.WithLabelValues(req.Namespace, metricsutil.ResultError).Inc()
+		return reconcile.Result{}, err
 	}
 
 	if err := r.reconcile(ctx, log, resource); err != nil {
@@ -200,6 +213,31 @@ func (r *SourceReconciler[T]) cleanup(ctx context.Context, resource T) (ctrl.Res
 		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 	return reconcile.Result{}, nil
+}
+
+// reapStaleRoutes deletes the Routes in the tenant's management-cluster namespace
+// that were generated from name/namespace but not from the origin currently living
+// under liveUID. The finalizer path only covers origins that still exist and still
+// carry the finalizer; everything else (tenant cluster rebuilt, etcd restore,
+// finalizers force-removed, namespace deleted while the CCM was down) leaves the
+// Route - and the management-cluster resources it generates - behind forever.
+func (r *SourceReconciler[T]) reapStaleRoutes(ctx context.Context, log logr.Logger, name, namespace, liveUID string) error {
+	stale, err := staleMirrorNames(ctx, r.LBClient, &kubelbv1alpha1.RouteList{}, r.ClusterName, liveUID, ctrlclient.MatchingLabels{
+		kubelb.LabelOriginName:         name,
+		kubelb.LabelOriginNamespace:    namespace,
+		kubelb.LabelOriginResourceKind: r.Adapter.GVK(),
+	})
+	if err != nil || len(stale) == 0 {
+		return err
+	}
+
+	for _, routeName := range stale {
+		log.Info("deleting orphaned Route", "name", routeName, "namespace", r.ClusterName)
+		if err := cleanupRoute(ctx, r.LBClient, routeName, r.ClusterName); err != nil {
+			return fmt.Errorf("failed to cleanup orphaned route: %w", err)
+		}
+	}
+	return nil
 }
 
 func (r *SourceReconciler[T]) countManaged(ctx context.Context, namespace string) (int, error) {

--- a/internal/controllers/ccm/source_reconciler_test.go
+++ b/internal/controllers/ccm/source_reconciler_test.go
@@ -189,6 +189,69 @@ func TestSourceReconciler_DeletionWithFinalizer_CleansUp(t *testing.T) {
 	}
 }
 
+func routeMirror(name string) *kubelbv1alpha1.Route {
+	return &kubelbv1alpha1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testCluster,
+			Labels: map[string]string{
+				kubelb.LabelOriginName:         testIngName,
+				kubelb.LabelOriginNamespace:    testNS,
+				kubelb.LabelOriginResourceKind: IngressGVK,
+				kubelb.LabelManagedBy:          kubelb.LabelControllerName,
+				kubelb.LabelTenantName:         testCluster,
+			},
+		},
+	}
+}
+
+// The origin Ingress vanished without the finalizer ever running (tenant cluster
+// rebuilt, etcd restore, finalizers force-removed, namespace deleted while the CCM
+// was down). The mirror Route - and the management-cluster resources it generates -
+// survive with nothing left to reap them.
+func TestSourceReconciler_OriginGoneReapsOrphanedRoute(t *testing.T) {
+	s := newScheme(t)
+	src := fake.NewClientBuilder().WithScheme(s).Build()
+	lb := fake.NewClientBuilder().WithScheme(s).WithObjects(routeMirror(testIngUID)).Build()
+	loop := newLoop(t, src, lb)
+
+	if _, err := loop.Reconcile(context.Background(), req()); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := lb.Get(context.Background(), types.NamespacedName{Name: testIngUID, Namespace: testCluster}, &kubelbv1alpha1.Route{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected orphaned Route deleted, got err=%v", err)
+	}
+}
+
+// Tenant cluster rebuilt: the Ingress returns under the same name/namespace with a
+// fresh UID, so a second Route mirror is created and the old one is orphaned.
+func TestSourceReconciler_RecreatedOriginReapsStaleUIDRoute(t *testing.T) {
+	s := newScheme(t)
+	ing := newIngress(func(i *networkingv1.Ingress) {
+		i.TypeMeta = metav1.TypeMeta{APIVersion: networkingv1.SchemeGroupVersion.String(), Kind: "Ingress"}
+		i.UID = "ing-uid-2"
+		i.Finalizers = []string{CleanupFinalizer}
+	})
+	src := fake.NewClientBuilder().WithScheme(s).WithObjects(ing).
+		WithStatusSubresource(&networkingv1.Ingress{}).Build()
+	lb := fake.NewClientBuilder().WithScheme(s).WithObjects(routeMirror(testIngUID), routeMirror("ing-uid-2")).
+		WithStatusSubresource(&kubelbv1alpha1.Route{}).Build()
+	loop := newLoop(t, src, lb)
+
+	// Stale mirrors are reaped before the Route is rebuilt; rebuilding it fails
+	// against the fake client because a typed Get strips TypeMeta off the Ingress,
+	// which is not what this test is about, so the error is not asserted on.
+	_, _ = loop.Reconcile(context.Background(), req())
+
+	if err := lb.Get(context.Background(), types.NamespacedName{Name: testIngUID, Namespace: testCluster}, &kubelbv1alpha1.Route{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected stale-UID Route deleted, got err=%v", err)
+	}
+	if err := lb.Get(context.Background(), types.NamespacedName{Name: "ing-uid-2", Namespace: testCluster}, &kubelbv1alpha1.Route{}); err != nil {
+		t.Fatalf("live Route must be kept: %v", err)
+	}
+}
+
 func TestSourceReconciler_OutOfScope_Skipped(t *testing.T) {
 	s := newScheme(t)
 	cls := "other"

--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -547,14 +547,16 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(config *kubelbv1alpha1.Config, 
 }
 
 func (r *EnvoyCPReconciler) envoyProxyAnnotations(config *kubelbv1alpha1.Config) map[string]string {
+	annotations := map[string]string{
+		kubelb.AnnotationResourceNamingVersion: kubelb.ResourceNamingVersion,
+	}
 	if config.Spec.EnvoyProxy.PodMonitor != nil && config.Spec.EnvoyProxy.PodMonitor.Enabled {
-		return nil
+		return annotations
 	}
-	return map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   fmt.Sprintf("%d", envoycp.EnvoyStatsPort),
-		"prometheus.io/path":   "/stats/prometheus",
-	}
+	annotations["prometheus.io/scrape"] = "true"
+	annotations["prometheus.io/port"] = fmt.Sprintf("%d", envoycp.EnvoyStatsPort)
+	annotations["prometheus.io/path"] = "/stats/prometheus"
+	return annotations
 }
 
 // podTemplateSpecNeedsUpdate compares the relevant fields of two PodTemplateSpecs

--- a/internal/controllers/kubelb/envoy_cp_controller.go
+++ b/internal/controllers/kubelb/envoy_cp_controller.go
@@ -60,6 +60,27 @@ const (
 	envoyProxyManagedByVal = "kubelb"
 )
 
+// defaultEnvoyProxyResources keeps the managed Envoy out of the BestEffort
+// QoS class. It carries all tenant data-plane traffic, so without a request
+// it is the first thing evicted or OOM-killed on a node it shares with other
+// proxies. Sized off measured load: ~12k QPS sat at roughly 45% of one CPU
+// and 18% of 512Mi, with bursts to ~1.1 CPU on a busy shared node.
+//
+// Overridden by Config.spec.envoyProxy.resources, or per tenant by
+// Tenant.spec.envoyProxy.resources.
+func defaultEnvoyProxyResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+}
+
 type EnvoyCPReconciler struct {
 	ctrlruntimeclient.Client
 	EnvoyCache        envoycachev3.SnapshotCache
@@ -513,10 +534,13 @@ func (r *EnvoyCPReconciler) getEnvoyProxyPodSpec(config *kubelbv1alpha1.Config, 
 		},
 	}
 
-	if tenant.Spec.EnvoyProxy != nil && tenant.Spec.EnvoyProxy.Resources != nil {
+	switch {
+	case tenant.Spec.EnvoyProxy != nil && tenant.Spec.EnvoyProxy.Resources != nil:
 		template.Spec.Containers[0].Resources = *tenant.Spec.EnvoyProxy.Resources
-	} else if envoyProxy.Resources != nil {
+	case envoyProxy.Resources != nil:
 		template.Spec.Containers[0].Resources = *envoyProxy.Resources
+	default:
+		template.Spec.Containers[0].Resources = defaultEnvoyProxyResources()
 	}
 
 	if envoyProxy.Affinity != nil {

--- a/internal/controllers/kubelb/envoy_cp_controller_test.go
+++ b/internal/controllers/kubelb/envoy_cp_controller_test.go
@@ -20,8 +20,12 @@ import (
 	"testing"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	envoycp "k8c.io/kubelb/internal/envoy"
 	"k8c.io/kubelb/internal/kubelb"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -60,4 +64,75 @@ func TestEnvoyProxyAnnotationsCarryResourceNamingVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The envoy-proxy container carries all tenant data-plane traffic but shipped
+// with no requests or limits, so it ran BestEffort — first in line for
+// eviction and OOM kill on a node it shares with other proxies.
+func TestEnvoyProxyContainerHasResourceDefaults(t *testing.T) {
+	reconciler := &EnvoyCPReconciler{Namespace: teardownConfigNamespace, EnvoyServer: newTestEnvoyServer(t)}
+	config := &kubelbv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: teardownConfigNamespace},
+	}
+	tenant := &kubelbv1alpha1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: "tenant-a"}}
+
+	template := reconciler.getEnvoyProxyPodSpec(config, "tenant-a", "envoy-tenant-a", "snapshot", tenant)
+
+	envoy := template.Spec.Containers[0]
+	if envoy.Name != envoyProxyContainerName {
+		t.Fatalf("containers[0] = %q, want %q", envoy.Name, envoyProxyContainerName)
+	}
+	for _, tc := range []struct {
+		kind string
+		list corev1.ResourceList
+	}{
+		{"requests", envoy.Resources.Requests},
+		{"limits", envoy.Resources.Limits},
+	} {
+		if tc.list.Cpu().IsZero() {
+			t.Fatalf("envoy-proxy has no CPU %s; the container runs BestEffort", tc.kind)
+		}
+		if tc.list.Memory().IsZero() {
+			t.Fatalf("envoy-proxy has no memory %s; the container runs BestEffort", tc.kind)
+		}
+	}
+}
+
+func TestEnvoyProxyResourceDefaultsAreOverridable(t *testing.T) {
+	reconciler := &EnvoyCPReconciler{Namespace: teardownConfigNamespace, EnvoyServer: newTestEnvoyServer(t)}
+	custom := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+	}
+
+	config := &kubelbv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: teardownConfigNamespace},
+		Spec: kubelbv1alpha1.ConfigSpec{
+			EnvoyProxy: kubelbv1alpha1.EnvoyProxy{Resources: &custom},
+		},
+	}
+	tenant := &kubelbv1alpha1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: "tenant-a"}}
+
+	template := reconciler.getEnvoyProxyPodSpec(config, "tenant-a", "envoy-tenant-a", "snapshot", tenant)
+	if got := template.Spec.Containers[0].Resources.Limits.Cpu().String(); got != "4" {
+		t.Fatalf("Config resources must win over the default, CPU limit = %q", got)
+	}
+
+	tenantOverride := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+	}
+	tenant.Spec.EnvoyProxy = &kubelbv1alpha1.TenantEnvoyProxy{Resources: &tenantOverride}
+	template = reconciler.getEnvoyProxyPodSpec(config, "tenant-a", "envoy-tenant-a", "snapshot", tenant)
+	if got := template.Spec.Containers[0].Resources.Limits.Cpu().String(); got != "8" {
+		t.Fatalf("Tenant resources must win over Config, CPU limit = %q", got)
+	}
+}
+
+func newTestEnvoyServer(t *testing.T) *envoycp.Server {
+	t.Helper()
+	server, err := envoycp.NewServer("0.0.0.0:8001", false)
+	if err != nil {
+		t.Fatalf("failed to create envoy server: %v", err)
+	}
+	return server
 }

--- a/internal/controllers/kubelb/envoy_cp_controller_test.go
+++ b/internal/controllers/kubelb/envoy_cp_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
@@ -30,5 +31,33 @@ import (
 func TestTenantSpecChangedPredicateTriggersOnDelete(t *testing.T) {
 	if !tenantSpecChangedPredicate().Delete(event.DeleteEvent{Object: &kubelbv1alpha1.Tenant{}}) {
 		t.Fatal("tenant deletion must enqueue a reconcile so the tenant's snapshot is cleared")
+	}
+}
+
+// TestEnvoyProxyAnnotationsCarryResourceNamingVersion pins the pod template
+// annotation that rolls every envoy proxy exactly once when the generated xDS
+// resource names change. Without the roll, a running proxy sees a rename as new
+// listeners added plus the old ones removed, and the removed listeners drain
+// with their routes pointing at deleted clusters.
+func TestEnvoyProxyAnnotationsCarryResourceNamingVersion(t *testing.T) {
+	podMonitorConfig := &kubelbv1alpha1.Config{}
+	podMonitorConfig.Spec.EnvoyProxy.PodMonitor = &kubelbv1alpha1.EnvoyProxyPodMonitor{Enabled: true}
+
+	tests := []struct {
+		name   string
+		config *kubelbv1alpha1.Config
+	}{
+		{name: "prometheus scrape annotations", config: &kubelbv1alpha1.Config{}},
+		{name: "pod monitor enabled", config: podMonitorConfig},
+	}
+
+	r := &EnvoyCPReconciler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.envoyProxyAnnotations(tt.config)[kubelb.AnnotationResourceNamingVersion]
+			if got != kubelb.ResourceNamingVersion {
+				t.Errorf("annotation %s = %q, want %q", kubelb.AnnotationResourceNamingVersion, got, kubelb.ResourceNamingVersion)
+			}
+		})
 	}
 }

--- a/internal/controllers/kubelb/loadbalancer_annotations_test.go
+++ b/internal/controllers/kubelb/loadbalancer_annotations_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The KubeLB Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelb
+
+import (
+	"context"
+	"testing"
+
+	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
+	portlookup "k8c.io/kubelb/internal/port-lookup"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	annotationTestNamespace = "tenant-annotations"
+	annotationTestLBName    = "lb-uid-1"
+	annotationTestService   = "envoy-lb-uid-1"
+	annotationTestApp       = "envoy-app"
+
+	providerAnnotation   = "load-balancer.hetzner.cloud/location"
+	thirdPartyAnnotation = "cloud-controller.example.com/state"
+)
+
+func annotationTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("corev1 scheme: %v", err)
+	}
+	if err := kubelbv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("kubelb scheme: %v", err)
+	}
+	return s
+}
+
+func annotatedLoadBalancer(annotations map[string]string) *kubelbv1alpha1.LoadBalancer {
+	return &kubelbv1alpha1.LoadBalancer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        annotationTestLBName,
+			Namespace:   annotationTestNamespace,
+			Annotations: annotations,
+			Labels: map[string]string{
+				kubelb.LabelOriginName:      "app",
+				kubelb.LabelOriginNamespace: "default",
+			},
+		},
+		Spec: kubelbv1alpha1.LoadBalancerSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []kubelbv1alpha1.LoadBalancerPort{{Name: "http", Port: 80, Protocol: corev1.ProtocolTCP}},
+			Endpoints: []kubelbv1alpha1.LoadBalancerEndpoints{{
+				Ports: []kubelbv1alpha1.EndpointPort{{Name: "http", Port: 30080, Protocol: corev1.ProtocolTCP}},
+			}},
+		},
+	}
+}
+
+func getGeneratedService(t *testing.T, client ctrlruntimeclient.Client) *corev1.Service {
+	t.Helper()
+	svc := &corev1.Service{}
+	key := types.NamespacedName{Name: annotationTestService, Namespace: annotationTestNamespace}
+	if err := client.Get(context.Background(), key, svc); err != nil {
+		t.Fatalf("get generated service: %v", err)
+	}
+	return svc
+}
+
+// A tenant that removes a cloud-provider annotation from its Service must see it
+// removed from the generated Service too, otherwise the annotation can never be
+// un-set. Annotations set by third parties on the generated Service are not ours to
+// remove and have to survive.
+func TestReconcileService_AnnotationRemovalPropagates(t *testing.T) {
+	settings := kubelbv1alpha1.AnnotationSettings{PropagateAllAnnotations: ptr.To(true)}
+	s := annotationTestScheme(t)
+	client := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &LoadBalancerReconciler{Client: client, Scheme: s}
+	allocator := portlookup.NewPortAllocator()
+	ctx := context.Background()
+
+	lb := annotatedLoadBalancer(map[string]string{providerAnnotation: "nbg1"})
+	if err := r.reconcileService(ctx, lb, annotationTestService, annotationTestApp, annotationTestNamespace, allocator, nil, settings); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+
+	// A third party annotates the generated Service.
+	svc := getGeneratedService(t, client)
+	svc.Annotations[thirdPartyAnnotation] = "ready"
+	if err := client.Update(ctx, svc); err != nil {
+		t.Fatalf("annotate service: %v", err)
+	}
+
+	// The tenant removes the provider annotation from its Service, which drops it
+	// from the LoadBalancer CR.
+	if err := r.reconcileService(ctx, annotatedLoadBalancer(nil), annotationTestService, annotationTestApp, annotationTestNamespace, allocator, nil, settings); err != nil {
+		t.Fatalf("reconcile after removal: %v", err)
+	}
+
+	got := getGeneratedService(t, client)
+	if value, ok := got.Annotations[providerAnnotation]; ok {
+		t.Fatalf("annotation %s should have been removed, still set to %q", providerAnnotation, value)
+	}
+	if got.Annotations[thirdPartyAnnotation] != "ready" {
+		t.Fatalf("third party annotation must be preserved, got %+v", got.Annotations)
+	}
+}
+
+// Value changes keep propagating, and re-reconciling an unchanged LoadBalancer must
+// not rewrite the Service (no update hot loop from the bookkeeping annotation).
+func TestReconcileService_AnnotationUpdateIsStable(t *testing.T) {
+	settings := kubelbv1alpha1.AnnotationSettings{PropagateAllAnnotations: ptr.To(true)}
+	s := annotationTestScheme(t)
+	client := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &LoadBalancerReconciler{Client: client, Scheme: s}
+	allocator := portlookup.NewPortAllocator()
+	ctx := context.Background()
+
+	if err := r.reconcileService(ctx, annotatedLoadBalancer(map[string]string{providerAnnotation: "nbg1"}), annotationTestService, annotationTestApp, annotationTestNamespace, allocator, nil, settings); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+	if err := r.reconcileService(ctx, annotatedLoadBalancer(map[string]string{providerAnnotation: "fsn1"}), annotationTestService, annotationTestApp, annotationTestNamespace, allocator, nil, settings); err != nil {
+		t.Fatalf("reconcile after value change: %v", err)
+	}
+
+	got := getGeneratedService(t, client)
+	if got.Annotations[providerAnnotation] != "fsn1" {
+		t.Fatalf("expected updated annotation value, got %+v", got.Annotations)
+	}
+	resourceVersion := got.ResourceVersion
+
+	if err := r.reconcileService(ctx, annotatedLoadBalancer(map[string]string{providerAnnotation: "fsn1"}), annotationTestService, annotationTestApp, annotationTestNamespace, allocator, nil, settings); err != nil {
+		t.Fatalf("no-op reconcile: %v", err)
+	}
+	if got = getGeneratedService(t, client); got.ResourceVersion != resourceVersion {
+		t.Fatalf("unchanged LoadBalancer rewrote the Service (resourceVersion %s -> %s)", resourceVersion, got.ResourceVersion)
+	}
+}

--- a/internal/controllers/kubelb/loadbalancer_controller.go
+++ b/internal/controllers/kubelb/loadbalancer_controller.go
@@ -294,31 +294,33 @@ func (r *LoadBalancerReconciler) reconcileService(ctx context.Context, loadBalan
 	// Handle service ports
 	desiredService.Spec.Ports = kubelb.CreateServicePorts(loadBalancer, existingService, portAllocator)
 
+	// Merge the annotations with the existing annotations to allow annotations that are configured by third party controllers on the existing service to be preserved,
+	// while still propagating the removal of annotations that KubeLB itself set on a previous pass. On create this only records the keys KubeLB owns.
+	desiredService.Annotations = k8sutils.ReconcileAnnotations(existingService.Annotations, desiredService.Annotations)
+
 	// If service doesn't exist, create it
 	if apierrors.IsNotFound(err) {
 		log.V(2).Info("creating service", "name", svcName)
 		if err := r.Create(ctx, desiredService); err != nil {
 			return fmt.Errorf("failed to create service: %w", err)
 		}
-	} else {
-		// Merge the annotations with the existing annotations to allow annotations that are configured by third party controllers on the existing service to be preserved.
-		desiredService.Annotations = k8sutils.MergeAnnotations(existingService.Annotations, desiredService.Annotations)
+		return nil
+	}
 
-		// Service already exists, we need to check if it needs to be updated.
-		if !equality.Semantic.DeepEqual(existingService.Spec.Ports, desiredService.Spec.Ports) ||
-			!equality.Semantic.DeepEqual(existingService.Spec.Selector, desiredService.Spec.Selector) ||
-			!equality.Semantic.DeepEqual(existingService.Spec.Type, desiredService.Spec.Type) ||
-			!equality.Semantic.DeepEqual(existingService.Spec.ExternalTrafficPolicy, desiredService.Spec.ExternalTrafficPolicy) ||
-			!equality.Semantic.DeepEqual(existingService.Spec.LoadBalancerClass, desiredService.Spec.LoadBalancerClass) ||
-			!equality.Semantic.DeepEqual(existingService.Labels, desiredService.Labels) ||
-			!k8sutils.CompareAnnotations(existingService.Annotations, desiredService.Annotations) {
-			log.V(2).Info("updating service", "name", svcName)
-			existingService.Spec = desiredService.Spec
-			existingService.Labels = desiredService.Labels
-			existingService.Annotations = desiredService.Annotations
-			if err := r.Update(ctx, existingService); err != nil {
-				return fmt.Errorf("failed to update service: %w", err)
-			}
+	// Service already exists, we need to check if it needs to be updated.
+	if !equality.Semantic.DeepEqual(existingService.Spec.Ports, desiredService.Spec.Ports) ||
+		!equality.Semantic.DeepEqual(existingService.Spec.Selector, desiredService.Spec.Selector) ||
+		!equality.Semantic.DeepEqual(existingService.Spec.Type, desiredService.Spec.Type) ||
+		!equality.Semantic.DeepEqual(existingService.Spec.ExternalTrafficPolicy, desiredService.Spec.ExternalTrafficPolicy) ||
+		!equality.Semantic.DeepEqual(existingService.Spec.LoadBalancerClass, desiredService.Spec.LoadBalancerClass) ||
+		!equality.Semantic.DeepEqual(existingService.Labels, desiredService.Labels) ||
+		!k8sutils.CompareAnnotations(existingService.Annotations, desiredService.Annotations) {
+		log.V(2).Info("updating service", "name", svcName)
+		existingService.Spec = desiredService.Spec
+		existingService.Labels = desiredService.Labels
+		existingService.Annotations = desiredService.Annotations
+		if err := r.Update(ctx, existingService); err != nil {
+			return fmt.Errorf("failed to update service: %w", err)
 		}
 	}
 	return nil

--- a/internal/envoy/resource.go
+++ b/internal/envoy/resource.go
@@ -271,7 +271,7 @@ func MapSnapshot(ctx context.Context, client ctrlclient.Client, loadBalancers []
 					listenerPort = uint32(value)
 				}
 
-				key := fmt.Sprintf(kubelb.EnvoyRoutePortIdentifierPattern, route.Namespace, svc.Namespace, svc.Name, originalRouteName, svc.UID, port.Port, port.Protocol)
+				key := fmt.Sprintf(kubelb.EnvoyRoutePortIdentifierPattern, route.Namespace, svc.Namespace, svc.Name, getOriginalRouteNamespace(&route), originalRouteName, port.Port, port.Protocol)
 
 				if l := makeRouteListener(key, listenerPort, port.Protocol, useHTTPListener, headerLimits); l != nil {
 					listener = append(listener, l)
@@ -646,6 +646,16 @@ func getOriginalRouteName(route *kubelbv1alpha1.Route) string {
 		}
 	}
 	return route.Name
+}
+
+func getOriginalRouteNamespace(route *kubelbv1alpha1.Route) string {
+	if route.Spec.Source.Kubernetes != nil && route.Spec.Source.Kubernetes.Route.GetNamespace() != "" {
+		return route.Spec.Source.Kubernetes.Route.GetNamespace()
+	}
+	if labels := route.GetLabels(); labels != nil {
+		return labels[kubelb.LabelOriginNamespace]
+	}
+	return ""
 }
 
 // makeHTTPListener creates an HTTP Connection Manager listener for L7 HTTP routes.

--- a/internal/envoy/resource_test.go
+++ b/internal/envoy/resource_test.go
@@ -19,6 +19,8 @@ package envoy
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -36,6 +38,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	kubelbv1alpha1 "k8c.io/kubelb/api/ce/kubelb.k8c.io/v1alpha1"
+	"k8c.io/kubelb/internal/kubelb"
 	managermetrics "k8c.io/kubelb/internal/metricsutil/manager"
 	portlookup "k8c.io/kubelb/internal/port-lookup"
 
@@ -43,6 +46,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -880,5 +884,80 @@ func TestListeners_TCPKeepalive(t *testing.T) {
 func TestMakeUDPListener_NoTCPKeepalive(t *testing.T) {
 	if options := makeUDPListener("test-cluster", "test-listener", 10001, nil).GetSocketOptions(); len(options) != 0 {
 		t.Fatalf("udp listener socket options = %v, want none", options)
+	}
+}
+
+// TestMapSnapshotRouteNamesSurviveServiceUIDChange pins the generated cluster
+// and listener names to the Service's logical identity. The mirrored NodePort
+// Service is owner-referenced by the origin Service, so replacing the origin
+// (helm upgrade, delete+apply) garbage-collects the mirror and the CCM recreates
+// it under the same namespace/name with a fresh UID. If the UID leaks into the
+// generated names, Envoy sees an add of a new cluster plus a new listener on the
+// same port instead of an update: the old listener drains forever with a route
+// pointing at a deleted cluster, and pooled upstream connections bound to it
+// keep returning 503/NC.
+func TestMapSnapshotRouteNamesSurviveServiceUIDChange(t *testing.T) {
+	ctx := context.Background()
+	cl := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	pa := portlookup.NewPortAllocator()
+
+	namesFor := func(uid string) (clusters, listeners []string) {
+		t.Helper()
+		route := ingressSourceRoute()
+		route.Spec.Source.Kubernetes.Services[0].UID = k8stypes.UID(uid)
+
+		snapshot, err := MapSnapshot(ctx, cl, nil, []kubelbv1alpha1.Route{route}, pa, "test-snapshot", ResolveHeaderLimits(nil))
+		if err != nil {
+			t.Fatalf("MapSnapshot() error = %v", err)
+		}
+		return resourceNames(snapshot, resource.ClusterType), resourceNames(snapshot, resource.ListenerType)
+	}
+
+	oldClusters, oldListeners := namesFor("abc123")
+	newClusters, newListeners := namesFor("def456")
+
+	if !slices.Equal(oldClusters, newClusters) {
+		t.Errorf("cluster names changed with the Service UID: %v != %v", oldClusters, newClusters)
+	}
+	if !slices.Equal(oldListeners, newListeners) {
+		t.Errorf("listener names changed with the Service UID: %v != %v", oldListeners, newListeners)
+	}
+}
+
+func resourceNames(snapshot interface {
+	GetResources(resource.Type) map[string]types.Resource
+}, typ resource.Type) []string {
+	names := slices.Collect(maps.Keys(snapshot.GetResources(typ)))
+	slices.Sort(names)
+	return names
+}
+
+// Two routes with the same origin name in different origin namespaces, sharing one
+// backend Service, are mirrored into the same management namespace. Their generated
+// cluster and listener names must differ or one route silently overwrites the
+// other's config. The origin route namespace in the identifier is what keeps them
+// apart.
+func TestMapSnapshotRouteNamesDisambiguateByOriginNamespace(t *testing.T) {
+	ctx := context.Background()
+	cl := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	pa := portlookup.NewPortAllocator()
+
+	namesFor := func(originNamespace string) []string {
+		t.Helper()
+		route := ingressSourceRoute()
+		route.Labels = map[string]string{kubelb.LabelOriginNamespace: originNamespace}
+
+		snapshot, err := MapSnapshot(ctx, cl, nil, []kubelbv1alpha1.Route{route}, pa, "test-snapshot", ResolveHeaderLimits(nil))
+		if err != nil {
+			t.Fatalf("MapSnapshot() error = %v", err)
+		}
+		return resourceNames(snapshot, resource.ClusterType)
+	}
+
+	a := namesFor("team-a")
+	b := namesFor("team-b")
+
+	if slices.Equal(a, b) {
+		t.Errorf("routes in different origin namespaces produced identical cluster names: %v", a)
 	}
 }

--- a/internal/kubelb/utils.go
+++ b/internal/kubelb/utils.go
@@ -53,11 +53,32 @@ const EnvoyEndpointPattern = "%s-%s-ep-%d"
 // EnvoyEndpointRoutePattern includes route name for per-route port allocation
 const EnvoyEndpointRoutePattern = "tenant-%s-route-%s-%s-%s"
 
-// EnvoyRoutePortIdentifierPattern includes route name for unique listener keys
-const EnvoyRoutePortIdentifierPattern = "tenant-%s-route-%s-%s-%s-svc-%s-port-%d-%s"
+// EnvoyRoutePortIdentifierPattern includes the origin route namespace and route name for unique listener keys
+// (supports same-named routes across origin namespaces sharing one backend).
+// Deliberately UID-free: the tuple already identifies one Service at any instant, while a UID makes the
+// name change every time the mirrored Service is replaced. Envoy then treats the replacement as a new
+// cluster plus a new listener on the same port instead of an update, leaving the old listener draining with
+// a route to a deleted cluster and pooled upstream connections stuck on it.
+const EnvoyRoutePortIdentifierPattern = "tenant-%s-route-%s-%s-%s-%s-port-%d-%s"
 const EnvoyListenerPattern = "%v-%s"
 const RouteServiceMapKey = "%s/%s"
 const DefaultRouteStatus = "{}"
+
+// AnnotationResourceNamingVersion stamps the envoy proxy pod template with the
+// scheme used to name generated xDS clusters and listeners. Bumping
+// ResourceNamingVersion rolls every envoy proxy pod exactly once, so a renamed
+// resource set reaches only freshly started proxies. Without the roll, running
+// proxies would see the rename as an add of new listeners plus a removal of the
+// old ones: the removed listeners sit in draining state with routes pointing at
+// deleted clusters, and pooled downstream connections still bound to them keep
+// getting NoCluster 503s.
+const AnnotationResourceNamingVersion = "kubelb.k8c.io/resource-naming-version"
+
+// ResourceNamingVersion must be incremented whenever a generated xDS resource
+// name changes. v2 dropped the Service UID from EnvoyRoutePortIdentifierPattern
+// and added the origin route namespace so same-named routes across origin
+// namespaces sharing one backend do not collide.
+const ResourceNamingVersion = "2"
 
 const ServiceKind = "Service"
 const NameSuffixLength = 4

--- a/internal/util/kubernetes/util.go
+++ b/internal/util/kubernetes/util.go
@@ -18,6 +18,8 @@ package kubernetes
 
 import (
 	"maps"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -44,6 +46,42 @@ func CompareAnnotations(a, b map[string]string) bool {
 	delete(aCopy, corev1.LastAppliedConfigAnnotation)
 	delete(bCopy, corev1.LastAppliedConfigAnnotation)
 	return equality.Semantic.DeepEqual(aCopy, bCopy)
+}
+
+// ManagedAnnotationsKey records, on a generated resource, the annotation keys KubeLB
+// propagated onto it during the previous reconciliation. It is what lets
+// ReconcileAnnotations tell an annotation it owns from one a third party added.
+const ManagedAnnotationsKey = "kubelb.k8c.io/managed-annotations"
+
+// ReconcileAnnotations merges desired into existing like MergeAnnotations, but also
+// drops the keys KubeLB propagated on an earlier pass and no longer wants. Without
+// this, removing an annotation upstream never reaches the generated resource and a
+// cloud-provider annotation can never be un-set. Keys KubeLB never set - annotations
+// configured by third party controllers on the generated resource - are left alone.
+func ReconcileAnnotations(existing, desired map[string]string) map[string]string {
+	merged := make(map[string]string, len(existing)+len(desired))
+	maps.Copy(merged, existing)
+
+	for _, key := range strings.Split(existing[ManagedAnnotationsKey], ",") {
+		if _, keep := desired[key]; !keep && key != "" {
+			delete(merged, key)
+		}
+	}
+	maps.Copy(merged, desired)
+
+	managed := make([]string, 0, len(desired))
+	for key := range desired {
+		if key != ManagedAnnotationsKey {
+			managed = append(managed, key)
+		}
+	}
+	if len(managed) == 0 {
+		delete(merged, ManagedAnnotationsKey)
+		return merged
+	}
+	sort.Strings(managed)
+	merged[ManagedAnnotationsKey] = strings.Join(managed, ",")
+	return merged
 }
 
 func MergeAnnotations(existing, desired map[string]string) map[string]string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix batch for xDS resource naming and management-cluster mirror lifecycle:

- Drop the Service UID from generated xDS cluster/listener names and include the origin route namespace. Replacing the origin Service regenerated the mirror with a fresh UID, so Envoy saw a new cluster + listener instead of an update and pooled connections on the drained listener returned NC 503s. Envoy proxy pods roll exactly once via a naming-version pod annotation so the renamed set only reaches fresh proxies.
- Reap orphaned mgmt-cluster mirrors when the origin Service/Ingress/route stops qualifying (type downgrade) or disappears without the finalizer running (cluster rebuilt, etcd restore). Transient Get errors requeue instead of reaping.
- Propagate annotation removals to the generated Service: track the keys KubeLB owns via `kubelb.k8c.io/managed-annotations` and remove only those, so a tenant can un-set a cloud-provider annotation without clobbering third-party annotations.
- Give the managed Envoy proxy default resource requests/limits (200m/256Mi, 2 CPU/1Gi) so it no longer runs BestEffort; `envoyProxy.resources` in Config/Tenant still overrides.

**Which issue(s) this PR fixes**:

Fixes #

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

The naming change and the proxy-roll annotation ship together on purpose: without the roll, running proxies receive the rename as add+remove and hit the drained-listener state this PR fixes.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
- Generated xDS cluster/listener names no longer include the Service UID; envoy proxy pods roll once on upgrade to pick up the new names.
- Orphaned LoadBalancer/Route mirrors in the management cluster are now cleaned up when the tenant origin resource is deleted, recreated, or no longer qualifies.
- Removing an annotation from a tenant Service now removes it from the generated LoadBalancer Service as well.
- The managed Envoy proxy container now defaults to 200m CPU / 256Mi memory requests and 2 CPU / 1Gi memory limits; envoyProxy.resources in Config/Tenant overrides this.
```

**Documentation**:

```documentation
NONE
```
