### PR TITLE
chore: drop gocyclo lint exceptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,14 +75,6 @@ linters:
           - revive
           - goconst
         path: _test\.go
-      - path: (.+)\.go$
-        text: cyclomatic complexity \d+ of func `CreateOrUpdateGRPCRoute` is high
-      - path: (.+)\.go$
-        text: cyclomatic complexity \d+ of func `CreateOrUpdateHTTPRoute` is high
-      - path: (.+)\.go$
-        text: cyclomatic complexity \d+ of func `\(\*LoadBalancerReconciler\)\.Reconcile` is high
-      - path: (.+)\.go$
-        text: cyclomatic complexity \d+ of func `\(\*Reconciler\)\.reconcile` is high
     paths:
       - zz_generated.*.go
       - hack

--- a/internal/resources/gatewayapi/gatewayapi.go
+++ b/internal/resources/gatewayapi/gatewayapi.go
@@ -17,6 +17,9 @@ limitations under the License.
 package gatewayapi
 
 import (
+	"k8c.io/kubelb/internal/kubelb"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -25,4 +28,25 @@ func NormalizeParentRefs(parentRefs []gwapiv1.ParentReference) []gwapiv1.ParentR
 		parentRefs[i].Namespace = nil
 	}
 	return parentRefs
+}
+
+// RewriteServiceBackendRef points ref at the service that was created against the Route in the LB
+// cluster, provided ref resolves to one of referencedServices. Non-service references are ignored.
+func RewriteServiceBackendRef(ref *gwapiv1.BackendObjectReference, referencedServices []metav1.ObjectMeta, routeName string) {
+	if ref.Kind != nil && *ref.Kind != kubelb.ServiceKind {
+		return
+	}
+
+	name, namespace := ref.Name, ref.Namespace
+	for _, service := range referencedServices {
+		if string(name) != service.Name {
+			continue
+		}
+		if namespace != nil && string(*namespace) != service.Namespace {
+			continue
+		}
+		ref.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace))
+		// Set the namespace to nil since all the services are created in the same namespace as the Route.
+		ref.Namespace = nil
+	}
 }

--- a/internal/resources/gatewayapi/gatewayapi.go
+++ b/internal/resources/gatewayapi/gatewayapi.go
@@ -30,23 +30,18 @@ func NormalizeParentRefs(parentRefs []gwapiv1.ParentReference) []gwapiv1.ParentR
 	return parentRefs
 }
 
