### PR TITLE
fix(ccm): requeue nodes without valid addresses

### DIFF
--- a/internal/controllers/ccm/node_controller.go
+++ b/internal/controllers/ccm/node_controller.go
@@ -84,11 +84,11 @@ func (r *KubeLBNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Compute current state
 	currentAddresses, err := r.GenerateAddresses(nodeList)
 	if err != nil {
-		log.Error(err, "unable to find a node with an IP address")
 		// This is a transient error and happens when the nodes are coming up.
 		// We will requeue after a short period of time to give the nodes a chance to be ready and have an IP address.
-		ccmmetrics.NodeReconcileTotal.WithLabelValues(metricsutil.ResultError).Inc()
-		return ctrl.Result{RequeueAfter: requeueAfter}, err
+		log.V(2).Info("no valid node addresses available yet; requeueing")
+		ccmmetrics.NodeReconcileTotal.WithLabelValues(metricsutil.ResultSkipped).Inc()
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	// Retrieve current state from the LB cluster

--- a/internal/controllers/ccm/node_controller_test.go
+++ b/internal/controllers/ccm/node_controller_test.go
@@ -75,6 +75,34 @@ func nodeWithInternalIP(name, ip string) *corev1.Node {
 	}
 }
 
+func TestNodeReconcileRequeuesWithoutErrorWhenNodeHasNoAddress(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-without-address"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}).Build()
+	r := &KubeLBNodeReconciler{
+		Client:              client,
+		Log:                 logr.Discard(),
+		EndpointAddressType: corev1.NodeInternalIP,
+	}
+
+	got, err := r.Reconcile(context.Background(), ctrl.Request{})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v, want nil for transient missing address", err)
+	}
+	want := ctrl.Result{RequeueAfter: requeueAfter}
+	if got != want {
+		t.Fatalf("Reconcile() result = %v, want %v", got, want)
+	}
+}
+
 // Every CCM in a tenant writes the same Addresses object, so a conflict on
 // update is routine. Losing the reconcile to it leaves the tenant's endpoints
 // stale until the next node event.


### PR DESCRIPTION
**What this PR does / why we need it**:

Treat a ready node that temporarily lacks the configured IP address as a transient reconciliation state. The CCM now logs this condition at debug verbosity, records the reconciliation as skipped, and requeues without returning an error. This avoids noisy error reporting and error metrics while nodes are still acquiring addresses.

Adds a regression test covering a ready node with no addresses.

**Which issue(s) this PR fixes**:

N/A

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
CCM node reconciliation now requeues without reporting an error while ready nodes are still waiting for their configured IP addresses.
```

**Documentation**:

```documentation
NONE
```