-// RewriteServiceBackendRef points ref at the service that was created against the Route in the LB
-// cluster, provided ref resolves to one of referencedServices. Non-service references are ignored.
-func RewriteServiceBackendRef(ref *gwapiv1.BackendObjectReference, referencedServices []metav1.ObjectMeta, routeName string) {
-	if ref.Kind != nil && *ref.Kind != kubelb.ServiceKind {
-		return
-	}
-
-	name, namespace := ref.Name, ref.Namespace
+// RetargetBackendRefToGeneratedService rewrites a BackendObjectReference to point at the
+// per-route Service generated in the LB cluster.
+func RetargetBackendRefToGeneratedService(ref *gwapiv1.BackendObjectReference, referencedServices []metav1.ObjectMeta, routeName string) {
 	for _, service := range referencedServices {
-		if string(name) != service.Name {
+		if string(ref.Name) != service.Name {
 			continue
 		}
-		if namespace != nil && string(*namespace) != service.Namespace {
+		if ref.Namespace != nil && string(*ref.Namespace) != service.Namespace {
 			continue
 		}
 		ref.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace))
-		// Set the namespace to nil since all the services are created in the same namespace as the Route.
 		ref.Namespace = nil
+		return
 	}
 }

--- a/internal/resources/gatewayapi/grpcroute/grpcroute.go
+++ b/internal/resources/gatewayapi/grpcroute/grpcroute.go
@@ -41,48 +41,17 @@ func CreateOrUpdateGRPCRoute(ctx context.Context, log logr.Logger, client ctrlcl
 	// Name of the services referenced by the Object have to be updated to match the services created against the Route in the LB cluster.
 	for i, rule := range object.Spec.Rules {
 		for j, filter := range rule.Filters {
-			if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
-				ref := filter.RequestMirror.BackendRef
-				for _, service := range referencedServices {
-					if string(ref.Name) == service.Name {
-						ns := ref.Namespace
-						// Corresponding service found, update the name.
-						if ns == nil || string(*ns) == service.Namespace {
-							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace)) // Set the namespace to nil since all the services are created in the same namespace as the Route.
-							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Namespace = nil
-						}
-					}
-				}
+			if filter.RequestMirror != nil {
+				gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef, referencedServices, routeName)
 			}
 		}
 
 		for j, ref := range rule.BackendRefs {
-			if ref.Kind == nil || *ref.Kind == kubelb.ServiceKind {
-				for _, service := range referencedServices {
-					if string(ref.Name) == service.Name {
-						ns := ref.Namespace
-						// Corresponding service found, update the name.
-						if ns == nil || string(*ns) == service.Namespace {
-							object.Spec.Rules[i].BackendRefs[j].Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace)) // Set the namespace to nil since all the services are created in the same namespace as the Route.
-							object.Spec.Rules[i].BackendRefs[j].Namespace = nil
-						}
-					}
-				}
-			}
-			// Collect services from the filters.
+			gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].BackendRefs[j].BackendObjectReference, referencedServices, routeName)
+
 			for k, filter := range ref.Filters {
-				if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
-					mirrorRef := filter.RequestMirror.BackendRef
-					for _, service := range referencedServices {
-						if string(mirrorRef.Name) == service.Name {
-							ns := mirrorRef.Namespace
-							// Corresponding service found, update the name.
-							if ns == nil || string(*ns) == service.Namespace {
-								object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace)) // Set the namespace to nil since all the services are created in the same namespace as the Route.
-								object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef.Namespace = nil
-							}
-						}
-					}
+				if filter.RequestMirror != nil {
+					gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef, referencedServices, routeName)
 				}
 			}
 		}

--- a/internal/resources/gatewayapi/grpcroute/grpcroute.go
+++ b/internal/resources/gatewayapi/grpcroute/grpcroute.go
@@ -41,17 +41,20 @@ func CreateOrUpdateGRPCRoute(ctx context.Context, log logr.Logger, client ctrlcl
 	// Name of the services referenced by the Object have to be updated to match the services created against the Route in the LB cluster.
 	for i, rule := range object.Spec.Rules {
 		for j, filter := range rule.Filters {
-			if filter.RequestMirror != nil {
-				gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef, referencedServices, routeName)
+			if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
+				gatewayapihelpers.RetargetBackendRefToGeneratedService(&object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef, referencedServices, routeName)
 			}
 		}
 
 		for j, ref := range rule.BackendRefs {
-			gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].BackendRefs[j].BackendObjectReference, referencedServices, routeName)
-
-			for k, filter := range ref.Filters {
-				if filter.RequestMirror != nil {
-					gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef, referencedServices, routeName)
+			if ref.Kind == nil || *ref.Kind == kubelb.ServiceKind {
+				gatewayapihelpers.RetargetBackendRefToGeneratedService(&object.Spec.Rules[i].BackendRefs[j].BackendObjectReference, referencedServices, routeName)
+			}
+			if ref.Filters != nil {
+				for k, filter := range ref.Filters {
+					if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
+						gatewayapihelpers.RetargetBackendRefToGeneratedService(&object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef, referencedServices, routeName)
+					}
 				}
 			}
 		}

--- a/internal/resources/gatewayapi/httproute/httproute.go
+++ b/internal/resources/gatewayapi/httproute/httproute.go
@@ -42,17 +42,20 @@ func CreateOrUpdateHTTPRoute(ctx context.Context, log logr.Logger, client ctrlcl
 	// Name of the services referenced by the Object have to be updated to match the services created against the Route in the LB cluster.
 	for i, rule := range object.Spec.Rules {
 		for j, filter := range rule.Filters {
-			if filter.RequestMirror != nil {
-				gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef, referencedServices, routeName)
+			if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
+				gatewayapihelpers.RetargetBackendRefToGeneratedService(&object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef, referencedServices, routeName)
 			}
 		}
 
 		for j, ref := range rule.BackendRefs {
-			gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].BackendRefs[j].BackendObjectReference, referencedServices, routeName)
-
-			for k, filter := range ref.Filters {
-				if filter.RequestMirror != nil {
-					gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef, referencedServices, routeName)
+			if ref.Kind == nil || *ref.Kind == kubelb.ServiceKind {
+				gatewayapihelpers.RetargetBackendRefToGeneratedService(&object.Spec.Rules[i].BackendRefs[j].BackendObjectReference, referencedServices, routeName)
+			}
+			if ref.Filters != nil {
+				for k, filter := range ref.Filters {
+					if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
+						gatewayapihelpers.RetargetBackendRefToGeneratedService(&object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef, referencedServices, routeName)
+					}
 				}
 			}
 		}

--- a/internal/resources/gatewayapi/httproute/httproute.go
+++ b/internal/resources/gatewayapi/httproute/httproute.go
@@ -42,51 +42,17 @@ func CreateOrUpdateHTTPRoute(ctx context.Context, log logr.Logger, client ctrlcl
 	// Name of the services referenced by the Object have to be updated to match the services created against the Route in the LB cluster.
 	for i, rule := range object.Spec.Rules {
 		for j, filter := range rule.Filters {
-			if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
-				ref := filter.RequestMirror.BackendRef
-				for _, service := range referencedServices {
-					if string(ref.Name) == service.Name {
-						ns := ref.Namespace
-						// Corresponding service found, update the name.
-						if ns == nil || string(*ns) == service.Namespace {
-							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace))
-							// Set the namespace to nil since all the services are created in the same namespace as the Route.
-							object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef.Namespace = nil
-						}
-					}
-				}
+			if filter.RequestMirror != nil {
+				gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].Filters[j].RequestMirror.BackendRef, referencedServices, routeName)
 			}
 		}
 
 		for j, ref := range rule.BackendRefs {
-			if ref.Kind == nil || *ref.Kind == kubelb.ServiceKind {
-				for _, service := range referencedServices {
-					if string(ref.Name) == service.Name {
-						ns := ref.Namespace
-						// Corresponding service found, update the name.
-						if ns == nil || string(*ns) == service.Namespace {
-							object.Spec.Rules[i].BackendRefs[j].Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace))
-							// Set the namespace to nil since all the services are created in the same namespace as the Route.
-							object.Spec.Rules[i].BackendRefs[j].Namespace = nil
-						}
-					}
-				}
-			}
-			// Collect services from the filters.
+			gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].BackendRefs[j].BackendObjectReference, referencedServices, routeName)
+
 			for k, filter := range ref.Filters {
-				if filter.RequestMirror != nil && (filter.RequestMirror.BackendRef.Kind == nil || *filter.RequestMirror.BackendRef.Kind == kubelb.ServiceKind) {
-					mirrorRef := filter.RequestMirror.BackendRef
-					for _, service := range referencedServices {
-						if string(mirrorRef.Name) == service.Name {
-							ns := mirrorRef.Namespace
-							// Corresponding service found, update the name.
-							if ns == nil || string(*ns) == service.Namespace {
-								object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef.Name = gwapiv1.ObjectName(kubelb.GenerateRouteServiceName(routeName, service.Name, service.Namespace))
-								// Set the namespace to nil since all the services are created in the same namespace as the Route.
-								object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef.Namespace = nil
-							}
-						}
-					}
+				if filter.RequestMirror != nil {
+					gatewayapihelpers.RewriteServiceBackendRef(&object.Spec.Rules[i].BackendRefs[j].Filters[k].RequestMirror.BackendRef, referencedServices, routeName)
 				}
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes all four `gocyclo` exclusions from `.golangci.yml`. Lint is clean without them.

**Which issue(s) this PR fixes**:
N/A

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

```release-note
NONE
```

**Documentation**:

```documentation
NONE
```